### PR TITLE
Add a signal preview page.

### DIFF
--- a/lilac/router_signal.py
+++ b/lilac/router_signal.py
@@ -78,6 +78,7 @@ def compute(
   if isinstance(signal, ConceptScoreSignal):
     result = server_compute_concept(signal, options.inputs, user)
   else:
+    signal.setup()
     result = list(signal.compute(options.inputs))
   return SignalComputeResponse(items=result)
 

--- a/lilac/router_utils.py
+++ b/lilac/router_utils.py
@@ -39,6 +39,7 @@ class RouteErrorHandler(APIRoute):
 def server_compute_concept(signal: ConceptScoreSignal, examples: Iterable[RichData],
                            user: Optional[UserInfo]) -> list[Optional[Item]]:
   """Compute a concept from the REST endpoints."""
+  # TODO(nsthorat): Move this to the setup() method in the concept_scorer.
   concept = DISK_CONCEPT_DB.get(signal.namespace, signal.concept_name, user)
   if not concept:
     raise HTTPException(

--- a/web/blueprint/src/app.css
+++ b/web/blueprint/src/app.css
@@ -101,19 +101,6 @@ button:disabled {
   @apply m-0 border-gray-200 py-4;
 }
 
-/** Navigation tabs */
-.bx--tabs__nav-item,
-.bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link,
-a.bx--tabs__nav-link {
-  @apply border-b-0 border-transparent;
-}
-a.bx--tabs__nav-link {
-  @apply rounded border-b-0;
-}
-a.bx--tabs__nav-link:focus {
-  @apply outline-transparent;
-}
-
 /** Expressive buttons */
 .bx--btn--icon-only.bx--btn--expressive {
   @apply p-1;

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import {getDatasetContext} from '$lib/stores/datasetStore';
   import {serializePath, type LilacField, type LilacValueNode} from '$lilac';
   import RowItemMedia from './RowItemMedia.svelte';
   import RowItemMetadata from './RowItemMetadata.svelte';
@@ -7,8 +8,12 @@
   export let mediaFields: LilacField[];
   export let visibleFields: LilacField[];
 
+  const datasetStore = getDatasetContext();
+
   const MIN_METADATA_HEIGHT_PX = 320;
   let mediaHeight = 0;
+
+  $: selectRowsSchema = $datasetStore.selectRowsSchema?.data;
 </script>
 
 <div class="rounded border-x border-b border-neutral-200 shadow-md">
@@ -28,7 +33,7 @@
           style={`max-height: ${Math.max(MIN_METADATA_HEIGHT_PX, mediaHeight)}px`}
           class="overflow-y-auto"
         >
-          <RowItemMetadata {row} {visibleFields} />
+          <RowItemMetadata {row} {visibleFields} {selectRowsSchema} />
         </div>
       </div>
     </div>

--- a/web/blueprint/src/lib/components/datasetView/RowItemMetadata.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItemMetadata.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {queryEmbeddings} from '$lib/queries/signalQueries';
-  import {getDatasetContext} from '$lib/stores/datasetStore';
   import {isItemVisible, isPreviewSignal} from '$lib/view_utils';
   import {
     L,
@@ -11,6 +10,7 @@
     serializePath,
     type DataTypeCasted,
     type LilacField,
+    type LilacSelectRowsSchema,
     type LilacValueNode,
     type Path
   } from '$lilac';
@@ -19,8 +19,8 @@
 
   export let row: LilacValueNode;
   export let visibleFields: LilacField[];
+  export let selectRowsSchema: LilacSelectRowsSchema | undefined = undefined;
 
-  const datasetStore = getDatasetContext();
   const embeddings = queryEmbeddings();
 
   interface MetadataRow {
@@ -78,7 +78,7 @@
             field,
             path,
             isSignal,
-            isPreviewSignal: isPreviewSignal($datasetStore.selectRowsSchema?.data || null, path),
+            isPreviewSignal: isPreviewSignal(selectRowsSchema, path),
             isEmbeddingSignal,
             value,
             formattedValue

--- a/web/blueprint/src/lib/components/datasetView/RowItemMetadata.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItemMetadata.svelte
@@ -78,7 +78,8 @@
             field,
             path,
             isSignal,
-            isPreviewSignal: isPreviewSignal(selectRowsSchema, path),
+            isPreviewSignal:
+              selectRowsSchema != null ? isPreviewSignal(selectRowsSchema, path) : false,
             isEmbeddingSignal,
             value,
             formattedValue

--- a/web/blueprint/src/lib/components/datasetView/SearchPanel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/SearchPanel.svelte
@@ -285,16 +285,6 @@
 </div>
 
 <style lang="postcss">
-  :global(.bx--tabs__nav) {
-    @apply flex w-full flex-row;
-  }
-  :global(.bx--tabs__nav-item) {
-    @apply w-28;
-  }
-  :global(.bx--tabs__nav-item .bx--tabs__nav-link) {
-    @apply w-28;
-  }
-
   :global(.bx--form__helper-text) {
     padding: 0 0 0 1rem;
   }

--- a/web/blueprint/src/lib/components/datasetView/SpanClick.ts
+++ b/web/blueprint/src/lib/components/datasetView/SpanClick.ts
@@ -4,14 +4,15 @@ import StringSpanDetails from './StringSpanDetails.svelte';
 
 export interface SpanClickInfo {
   details: () => SpanDetails;
-  findSimilar: (embedding: string, text: string) => unknown;
-  computedEmbeddings: string[];
+  findSimilar: ((embedding: string, text: string) => unknown) | null;
+  embeddings: string[];
   addConceptLabel: (
     conceptName: string,
     conceptNamespace: string,
     text: string,
     label: boolean
   ) => void;
+  disabled: boolean;
 }
 
 export function spanClick(element: HTMLSpanElement, clickInfo: SpanClickInfo) {
@@ -19,11 +20,14 @@ export function spanClick(element: HTMLSpanElement, clickInfo: SpanClickInfo) {
   let curClickInfo = clickInfo;
   element.addEventListener('click', e => showClickDetails(e));
   function showClickDetails(e: MouseEvent) {
+    if (curClickInfo.disabled) {
+      return;
+    }
     spanDetailsComponent = new StringSpanDetails({
       props: {
         details: curClickInfo.details(),
         clickPosition: {x: e.clientX, y: e.clientY},
-        computedEmbeddings: curClickInfo.computedEmbeddings,
+        embeddings: curClickInfo.embeddings,
         addConceptLabel: curClickInfo.addConceptLabel,
         findSimilar: curClickInfo.findSimilar
       },

--- a/web/blueprint/src/lib/components/datasetView/StringSpanDetails.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanDetails.svelte
@@ -64,13 +64,13 @@
     </div>
   {/if}
 
-  {#if findSimilar}
+  {#if findSimilar != null}
     <div class="more-button flex flex-col">
       {#each embeddings as computedEmbedding (computedEmbedding)}
         <button
           class="flex w-full items-center justify-between"
           on:click={() => {
-            findSimilar(computedEmbedding, details.text);
+            if (findSimilar) findSimilar(computedEmbedding, details.text);
             dispatch('click');
           }}
           ><div>Find similar</div>

--- a/web/blueprint/src/lib/components/datasetView/StringSpanDetails.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanDetails.svelte
@@ -24,7 +24,7 @@
   // The coordinates of the click so we can position the popup next to the cursor.
   export let clickPosition: {x: number; y: number} | undefined;
 
-  export let computedEmbeddings: string[];
+  export let embeddings: string[];
 
   // We cant create mutations from this component since it is hoisted so we pass the function in.
   export let addConceptLabel: (
@@ -33,7 +33,7 @@
     text: string,
     label: boolean
   ) => void;
-  export let findSimilar: (embedding: string, text: string) => unknown;
+  export let findSimilar: ((embedding: string, text: string) => unknown) | null;
 
   const dispatch = createEventDispatcher();
   function addLabel(label: boolean) {
@@ -64,17 +64,19 @@
     </div>
   {/if}
 
-  <div class="more-button flex flex-col">
-    {#each computedEmbeddings as computedEmbedding (computedEmbedding)}
-      <button
-        class="flex w-full items-center justify-between"
-        on:click={() => {
-          findSimilar(computedEmbedding, details.text);
-          dispatch('click');
-        }}
-        ><div>Find similar</div>
-        <EmbeddingBadge class="hover:cursor-pointer" embedding={computedEmbedding} />
-      </button>
-    {/each}
-  </div>
+  {#if findSimilar}
+    <div class="more-button flex flex-col">
+      {#each embeddings as computedEmbedding (computedEmbedding)}
+        <button
+          class="flex w-full items-center justify-between"
+          on:click={() => {
+            findSimilar(computedEmbedding, details.text);
+            dispatch('click');
+          }}
+          ><div>Find similar</div>
+          <EmbeddingBadge class="hover:cursor-pointer" embedding={computedEmbedding} />
+        </button>
+      {/each}
+    </div>
+  {/if}
 </div>

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -6,7 +6,6 @@
   import type {DatasetState} from '$lib/stores/datasetStore';
   import {
     ITEM_SCROLL_CONTAINER_CTX_KEY,
-    getComputedEmbeddings,
     getSearchPath,
     mergeSpans,
     type MergedSpan
@@ -48,6 +47,7 @@
   // Information about each value under span paths to render.
   export let valuePaths: SpanValueInfo[];
   export let markdown = false;
+  export let embeddings: string[];
 
   // When defined, enables semantic search on spans.
   export let datasetViewStore: DatasetViewStore | undefined = undefined;
@@ -153,11 +153,9 @@
 
   // Click details.
   let searchPath: Path | null;
-  let computedEmbeddings: string[] = [];
   $: {
     if ($datasetViewStore != null && datasetStore != null) {
       searchPath = getSearchPath($datasetViewStore, datasetStore);
-      computedEmbeddings = getComputedEmbeddings(datasetStore, searchPath);
     }
   }
 
@@ -175,7 +173,7 @@
   };
 </script>
 
-<div class="relative mx-4 overflow-x-hidden text-ellipsis whitespace-break-spaces py-4">
+<div class="relative overflow-x-hidden text-ellipsis whitespace-break-spaces py-4">
   {#each snippetSpans as snippetSpan}
     {@const renderSpan = snippetSpan.renderSpan}
     {#if snippetSpan.isShown}
@@ -188,9 +186,11 @@
         }}
         use:spanClick={{
           details: () => getSpanDetails(renderSpan),
-          findSimilar,
-          computedEmbeddings,
-          addConceptLabel
+          // Disable similarity search when there's no dataset store.
+          findSimilar: datasetStore != null ? findSimilar : null,
+          embeddings,
+          addConceptLabel,
+          disabled: renderSpan.paths.length === 0 || embeddings.length === 0
         }}
         class="hover:cursor-poiner highlight-span break-words text-sm leading-5"
         class:hover:cursor-pointer={spanPaths.length > 0}

--- a/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
+++ b/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
@@ -22,7 +22,7 @@ export interface SpanValueInfo {
   path: Path;
   spanPath: Path;
   name: string;
-  type: 'concept_score' | 'label' | 'semantic_similarity' | 'keyword' | 'metadata';
+  type: 'concept_score' | 'label' | 'semantic_similarity' | 'keyword' | 'metadata' | 'leaf_span';
   dtype: DataType;
   signal?: Signal;
 }
@@ -120,6 +120,7 @@ export function getRenderSpans(
     }
 
     const isLabeled = namedValues.some(v => v.info.type === 'label');
+    const isLeafSpan = namedValues.some(v => v.info.type === 'leaf_span');
     const isKeywordSearch = namedValues.some(v => v.info.type === 'keyword');
     const hasNonNumericMetadata = namedValues.some(
       v => v.info.type === 'metadata' && !isNumeric(v.info.dtype)
@@ -135,7 +136,7 @@ export function getRenderSpans(
 
     renderSpans.push({
       backgroundColor: colorFromScore(maxScore),
-      isBlackBolded: isKeywordSearch || hasNonNumericMetadata,
+      isBlackBolded: isKeywordSearch || hasNonNumericMetadata || isLeafSpan,
       isHighlightBolded: isLabeled,
       isShownSnippet,
       snippetScore: maxScore,

--- a/web/blueprint/src/lib/components/schemaView/SchemaView.svelte
+++ b/web/blueprint/src/lib/components/schemaView/SchemaView.svelte
@@ -10,7 +10,7 @@
   $: selectRowsSchema = $datasetStore.selectRowsSchema;
 </script>
 
-<div class="flex h-full flex-col pt-4">
+<div class="schema flex h-full flex-col pt-4">
   <Tabs class="overflow-hidden border-b border-gray-200">
     <Tab label="Schema" class="w-1/3" />
     <Tab label="Tree View" class="w-1/3" />
@@ -48,7 +48,7 @@
 </div>
 
 <style>
-  :global(.bx--tab-content) {
+  :global(.schema .bx--tab-content) {
     padding: 0 !important;
   }
 </style>

--- a/web/blueprint/src/lib/components/signals/SignalView.svelte
+++ b/web/blueprint/src/lib/components/signals/SignalView.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import {querySignalCompute, querySignalSchema} from '$lib/queries/signalQueries';
+  import {getSpanValuePaths} from '$lib/view_utils';
+  import {
+    deserializeField,
+    deserializeRow,
+    pathIncludes,
+    petals,
+    type DataTypeCasted,
+    type LilacField,
+    type LilacValueNode,
+    type Path,
+    type SignalInfoWithTypedSchema
+  } from '$lilac';
+  import {Button, SkeletonText, Tab, TabContent, Tabs, TextArea} from 'carbon-components-svelte';
+  import type {JSONSchema4Type} from 'json-schema';
+  import type {JSONError} from 'json-schema-library';
+  import {onMount, type SvelteComponent} from 'svelte';
+  import SvelteMarkdown from 'svelte-markdown';
+  import JsonSchemaForm from '../JSONSchema/JSONSchemaForm.svelte';
+  import EmptyComponent from '../commands/customComponents/EmptyComponent.svelte';
+  import SelectConcept from '../commands/customComponents/SelectConcept.svelte';
+  import SelectEmbedding from '../commands/customComponents/SelectEmbedding.svelte';
+  import RowItemMetadata from '../datasetView/RowItemMetadata.svelte';
+  import StringSpanHighlight from '../datasetView/StringSpanHighlight.svelte';
+  import type {SpanValueInfo} from '../datasetView/spanHighlight';
+
+  export let signalInfo: SignalInfoWithTypedSchema;
+
+  export let text: string | undefined = undefined;
+
+  // User entered text.
+  let textAreaText = text?.trim() || '';
+
+  // Auto-compute the text passed in if it's defined.
+  onMount(() => {
+    if (text != null) {
+      computeSignal();
+    }
+  });
+
+  // Reset the text when the example changes.
+  $: {
+    if (text != null) {
+      textAreaText = text.trim();
+      previewText = undefined;
+    }
+  }
+
+  function textChanged(e: Event) {
+    textAreaText = (e.target as HTMLTextAreaElement).value;
+    previewText = undefined;
+  }
+
+  // The text shown in the highlight preview.
+  let previewText: string | undefined = undefined;
+  let propertyValues: Record<string, JSONSchema4Type> = {};
+
+  $: signal = {...propertyValues, signal_name: signalInfo.name};
+  $: compute =
+    previewText != null
+      ? querySignalCompute({
+          signal,
+          inputs: [previewText]
+        })
+      : null;
+  $: signalSchema = querySignalSchema({signal});
+  function computeSignal() {
+    previewText = textAreaText;
+  }
+
+  let previewResultItem: LilacValueNode | undefined = undefined;
+  // For spans.
+  let valuePaths: SpanValueInfo[];
+  let spanPaths: Path[];
+  // For regular metadata.
+  let metadataFields: LilacField[];
+  // For primitives.
+  let primitiveValue: DataTypeCasted;
+  $: {
+    if ($compute?.data != null && $signalSchema.data?.fields != null) {
+      primitiveValue = null;
+      const item = $compute.data.items[0];
+      const resultSchema = deserializeField($signalSchema.data.fields);
+      previewResultItem = deserializeRow(item, resultSchema);
+
+      const spanValuePaths = getSpanValuePaths(resultSchema);
+      spanPaths = spanValuePaths.spanPaths;
+      valuePaths = spanValuePaths.valuePaths;
+
+      const children = petals(resultSchema);
+
+      // Find the non-span fields to render as a table.
+      metadataFields = children.filter(f => {
+        // Remove any children that are the child of a span.
+        return !spanPaths.some(p => {
+          return pathIncludes(f.path, p);
+        });
+      });
+
+      if (children.length === 0) {
+        // For primitive values, just show the value directly.
+        primitiveValue = item as unknown as DataTypeCasted;
+      }
+    }
+  }
+  let errors: JSONError[] = [];
+  const customComponents: Record<string, Record<string, typeof SvelteComponent>> = {
+    concept_score: {
+      '/namespace': EmptyComponent,
+      '/concept_name': SelectConcept,
+      '/embedding': SelectEmbedding
+    }
+  };
+  $: hasOptions =
+    Object.keys(signalInfo?.json_schema?.properties || {}).filter(p => p != 'signal_name').length >
+    0;
+</script>
+
+<div class="flex h-full w-full flex-col gap-y-8 px-10">
+  <div>
+    <div class="mb-4 flex flex-row items-center text-2xl font-semibold">
+      {signalInfo.json_schema.title}
+    </div>
+    {#if signalInfo.json_schema.description}
+      <div class="text text-base text-gray-600">
+        <SvelteMarkdown source={signalInfo.json_schema.description} />
+      </div>
+    {/if}
+  </div>
+  <div class="w-full">
+    <div class="flex w-full flex-col gap-x-8">
+      <div>
+        <TextArea
+          value={textAreaText}
+          on:input={textChanged}
+          cols={50}
+          placeholder="Paste text to try the signal."
+          rows={6}
+          class="mb-2"
+        />
+        <div class="flex flex-row justify-between">
+          <div class="pt-4">
+            <Button on:click={() => computeSignal()}>Compute</Button>
+          </div>
+        </div>
+      </div>
+      <div class:border-t={previewText != null} class="mb-8 mt-4 border-gray-200 pt-4">
+        {#if $compute?.isFetching}
+          <SkeletonText />
+        {:else if previewResultItem != null && previewText != null && $compute?.data != null}
+          <Tabs>
+            <Tab label="Preview" />
+            <Tab label="Raw response" />
+            <svelte:fragment slot="content">
+              <TabContent>
+                <div class="mt-2">
+                  {#if valuePaths.length > 0}
+                    <StringSpanHighlight
+                      text={previewText}
+                      row={previewResultItem}
+                      {spanPaths}
+                      {valuePaths}
+                      embeddings={[]}
+                    />
+                  {/if}
+                  {#if metadataFields.length > 0}
+                    <RowItemMetadata row={previewResultItem} visibleFields={metadataFields} />
+                  {/if}
+                  {#if primitiveValue != null}
+                    <div class="flex flex-row items-center">
+                      <div class="text text-base">
+                        {primitiveValue}
+                      </div>
+                    </div>
+                  {/if}
+                </div>
+              </TabContent>
+              <TabContent>
+                <TextArea
+                  value={JSON.stringify($compute.data.items[0], null, 2)}
+                  readonly
+                  rows={10}
+                  class="mb-2 font-mono"
+                /></TabContent
+              >
+            </svelte:fragment>
+          </Tabs>
+        {/if}
+      </div>
+      {#if hasOptions}
+        <div>
+          <h4>Signal options</h4>
+
+          <JsonSchemaForm
+            schema={signalInfo.json_schema}
+            bind:value={propertyValues}
+            bind:validationErrors={errors}
+            showDescription={false}
+            hiddenProperties={['/signal_name']}
+            customComponents={customComponents[signalInfo?.name]}
+          />
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style lang="postcss">
+  :global(.bx--tab-content) {
+    @apply p-0;
+  }
+</style>

--- a/web/blueprint/src/lib/queries/datasetQueries.ts
+++ b/web/blueprint/src/lib/queries/datasetQueries.ts
@@ -35,7 +35,7 @@ export const SELECT_GROUPS_SUPPORTED_DTYPES: DataType[] = [
 export const DATASETS_TAG = 'datasets';
 export const DATASETS_SETTINGS_TAG = 'settings';
 
-export const DEFAULT_SELECT_ROWS_LIMIT = 1;
+export const DEFAULT_SELECT_ROWS_LIMIT = 20;
 
 export const queryDatasets = createApiQuery(DatasetsService.getDatasets, DATASETS_TAG);
 export const queryDatasetManifest = createApiQuery(DatasetsService.getManifest, DATASETS_TAG, {});

--- a/web/blueprint/src/lib/queries/datasetQueries.ts
+++ b/web/blueprint/src/lib/queries/datasetQueries.ts
@@ -35,7 +35,7 @@ export const SELECT_GROUPS_SUPPORTED_DTYPES: DataType[] = [
 export const DATASETS_TAG = 'datasets';
 export const DATASETS_SETTINGS_TAG = 'settings';
 
-export const DEFAULT_SELECT_ROWS_LIMIT = 20;
+export const DEFAULT_SELECT_ROWS_LIMIT = 1;
 
 export const queryDatasets = createApiQuery(DatasetsService.getDatasets, DATASETS_TAG);
 export const queryDatasetManifest = createApiQuery(DatasetsService.getManifest, DATASETS_TAG, {});

--- a/web/blueprint/src/lib/queries/signalQueries.ts
+++ b/web/blueprint/src/lib/queries/signalQueries.ts
@@ -12,3 +12,6 @@ export const queryEmbeddings = createApiQuery(
   SignalsService.getEmbeddings as () => Promise<SignalInfoWithTypedSchema[]>,
   SIGNALS_TAG
 );
+
+export const querySignalCompute = createApiQuery(SignalsService.compute, SIGNALS_TAG);
+export const querySignalSchema = createApiQuery(SignalsService.schema, SIGNALS_TAG);

--- a/web/blueprint/src/lib/stores/urlHashStore.ts
+++ b/web/blueprint/src/lib/stores/urlHashStore.ts
@@ -2,7 +2,7 @@ import {mergeDeep} from '$lilac';
 import {getContext, hasContext, setContext} from 'svelte';
 import {writable, type Writable} from 'svelte/store';
 
-export type AppPage = 'home' | 'concepts' | 'datasets' | 'settings';
+export type AppPage = 'home' | 'concepts' | 'datasets' | 'signals' | 'settings';
 interface UrlHashState {
   hash: string;
   page: AppPage | null;

--- a/web/blueprint/src/lib/utils.ts
+++ b/web/blueprint/src/lib/utils.ts
@@ -17,3 +17,7 @@ export function datasetIdentifier(namespace: string, datasetName: string) {
 export function datasetLink(namespace: string, datasetName: string) {
   return `/datasets#${datasetIdentifier(namespace, datasetName)}`;
 }
+
+export function signalLink(name: string) {
+  return `/signals#${name}`;
+}

--- a/web/blueprint/src/routes/+layout.svelte
+++ b/web/blueprint/src/routes/+layout.svelte
@@ -25,6 +25,7 @@
     '/': 'home',
     '/datasets': 'datasets',
     '/concepts': 'concepts',
+    '/signals': 'signals',
     '/settings': 'settings'
   };
 

--- a/web/blueprint/src/routes/signals/+page.svelte
+++ b/web/blueprint/src/routes/signals/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import {goto} from '$app/navigation';
+  import Page from '$lib/components/Page.svelte';
+  import SignalView from '$lib/components/signals/SignalView.svelte';
+  import {querySignals} from '$lib/queries/signalQueries';
+  import {getUrlHashContext} from '$lib/stores/urlHashStore';
+  import {signalLink} from '$lib/utils';
+  import {SkeletonText, Tag} from 'carbon-components-svelte';
+
+  let signalName: string | undefined = undefined;
+
+  const urlHashStore = getUrlHashContext();
+  $: {
+    if ($urlHashStore.page === 'signals' && $urlHashStore.identifier != null) {
+      if (signalName != $urlHashStore.identifier) {
+        signalName = $urlHashStore.identifier;
+      }
+    }
+  }
+
+  const signals = querySignals();
+  $: signalInfo = $signals.data?.find(c => c.name === signalName);
+
+  $: link = signalName != null ? signalLink(signalName) : '';
+</script>
+
+<Page>
+  <div slot="header-subtext">
+    {#if $signals.isFetching}
+      <SkeletonText />
+    {:else}
+      <Tag type="blue">
+        <a class="font-semibold text-black" on:click={() => goto(link)} href={link}
+          >{signalName}
+        </a>
+      </Tag>
+    {/if}
+  </div>
+
+  <div class="flex h-full w-full overflow-x-hidden overflow-y-scroll">
+    <div class="lilac-page flex w-full">
+      {#if $signals?.isFetching}
+        <SkeletonText />
+      {:else if $signals?.isError}
+        <p>{$signals.error}</p>
+      {:else if $signals?.isSuccess && signalInfo}
+        {#key signalInfo}
+          <SignalView {signalInfo} />
+        {/key}
+      {/if}
+    </div>
+  </div>
+</Page>


### PR DESCRIPTION
- Add a signal preview page which lets you paste text and preview a signal's output.
- Change the concept preview to use the schema endpoint for the concept scorer.

NOTE: This doesn't share logic with the concept preview because they are different enough.

https://lilacai-nikhil-staging.hf.space/signals#lang_detection

<img width="1425" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/abb7008d-6de6-4ec8-a85b-8fd00af038e6">
