### PR TITLE
Add HNSW vector store, and update the embedding format

### DIFF
--- a/data/concept/lilac/toxicity/concept.json
+++ b/data/concept/lilac/toxicity/concept.json
@@ -5882,7 +5882,12 @@
       "label": true,
       "text": "Omg if you wanna know that ask your mom. You like DUMB CUNT",
       "id": "ac25d74836aa4393a6b8e0902c83c556"
+    },
+    "8fd430964273490faf67f1a1fdd6797d": {
+      "label": false,
+      "text": "Jerry Seinfeld\nJason Alexander\nJulia Louis-Dreyfus\nMichael Richards",
+      "id": "8fd430964273490faf67f1a1fdd6797d"
     }
   },
-  "version": 156
+  "version": 157
 }

--- a/lilac/__init__.py
+++ b/lilac/__init__.py
@@ -4,6 +4,7 @@ from .data import *  # noqa: F403
 from .data.dataset_duckdb import DatasetDuckDB
 from .data_loader import create_dataset
 from .db_manager import get_dataset, set_default_dataset_cls
+from .embeddings.default_vector_stores import register_default_vector_stores
 from .server import start_server, stop_server
 from .signals import *  # noqa: F403
 from .signals.default_signals import register_default_signals
@@ -17,6 +18,7 @@ except metadata.PackageNotFoundError:
 
 register_default_sources()
 register_default_signals()
+register_default_vector_stores()
 set_default_dataset_cls(DatasetDuckDB)
 
 # Avoids polluting the results of dir(__package__).

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -7,7 +7,7 @@ import pathlib
 import re
 import shutil
 import threading
-from typing import Any, Iterable, Iterator, Optional, Sequence, Type, Union, cast
+from typing import Any, Iterable, Iterator, Optional, Sequence, Union, cast
 
 import duckdb
 import numpy as np
@@ -20,8 +20,7 @@ from ..auth import UserInfo
 from ..batch_utils import deep_flatten, deep_unflatten
 from ..concepts.concept import ConceptColumnInfo
 from ..config import data_path, env
-from ..embeddings.vector_store import VectorDBIndex, VectorStore
-from ..embeddings.vector_store_numpy import NumpyVectorStore
+from ..embeddings.vector_store import VectorDBIndex
 from ..schema import (
   MANIFEST_FILENAME,
   PATH_WILDCARD,
@@ -94,7 +93,6 @@ from .dataset_utils import (
   create_signal_schema,
   flatten_keys,
   merge_schemas,
-  read_embeddings_from_disk,
   schema_contains_path,
   sparse_to_dense_compute,
   wrap_in_dicts,
@@ -140,10 +138,7 @@ class DuckDBSearchUDFs(BaseModel):
 class DatasetDuckDB(Dataset):
   """The DuckDB implementation of the dataset database."""
 
-  def __init__(self,
-               namespace: str,
-               dataset_name: str,
-               vector_store_cls: Type[VectorStore] = NumpyVectorStore):
+  def __init__(self, namespace: str, dataset_name: str, vector_store: str = 'hnsw'):
     super().__init__(namespace, dataset_name)
 
     self.dataset_path = get_dataset_output_dir(data_path(), namespace, dataset_name)
@@ -155,7 +150,7 @@ class DatasetDuckDB(Dataset):
 
     # Maps a path and embedding to the vector index. This is lazily generated as needed.
     self._vector_indices: dict[tuple[PathKey, str], VectorDBIndex] = {}
-    self.vector_store_cls = vector_store_cls
+    self.vector_store = vector_store
     self._manifest_lock = threading.Lock()
 
     # Calling settings creates the default settings JSON file if it doesn't exist.
@@ -276,22 +271,22 @@ class DatasetDuckDB(Dataset):
       return self._vector_indices[index_key]
 
     manifests = [
-      m for m in self._signal_manifests if schema_contains_path(m.data_schema, path) and
-      m.embedding_filename_prefix and m.signal.name == embedding
+      m for m in self._signal_manifests
+      if schema_contains_path(m.data_schema, path) and m.vector_store and m.signal.name == embedding
     ]
     if not manifests:
       raise ValueError(f'No embedding found for path {path}.')
     if len(manifests) > 1:
       raise ValueError(f'Multiple embeddings found for path {path}. Got: {manifests}')
     manifest = manifests[0]
-    if not manifest.embedding_filename_prefix:
+    if not manifest.vector_store:
       raise ValueError(f'Signal manifest for path {path} is not an embedding. '
                        f'Got signal manifest: {manifest}')
 
-    filepath_prefix = os.path.join(self.dataset_path, _signal_dir(manifest.enriched_path),
-                                   manifest.signal.name, manifest.embedding_filename_prefix)
-    spans, embeddings = read_embeddings_from_disk(filepath_prefix)
-    vector_index = VectorDBIndex(self.vector_store_cls, spans, embeddings)
+    base_path = os.path.join(self.dataset_path, _signal_dir(manifest.enriched_path),
+                             manifest.signal.name)
+    vector_index = VectorDBIndex(manifest.vector_store)
+    vector_index.load(base_path)
     # Cache the vector index.
     self._vector_indices[index_key] = vector_index
     return vector_index
@@ -376,13 +371,12 @@ class DatasetDuckDB(Dataset):
     enriched_path = _col_destination_path(signal_col, is_computed_signal=True)
     output_dir = os.path.join(self.dataset_path, _signal_dir(enriched_path))
     signal_schema = create_signal_schema(signal, source_path, manifest.data_schema)
-    embedding_filename_prefix = os.path.basename(
-      write_embeddings_to_disk(
-        uuids=df[UUID_COLUMN],
-        signal_items=values,
-        output_dir=output_dir,
-        shard_index=0,
-        num_shards=1))
+
+    write_embeddings_to_disk(
+      vector_store=self.vector_store,
+      uuids=df[UUID_COLUMN],
+      signal_items=values,
+      output_dir=output_dir)
 
     signal_manifest = SignalManifest(
       files=[],
@@ -390,7 +384,7 @@ class DatasetDuckDB(Dataset):
       signal=signal,
       enriched_path=source_path,
       parquet_id=make_parquet_id(signal, source_path, is_computed_signal=True),
-      embedding_filename_prefix=embedding_filename_prefix)
+      vector_store=self.vector_store)
     signal_manifest_filepath = os.path.join(output_dir, SIGNAL_MANIFEST_FILENAME)
 
     with open_file(signal_manifest_filepath, 'w') as f:
@@ -1530,8 +1524,8 @@ class SignalManifest(BaseModel):
   # The column path that this signal is derived from.
   enriched_path: PathTuple
 
-  # The filename prefix for the embedding. Present when the signal is an embedding.
-  embedding_filename_prefix: Optional[str] = None
+  # The name of the vector store. Present when the signal is an embedding.
+  vector_store: Optional[str] = None
 
   @validator('signal', pre=True)
   def parse_signal(cls, signal: dict) -> Signal:

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1,5 +1,6 @@
 """The DuckDB implementation of the dataset database."""
 import functools
+import gc
 import glob
 import math
 import os
@@ -377,6 +378,9 @@ class DatasetDuckDB(Dataset):
       uuids=df[UUID_COLUMN],
       signal_items=values,
       output_dir=output_dir)
+
+    del select_rows_result, df, values
+    gc.collect()
 
     signal_manifest = SignalManifest(
       files=[],

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -827,7 +827,9 @@ class DatasetDuckDB(Dataset):
         vector_index = self.get_vector_db_index(topk_signal.embedding, topk_udf_col.path)
         k = (limit or 0) + (offset or 0)
         topk = topk_signal.vector_compute_topk(k, vector_index, path_keys)
-        topk_uuids = list(dict.fromkeys([cast(str, path_key[0]) for path_key, _ in topk]))
+        topk_uuids = list(dict.fromkeys([cast(str, uuid) for (uuid, *_), _ in topk]))
+        # Update the offset to account for the number of unique UUIDs.
+        offset = len(dict.fromkeys([cast(str, uuid) for (uuid, *_), _ in topk[:offset]]))
 
         # Ignore all the other filters and filter DuckDB results only by the top k UUIDs.
         uuid_filter = Filter(path=(UUID_COLUMN,), op=ListOp.IN, value=topk_uuids)

--- a/lilac/data/dataset_select_rows_sort_test.py
+++ b/lilac/data/dataset_select_rows_sort_test.py
@@ -850,7 +850,7 @@ def test_sort_by_topk_embedding_udf(make_test_data: TestDataMaker) -> None:
   result = dataset.select_rows(['*', text_udf],
                                sort_by=['udf'],
                                sort_order=SortOrder.DESC,
-                               limit=3,
+                               limit=2,
                                combine_columns=True)
   assert list(result) == [{
     UUID_COLUMN: '3',
@@ -864,11 +864,11 @@ def test_sort_by_topk_embedding_udf(make_test_data: TestDataMaker) -> None:
                              lilac_span(2, 3, {'score': 1.0})]}),
   }]
 
-  # Same but set limit to 4.
+  # Same but set limit to 3.
   result = dataset.select_rows(['*', text_udf],
                                sort_by=['udf'],
                                sort_order=SortOrder.DESC,
-                               limit=4,
+                               limit=3,
                                combine_columns=True)
   assert list(result) == [{
     UUID_COLUMN: '3',

--- a/lilac/data/dataset_test_utils.py
+++ b/lilac/data/dataset_test_utils.py
@@ -7,7 +7,7 @@ from typing import Optional, Type, cast
 import numpy as np
 from typing_extensions import Protocol
 
-from ..embeddings.vector_store import VectorDBIndex, VectorStore
+from ..embeddings.vector_store import VectorDBIndex
 from ..schema import (
   MANIFEST_FILENAME,
   PARQUET_FILENAME_PREFIX,
@@ -110,8 +110,8 @@ def enriched_item(value: Optional[Item] = None, metadata: dict[str, Item] = {}) 
   return {VALUE_KEY: value, **metadata}
 
 
-def make_vector_index(vector_store_cls: Type[VectorStore],
-                      vector_dict: dict[PathKey, list[list[float]]]) -> VectorDBIndex:
+def make_vector_index(vector_store: str, vector_dict: dict[PathKey,
+                                                           list[list[float]]]) -> VectorDBIndex:
   """Make a vector index from a dictionary of vector keys to vectors."""
   embeddings: list[np.ndarray] = []
   spans: list[tuple[PathKey, list[tuple[int, int]]]] = []
@@ -122,4 +122,6 @@ def make_vector_index(vector_store_cls: Type[VectorStore],
       vector_spans.append((0, 0))
     spans.append((path_key, vector_spans))
 
-  return VectorDBIndex(vector_store_cls, spans, np.array(embeddings))
+  vector_index = VectorDBIndex(vector_store)
+  vector_index.add(spans, np.array(embeddings))
+  return vector_index

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -1,5 +1,6 @@
 """Utilities for working with datasets."""
 
+import gc
 import json
 import math
 import os
@@ -183,11 +184,16 @@ def write_embeddings_to_disk(vector_store: str, uuids: Iterable[str], signal_ite
       spans.append((span[TEXT_SPAN_START_FEATURE], span[TEXT_SPAN_END_FEATURE]))
     all_spans.append((path_key, spans))
   embedding_matrix = np.array(embedding_vectors)
+  del path_keys, all_embeddings, embedding_vectors
+  gc.collect()
 
   # Write to disk.
   vector_index = VectorDBIndex(vector_store)
   vector_index.add(all_spans, embedding_matrix)
   vector_index.save(output_dir)
+
+  del vector_index
+  gc.collect()
 
 
 def write_items_to_parquet(items: Iterable[Item], output_dir: str, schema: Schema,

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -3,7 +3,6 @@
 import json
 import math
 import os
-import pickle
 import pprint
 import secrets
 from collections.abc import Iterable
@@ -14,6 +13,7 @@ import pyarrow as pa
 
 from ..batch_utils import deep_flatten
 from ..config import env
+from ..embeddings.vector_store import VectorDBIndex
 from ..parquet_writer import ParquetWriter
 from ..schema import (
   EMBEDDING_KEY,
@@ -33,10 +33,7 @@ from ..schema import (
   schema_to_arrow_schema,
 )
 from ..signals.signal import Signal
-from ..utils import file_exists, is_primitive, log, open_file
-
-_SPANS_SUFFIX = '.spans.pkl'
-_EMBEDDINGS_SUFFIX = '.npy'
+from ..utils import is_primitive, log, open_file
 
 
 def _replace_embeddings_with_none(input: Union[Item, Item]) -> Union[Item, Item]:
@@ -158,12 +155,10 @@ def create_signal_schema(signal: Signal, source_path: PathTuple, current_schema:
   return schema({UUID_COLUMN: 'string', **cast(dict, enriched_schema.fields)})
 
 
-def write_embeddings_to_disk(uuids: Iterable[str], signal_items: Iterable[Item], output_dir: str,
-                             shard_index: int, num_shards: int) -> str:
+def write_embeddings_to_disk(vector_store: str, uuids: Iterable[str], signal_items: Iterable[Item],
+                             output_dir: str) -> None:
   """Write a set of embeddings to disk."""
-  output_path_prefix = embedding_index_filename_prefix(output_dir, shard_index, num_shards)
 
-  # For each item, we have a list of embedding spans.
   def embedding_predicate(input: Any) -> bool:
     return (isinstance(input, list) and len(input) > 0 and isinstance(input[0], dict) and
             EMBEDDING_KEY in input[0])
@@ -187,29 +182,12 @@ def write_embeddings_to_disk(uuids: Iterable[str], signal_items: Iterable[Item],
       embedding_vectors.append(vector.reshape(-1))
       spans.append((span[TEXT_SPAN_START_FEATURE], span[TEXT_SPAN_END_FEATURE]))
     all_spans.append((path_key, spans))
-
   embedding_matrix = np.array(embedding_vectors)
-  # Write the embedding index and the ordered UUID column to disk so they can be joined later.
 
-  with open_file(output_path_prefix + _EMBEDDINGS_SUFFIX, 'wb') as f:
-    np.save(cast(str, f), embedding_matrix, allow_pickle=False)
-  with open_file(output_path_prefix + _SPANS_SUFFIX, 'wb') as f:
-    pickle.dump(all_spans, f)
-
-  return output_path_prefix
-
-
-def read_embeddings_from_disk(
-    filepath_prefix: str) -> tuple[list[tuple[PathKey, list[tuple[int, int]]]], np.ndarray]:
-  """Reads the embeddings from disk."""
-  if not file_exists(filepath_prefix + _EMBEDDINGS_SUFFIX):
-    raise ValueError(F'Embedding index does not exist at path {filepath_prefix}. '
-                     'Please run dataset.compute_signal() on the embedding signal first.')
-  # Read the embedding index from disk.
-  embeddings = np.load(filepath_prefix + _EMBEDDINGS_SUFFIX, allow_pickle=False)
-  with open_file(filepath_prefix + _SPANS_SUFFIX, 'rb') as f:
-    spans: list[tuple[PathKey, list[tuple[int, int]]]] = pickle.load(f)
-  return spans, embeddings
+  # Write to disk.
+  vector_index = VectorDBIndex(vector_store)
+  vector_index.add(all_spans, embedding_matrix)
+  vector_index.save(output_dir)
 
 
 def write_items_to_parquet(items: Iterable[Item], output_dir: str, schema: Schema,
@@ -280,12 +258,6 @@ def flatten_keys(
       yield None
       continue
     yield from _flatten_keys(uuid, input, [], is_primitive_predicate)
-
-
-def embedding_index_filename_prefix(output_dir: str, shard_index: int, num_shards: int) -> str:
-  """Return the filename prefix for the embedding index."""
-  npy_filename = f'embeddings-{shard_index:05d}-of-{num_shards:05d}'
-  return os.path.join(output_dir, npy_filename)
 
 
 Tin = TypeVar('Tin')

--- a/lilac/embeddings/default_vector_stores.py
+++ b/lilac/embeddings/default_vector_stores.py
@@ -1,0 +1,10 @@
+"""Registers all vector stores."""
+from .vector_store import register_vector_store
+from .vector_store_hnsw import HNSWVectorStore
+from .vector_store_numpy import NumpyVectorStore
+
+
+def register_default_vector_stores() -> None:
+  """Register all the default vector stores."""
+  register_vector_store(HNSWVectorStore)
+  register_vector_store(NumpyVectorStore)

--- a/lilac/embeddings/embedding.py
+++ b/lilac/embeddings/embedding.py
@@ -87,8 +87,7 @@ def compute_split_embeddings(docs: Iterable[str],
 
     for x in list(pool.map(lambda x: embed_fn(x), chunks(texts, batch_size))):
       embeddings.extend(x)
-    matrix = cast(np.ndarray, normalize(np.array(embeddings)))
-    matrix = matrix.astype(np.float16)
+    matrix = cast(np.ndarray, normalize(np.array(embeddings, dtype=np.float32)))
     # np.split returns a shallow copy of each embedding so we don't increase the mem footprint.
     embeddings_batch = cast(list[np.ndarray], np.split(matrix, matrix.shape[0]))
     for (index, (_, (start, end))), embedding in zip(batch, embeddings_batch):

--- a/lilac/embeddings/vector_store.py
+++ b/lilac/embeddings/vector_store.py
@@ -1,15 +1,31 @@
 """Interface for storing vectors."""
 
 import abc
+import os
+import pickle
 from typing import Iterable, Optional, Type
 
 import numpy as np
 
 from ..schema import SpanVector, VectorKey
+from ..utils import open_file
 
 
 class VectorStore(abc.ABC):
   """Interface for storing and retrieving vectors."""
+
+  # The global name of the vector store.
+  name: str
+
+  @abc.abstractmethod
+  def save(self, base_path: str) -> None:
+    """Save the store to disk."""
+    pass
+
+  @abc.abstractmethod
+  def load(self, base_path: str) -> None:
+    """Load the store from disk."""
+    pass
 
   @abc.abstractmethod
   def keys(self) -> list[VectorKey]:
@@ -59,6 +75,8 @@ class VectorStore(abc.ABC):
 
 PathKey = VectorKey
 
+_SPANS_PICKLE_NAME = 'spans.pkl'
+
 
 class VectorDBIndex:
   """Stores and retrives span vectors.
@@ -67,17 +85,41 @@ class VectorDBIndex:
   to span keys, such as (uuid1, 0, 0), which denotes the first span in the (uuid1, 0) text document.
   """
 
-  def __init__(self, vector_store_cls: Type[VectorStore],
-               spans: list[tuple[PathKey, list[tuple[int, int]]]], embeddings: np.ndarray) -> None:
-    vector_keys = [(*path_key, i) for path_key, spans in spans for i in range(len(spans))]
-    self._vector_store = vector_store_cls()
-    self._vector_store.add(vector_keys, embeddings)
+  def __init__(self, vector_store: str) -> None:
+    self._vector_store: VectorStore = get_vector_store_cls(vector_store)()
     # Map a path key to spans for that path.
     self._id_to_spans: dict[PathKey, list[tuple[int, int]]] = {}
+
+  def load(self, base_path: str) -> None:
+    """Load the vector index from disk."""
+    assert not self._id_to_spans, 'Cannot load into a non-empty index.'
+    with open_file(os.path.join(base_path, _SPANS_PICKLE_NAME), 'rb') as f:
+      self._id_to_spans.update(pickle.load(f))
+    self._vector_store.load(os.path.join(base_path, self._vector_store.name))
+
+  def save(self, base_path: str) -> None:
+    """Save the vector index to disk."""
+    assert self._id_to_spans, 'Cannot save an empty index.'
+    with open_file(os.path.join(base_path, _SPANS_PICKLE_NAME), 'wb') as f:
+      pickle.dump(list(self._id_to_spans.items()), f)
+    self._vector_store.save(os.path.join(base_path, self._vector_store.name))
+
+  def add(self, spans: list[tuple[PathKey, list[tuple[int, int]]]], embeddings: np.ndarray) -> None:
+    """Add the given spans and embeddings.
+
+    Args:
+      spans: The spans to initialize the index with.
+      embeddings: The embeddings to initialize the index with.
+    """
+    assert not self._id_to_spans, 'Cannot add to a non-empty index.'
     self._id_to_spans.update(spans)
+    vector_keys = [(*path_key, i) for path_key, spans in spans for i in range(len(spans))]
+    assert len(vector_keys) == len(embeddings), (
+      f'Number of spans ({len(vector_keys)}) and embeddings ({len(embeddings)}) must match.')
+    self._vector_store.add(vector_keys, embeddings)
 
   def get_vector_store(self) -> VectorStore:
-    """Return the vector store."""
+    """Return the underlying vector store."""
     return self._vector_store
 
   def get(self, keys: Iterable[PathKey]) -> Iterable[list[SpanVector]]:
@@ -135,3 +177,24 @@ class VectorDBIndex:
           path_key_scores[path_key] = score
 
     return list(path_key_scores.items())[:k]
+
+
+VECTOR_STORE_REGISTRY: dict[str, Type[VectorStore]] = {}
+
+
+def register_vector_store(vector_store_cls: Type[VectorStore]) -> None:
+  """Register a vector store in the global registry."""
+  if vector_store_cls.name in VECTOR_STORE_REGISTRY:
+    raise ValueError(f'Vector store "{vector_store_cls.name}" has already been registered!')
+
+  VECTOR_STORE_REGISTRY[vector_store_cls.name] = vector_store_cls
+
+
+def get_vector_store_cls(vector_store_name: str) -> Type[VectorStore]:
+  """Return a registered vector store given the name in the registry."""
+  return VECTOR_STORE_REGISTRY[vector_store_name]
+
+
+def clear_vector_store_registry() -> None:
+  """Clear the vector store registry."""
+  VECTOR_STORE_REGISTRY.clear()

--- a/lilac/embeddings/vector_store.py
+++ b/lilac/embeddings/vector_store.py
@@ -117,15 +117,21 @@ class VectorDBIndex:
     Returns
       A list of (key, score) tuples.
     """
-    vector_keys: Optional[list[VectorKey]] = None
+    span_keys: Optional[list[VectorKey]] = None
     if path_keys is not None:
-      vector_keys = [
+      span_keys = [
         (*path_key, i) for path_key in path_keys for i in range(len(self._id_to_spans[path_key]))
       ]
-    vector_key_scores = self._vector_store.topk(query, k, vector_keys)
+    span_k = k
     path_key_scores: dict[PathKey, float] = {}
-    for (*path_key_list, _), score in vector_key_scores:
-      path_key = tuple(path_key_list)
-      if path_key not in path_key_scores:
-        path_key_scores[path_key] = score
-    return list(path_key_scores.items())
+    total_num_span_keys = len(self._vector_store.keys())
+    while (len(path_key_scores) < k and span_k < total_num_span_keys and
+           (not span_keys or span_k < len(span_keys))):
+      span_k += k
+      vector_key_scores = self._vector_store.topk(query, span_k, span_keys)
+      for (*path_key_list, _), score in vector_key_scores:
+        path_key = tuple(path_key_list)
+        if path_key not in path_key_scores:
+          path_key_scores[path_key] = score
+
+    return list(path_key_scores.items())[:k]

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -1,0 +1,102 @@
+"""HNSW vector store."""
+
+import multiprocessing
+from typing import Iterable, Optional, cast
+
+import hnswlib
+import numpy as np
+import pandas as pd
+from typing_extensions import override
+
+from ..schema import VectorKey
+from ..utils import DebugTimer
+from .vector_store import VectorStore
+
+_HNSW_SUFFIX = '.hnswlib.bin'
+_LOOKUP_SUFFIX = '.lookup.pkl'
+
+
+class HNSWVectorStore(VectorStore):
+  """HNSW-backed vector store."""
+
+  name = 'hnsw'
+
+  def __init__(self) -> None:
+    # Maps a `VectorKey` to a row index in `_embeddings`.
+    self._lookup: Optional[pd.Series] = None
+    self._index: Optional[hnswlib.Index] = None
+
+  @override
+  def save(self, base_path: str) -> None:
+    assert self._lookup is not None and self._index is not None, (
+      'The vector store has no embeddings. Call load() or add() first.')
+    self._index.save_index(base_path + _HNSW_SUFFIX)
+    self._lookup.to_pickle(base_path + _LOOKUP_SUFFIX)
+
+  @override
+  def load(self, base_path: str) -> None:
+    self._lookup = pd.read_pickle(base_path + _LOOKUP_SUFFIX)
+    dim = int(self._lookup.name)
+    with DebugTimer('Loading hnswlib index'):
+      index = hnswlib.Index(space='ip', dim=dim)
+      index.set_ef(10)
+      index.set_num_threads(multiprocessing.cpu_count())
+      index.load_index(base_path + _HNSW_SUFFIX)
+    self._index = index
+
+  @override
+  def keys(self) -> list[VectorKey]:
+    assert self._lookup is not None, 'No embeddings exist in this store.'
+    return self._lookup.index.tolist()
+
+  @override
+  def add(self, keys: list[VectorKey], embeddings: np.ndarray) -> None:
+    assert self._index is None, (
+      'Embeddings already exist in this store. Upsert is not yet supported.')
+
+    if len(keys) != embeddings.shape[0]:
+      raise ValueError(
+        f'Length of keys ({len(keys)}) does not match number of embeddings {embeddings.shape[0]}.')
+
+    dim = embeddings.shape[1]
+    with DebugTimer('hnswlib index creation'):
+      index = hnswlib.Index(space='ip', dim=dim)
+      index.set_ef(10)
+      index.set_num_threads(multiprocessing.cpu_count())
+      index.init_index(max_elements=len(keys), ef_construction=50, M=16)
+
+      # Cast to float32 since dot product with float32 is 40-50x faster than float16 and 2.5x faster
+      # than float64.
+      embeddings = embeddings.astype(np.float32)
+      row_indices = np.arange(len(keys), dtype=np.uint32)
+      self._lookup = pd.Series(row_indices, index=keys, dtype=np.uint32)
+      self._lookup.name = str(dim)
+      index.add_items(embeddings, row_indices)
+      self._index = index
+
+  @override
+  def get(self, keys: Optional[Iterable[VectorKey]] = None) -> np.ndarray:
+    assert self._index is not None and self._lookup is not None, (
+      'No embeddings exist in this store.')
+    if not keys:
+      return self._index.get_items(self._lookup.values)
+    locs = self._lookup.loc[cast(list[str], keys)].values
+    return self._index.get_items(locs)
+
+  @override
+  def topk(self,
+           query: np.ndarray,
+           k: int,
+           keys: Optional[Iterable[VectorKey]] = None) -> list[tuple[VectorKey, float]]:
+    assert self._index is not None and self._lookup is not None, (
+      'No embeddings exist in this store.')
+    row_indices: Optional[Iterable[int]] = None
+    if keys is not None:
+      row_indices = self._lookup.loc[cast(list[str], keys)].values
+
+    query = np.expand_dims(query.astype(np.float32), axis=0)
+    locs, scores = self._index.knn_query(query, k=k, filter=row_indices)
+    locs = locs[0]
+    scores = scores[0]
+    topk_keys = self._lookup.index.values[locs]
+    return [(key, score) for key, score in zip(topk_keys, scores)]

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -37,11 +37,10 @@ class HNSWVectorStore(VectorStore):
   def load(self, base_path: str) -> None:
     self._lookup = pd.read_pickle(base_path + _LOOKUP_SUFFIX)
     dim = int(self._lookup.name)
-    with DebugTimer('Loading hnswlib index'):
-      index = hnswlib.Index(space='ip', dim=dim)
-      index.set_ef(10)
-      index.set_num_threads(multiprocessing.cpu_count())
-      index.load_index(base_path + _HNSW_SUFFIX)
+    index = hnswlib.Index(space='ip', dim=dim)
+    index.set_ef(10)
+    index.set_num_threads(multiprocessing.cpu_count())
+    index.load_index(base_path + _HNSW_SUFFIX)
     self._index = index
 
   @override

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -23,20 +23,20 @@ class HNSWVectorStore(VectorStore):
 
   def __init__(self) -> None:
     # Maps a `VectorKey` to a row index in `_embeddings`.
-    self._lookup: Optional[pd.Series] = None
+    self._key_to_label: Optional[pd.Series] = None
     self._index: Optional[hnswlib.Index] = None
 
   @override
   def save(self, base_path: str) -> None:
-    assert self._lookup is not None and self._index is not None, (
+    assert self._key_to_label is not None and self._index is not None, (
       'The vector store has no embeddings. Call load() or add() first.')
     self._index.save_index(base_path + _HNSW_SUFFIX)
-    self._lookup.to_pickle(base_path + _LOOKUP_SUFFIX)
+    self._key_to_label.to_pickle(base_path + _LOOKUP_SUFFIX)
 
   @override
   def load(self, base_path: str) -> None:
-    self._lookup = pd.read_pickle(base_path + _LOOKUP_SUFFIX)
-    dim = int(self._lookup.name)
+    self._key_to_label = pd.read_pickle(base_path + _LOOKUP_SUFFIX)
+    dim = int(self._key_to_label.name)
     index = hnswlib.Index(space='ip', dim=dim)
     index.set_ef(10)
     index.set_num_threads(multiprocessing.cpu_count())
@@ -45,8 +45,8 @@ class HNSWVectorStore(VectorStore):
 
   @override
   def keys(self) -> list[VectorKey]:
-    assert self._lookup is not None, 'No embeddings exist in this store.'
-    return self._lookup.index.tolist()
+    assert self._key_to_label is not None, 'No embeddings exist in this store.'
+    return self._key_to_label.index.tolist()
 
   @override
   def add(self, keys: list[VectorKey], embeddings: np.ndarray) -> None:
@@ -68,18 +68,18 @@ class HNSWVectorStore(VectorStore):
       # than float64.
       embeddings = embeddings.astype(np.float32)
       row_indices = np.arange(len(keys), dtype=np.int32)
-      self._lookup = pd.Series(row_indices, index=keys, dtype=np.int32)
-      self._lookup.name = str(dim)
+      self._key_to_label = pd.Series(row_indices, index=keys, dtype=np.int32)
+      self._key_to_label.name = str(dim)
       index.add_items(embeddings, row_indices)
       self._index = index
 
   @override
   def get(self, keys: Optional[Iterable[VectorKey]] = None) -> np.ndarray:
-    assert self._index is not None and self._lookup is not None, (
+    assert self._index is not None and self._key_to_label is not None, (
       'No embeddings exist in this store.')
     if not keys:
-      return np.array(self._index.get_items(self._lookup.values), dtype=np.float32)
-    locs = self._lookup.loc[cast(list[str], keys)].values
+      return np.array(self._index.get_items(self._key_to_label.values), dtype=np.float32)
+    locs = self._key_to_label.loc[cast(list[str], keys)].values
     return np.array(self._index.get_items(locs), dtype=np.float32)
 
   @override
@@ -87,11 +87,11 @@ class HNSWVectorStore(VectorStore):
            query: np.ndarray,
            k: int,
            keys: Optional[Iterable[VectorKey]] = None) -> list[tuple[VectorKey, float]]:
-    assert self._index is not None and self._lookup is not None, (
+    assert self._index is not None and self._key_to_label is not None, (
       'No embeddings exist in this store.')
     labels: Set[int] = set()
     if keys is not None:
-      labels = set(self._lookup.loc[cast(list[str], keys)].tolist())
+      labels = set(self._key_to_label.loc[cast(list[str], keys)].tolist())
       k = min(k, len(labels))
 
     def filter_func(label: int) -> bool:
@@ -101,5 +101,5 @@ class HNSWVectorStore(VectorStore):
     locs, dists = self._index.knn_query(query, k=k, filter=filter_func if labels else None)
     locs = locs[0]
     dists = dists[0]
-    topk_keys = self._lookup.index.values[locs]
+    topk_keys = self._key_to_label.index.values[locs]
     return [(key, 1 - dist) for key, dist in zip(topk_keys, dists)]

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -1,7 +1,7 @@
 """HNSW vector store."""
 
 import multiprocessing
-from typing import Iterable, Optional, cast
+from typing import Iterable, Optional, Set, cast
 
 import hnswlib
 import numpy as np
@@ -68,8 +68,8 @@ class HNSWVectorStore(VectorStore):
       # Cast to float32 since dot product with float32 is 40-50x faster than float16 and 2.5x faster
       # than float64.
       embeddings = embeddings.astype(np.float32)
-      row_indices = np.arange(len(keys), dtype=np.uint32)
-      self._lookup = pd.Series(row_indices, index=keys, dtype=np.uint32)
+      row_indices = np.arange(len(keys), dtype=np.int32)
+      self._lookup = pd.Series(row_indices, index=keys, dtype=np.int32)
       self._lookup.name = str(dim)
       index.add_items(embeddings, row_indices)
       self._index = index
@@ -79,9 +79,9 @@ class HNSWVectorStore(VectorStore):
     assert self._index is not None and self._lookup is not None, (
       'No embeddings exist in this store.')
     if not keys:
-      return self._index.get_items(self._lookup.values)
+      return np.array(self._index.get_items(self._lookup.values), dtype=np.float32)
     locs = self._lookup.loc[cast(list[str], keys)].values
-    return self._index.get_items(locs)
+    return np.array(self._index.get_items(locs), dtype=np.float32)
 
   @override
   def topk(self,
@@ -90,13 +90,17 @@ class HNSWVectorStore(VectorStore):
            keys: Optional[Iterable[VectorKey]] = None) -> list[tuple[VectorKey, float]]:
     assert self._index is not None and self._lookup is not None, (
       'No embeddings exist in this store.')
-    row_indices: Optional[Iterable[int]] = None
+    labels: Set[int] = set()
     if keys is not None:
-      row_indices = self._lookup.loc[cast(list[str], keys)].values
+      labels = set(self._lookup.loc[cast(list[str], keys)].tolist())
+      k = min(k, len(labels))
+
+    def filter_func(label: int) -> bool:
+      return label in labels
 
     query = np.expand_dims(query.astype(np.float32), axis=0)
-    locs, scores = self._index.knn_query(query, k=k, filter=row_indices)
+    locs, dists = self._index.knn_query(query, k=k, filter=filter_func if labels else None)
     locs = locs[0]
-    scores = scores[0]
+    dists = dists[0]
     topk_keys = self._lookup.index.values[locs]
-    return [(key, score) for key, score in zip(topk_keys, scores)]
+    return [(key, 1 - dist) for key, dist in zip(topk_keys, dists)]

--- a/lilac/embeddings/vector_store_numpy.py
+++ b/lilac/embeddings/vector_store_numpy.py
@@ -9,44 +9,56 @@ from typing_extensions import override
 from ..schema import VectorKey
 from .vector_store import VectorStore
 
+_EMBEDDINGS_SUFFIX = '.matrix.npy'
+_LOOKUP_SUFFIX = '.lookup.pkl'
+
 
 class NumpyVectorStore(VectorStore):
   """Stores vectors as in-memory np arrays."""
-  _embeddings: np.ndarray
-  _keys: list[VectorKey]
-  # Maps a `VectorKey` to a row index in `_embeddings`.
-  _lookup: pd.Series
+  name = 'numpy'
+
+  def __init__(self) -> None:
+    self._embeddings: Optional[np.ndarray] = None
+    # Maps a `VectorKey` to a row index in `_embeddings`.
+    self._lookup: Optional[pd.Series] = None
 
   @override
   def keys(self) -> list[VectorKey]:
-    return self._keys
+    assert self._lookup is not None, (
+      'The vector store has no embeddings. Call load() or add() first.')
+    return self._lookup.index.tolist()
+
+  @override
+  def save(self, base_path: str) -> None:
+    assert self._embeddings is not None and self._lookup is not None, (
+      'The vector store has no embeddings. Call load() or add() first.')
+    np.save(base_path + _EMBEDDINGS_SUFFIX, self._embeddings, allow_pickle=False)
+    self._lookup.to_pickle(base_path + _LOOKUP_SUFFIX)
+
+  @override
+  def load(self, base_path: str) -> None:
+    self._embeddings = np.load(base_path + _EMBEDDINGS_SUFFIX, allow_pickle=False)
+    self._lookup = pd.read_pickle(base_path + _LOOKUP_SUFFIX)
 
   @override
   def add(self, keys: list[VectorKey], embeddings: np.ndarray) -> None:
-    if hasattr(self, '_embeddings') or hasattr(self, '_keys'):
+    if self._embeddings or self._lookup:
       raise ValueError('Embeddings already exist in this store. Upsert is not yet supported.')
 
     if len(keys) != embeddings.shape[0]:
       raise ValueError(
         f'Length of keys ({len(keys)}) does not match number of embeddings {embeddings.shape[0]}.')
 
-    self._keys = keys
     # Cast to float32 since dot product with float32 is 40-50x faster than float16 and 2.5x faster
     # than float64.
     self._embeddings = embeddings.astype(np.float32)
-    row_indices = np.arange(len(self._embeddings), dtype=np.uint32)
-    self._lookup = pd.Series(row_indices, index=keys)
+    row_indices = np.arange(len(embeddings), dtype=np.uint32)
+    self._lookup = pd.Series(row_indices, index=keys, dtype=np.uint32)
 
   @override
   def get(self, keys: Optional[Iterable[VectorKey]] = None) -> np.ndarray:
-    """Return the embeddings for given keys.
-
-    Args:
-      keys: The keys to return the embeddings for.
-
-    Returns
-      The embeddings for the given keys.
-    """
+    assert self._embeddings is not None and self._lookup is not None, (
+      'The vector store has no embeddings. Call load() or add() first.')
     if not keys:
       return self._embeddings
     locs = self._lookup.loc[cast(list[str], keys)]
@@ -57,12 +69,14 @@ class NumpyVectorStore(VectorStore):
            query: np.ndarray,
            k: int,
            keys: Optional[Iterable[VectorKey]] = None) -> list[tuple[VectorKey, float]]:
+    assert self._embeddings is not None and self._lookup is not None, (
+      'The vector store has no embeddings. Call load() or add() first.')
     if keys is not None:
-      # This uses the hierarchical index (MutliIndex) to do a prefix lookup.
       row_indices = self._lookup.loc[cast(list[str], keys)]
-      keys, embeddings = list(row_indices.index), self._embeddings.take(row_indices, axis=0)
+      embeddings = self._embeddings.take(row_indices, axis=0)
+      keys = list(keys)
     else:
-      keys, embeddings = self._keys, self._embeddings
+      keys, embeddings = cast(list[VectorKey], self._lookup.index.tolist()), self._embeddings
 
     query = query.astype(embeddings.dtype)
     similarities: np.ndarray = np.dot(embeddings, query).reshape(-1)

--- a/lilac/signals/concept_scorer_test.py
+++ b/lilac/signals/concept_scorer_test.py
@@ -26,6 +26,7 @@ from .signal import TextEmbeddingSignal, clear_signal_registry, register_signal
 
 ALL_CONCEPT_DBS = [DiskConceptDB]
 ALL_CONCEPT_MODEL_DBS = [DiskConceptModelDB]
+ALL_VECTOR_STORES = ['numpy', 'hnsw']
 
 
 @pytest.fixture(autouse=True)
@@ -172,8 +173,9 @@ def test_concept_model_with_dataset_score(concept_db_cls: Type[ConceptDB],
 
 @pytest.mark.parametrize('concept_db_cls', ALL_CONCEPT_DBS)
 @pytest.mark.parametrize('model_db_cls', ALL_CONCEPT_MODEL_DBS)
+@pytest.mark.parametrize('vector_store', ALL_VECTOR_STORES)
 def test_concept_model_vector_score(concept_db_cls: Type[ConceptDB],
-                                    model_db_cls: Type[ConceptModelDB]) -> None:
+                                    model_db_cls: Type[ConceptModelDB], vector_store: str) -> None:
   concept_db = concept_db_cls()
   model_db = model_db_cls(concept_db)
   namespace = 'test'
@@ -195,7 +197,7 @@ def test_concept_model_vector_score(concept_db_cls: Type[ConceptDB],
   model_db.sync(model)
 
   vector_index = make_vector_index(
-    'numpy', {
+    vector_store, {
       ('1',): [EMBEDDING_MAP['in concept']],
       ('2',): [EMBEDDING_MAP['not in concept']],
       ('3',): [EMBEDDING_MAP['a new data point']],
@@ -210,8 +212,9 @@ def test_concept_model_vector_score(concept_db_cls: Type[ConceptDB],
 
 @pytest.mark.parametrize('concept_db_cls', ALL_CONCEPT_DBS)
 @pytest.mark.parametrize('model_db_cls', ALL_CONCEPT_MODEL_DBS)
+@pytest.mark.parametrize('vector_store', ALL_VECTOR_STORES)
 def test_concept_model_topk_score(concept_db_cls: Type[ConceptDB],
-                                  model_db_cls: Type[ConceptModelDB]) -> None:
+                                  model_db_cls: Type[ConceptModelDB], vector_store: str) -> None:
   concept_db = concept_db_cls()
   model_db = model_db_cls(concept_db)
   namespace = 'test'
@@ -231,7 +234,7 @@ def test_concept_model_topk_score(concept_db_cls: Type[ConceptDB],
   model = ConceptModel(
     namespace='test', concept_name='test_concept', embedding_name='test_embedding')
   model_db.sync(model)
-  vector_index = make_vector_index('numpy', {
+  vector_index = make_vector_index(vector_store, {
     ('1',): [[0.1, 0.2, 0.3]],
     ('2',): [[0.1, 0.87, 0.0]],
     ('3',): [[1.0, 0.0, 0.0]],
@@ -258,8 +261,9 @@ def test_concept_model_topk_score(concept_db_cls: Type[ConceptDB],
 
 @pytest.mark.parametrize('concept_db_cls', ALL_CONCEPT_DBS)
 @pytest.mark.parametrize('model_db_cls', ALL_CONCEPT_MODEL_DBS)
-def test_concept_model_draft(concept_db_cls: Type[ConceptDB],
-                             model_db_cls: Type[ConceptModelDB]) -> None:
+@pytest.mark.parametrize('vector_store', ALL_VECTOR_STORES)
+def test_concept_model_draft(concept_db_cls: Type[ConceptDB], model_db_cls: Type[ConceptModelDB],
+                             vector_store: str) -> None:
   concept_db = concept_db_cls()
   model_db = model_db_cls(concept_db)
   namespace = 'test'
@@ -283,7 +287,7 @@ def test_concept_model_draft(concept_db_cls: Type[ConceptDB],
     namespace='test', concept_name='test_concept', embedding_name='test_embedding')
   model_db.sync(model)
 
-  vector_index = make_vector_index('numpy', {
+  vector_index = make_vector_index(vector_store, {
     ('1',): [[1.0, 0.0, 0.0]],
     ('2',): [[0.9, 0.1, 0.0]],
     ('3',): [[0.1, 0.9, 0.0]],
@@ -295,7 +299,7 @@ def test_concept_model_draft(concept_db_cls: Type[ConceptDB],
   assert scores[2][0]['score'] < 0.5
 
   # Make sure the draft signal works. It has different values than the original signal.
-  vector_index = make_vector_index('numpy', {
+  vector_index = make_vector_index(vector_store, {
     ('1',): [[1.0, 0.0, 0.0]],
     ('2',): [[0.9, 0.1, 0.0]],
     ('3',): [[0.1, 0.2, 0.3]],

--- a/lilac/signals/concept_scorer_test.py
+++ b/lilac/signals/concept_scorer_test.py
@@ -20,7 +20,6 @@ from ..concepts.db_concept import (
 from ..data.dataset_duckdb import DatasetDuckDB
 from ..data.dataset_test_utils import TestDataMaker, make_vector_index
 from ..db_manager import set_default_dataset_cls
-from ..embeddings.vector_store_numpy import NumpyVectorStore
 from ..schema import UUID_COLUMN, Item, RichData, SignalInputType, lilac_embedding
 from .concept_scorer import ConceptScoreSignal
 from .signal import TextEmbeddingSignal, clear_signal_registry, register_signal
@@ -196,7 +195,7 @@ def test_concept_model_vector_score(concept_db_cls: Type[ConceptDB],
   model_db.sync(model)
 
   vector_index = make_vector_index(
-    NumpyVectorStore, {
+    'numpy', {
       ('1',): [EMBEDDING_MAP['in concept']],
       ('2',): [EMBEDDING_MAP['not in concept']],
       ('3',): [EMBEDDING_MAP['a new data point']],
@@ -232,7 +231,7 @@ def test_concept_model_topk_score(concept_db_cls: Type[ConceptDB],
   model = ConceptModel(
     namespace='test', concept_name='test_concept', embedding_name='test_embedding')
   model_db.sync(model)
-  vector_index = make_vector_index(NumpyVectorStore, {
+  vector_index = make_vector_index('numpy', {
     ('1',): [[0.1, 0.2, 0.3]],
     ('2',): [[0.1, 0.87, 0.0]],
     ('3',): [[1.0, 0.0, 0.0]],
@@ -284,7 +283,7 @@ def test_concept_model_draft(concept_db_cls: Type[ConceptDB],
     namespace='test', concept_name='test_concept', embedding_name='test_embedding')
   model_db.sync(model)
 
-  vector_index = make_vector_index(NumpyVectorStore, {
+  vector_index = make_vector_index('numpy', {
     ('1',): [[1.0, 0.0, 0.0]],
     ('2',): [[0.9, 0.1, 0.0]],
     ('3',): [[0.1, 0.9, 0.0]],
@@ -296,7 +295,7 @@ def test_concept_model_draft(concept_db_cls: Type[ConceptDB],
   assert scores[2][0]['score'] < 0.5
 
   # Make sure the draft signal works. It has different values than the original signal.
-  vector_index = make_vector_index(NumpyVectorStore, {
+  vector_index = make_vector_index('numpy', {
     ('1',): [[1.0, 0.0, 0.0]],
     ('2',): [[0.9, 0.1, 0.0]],
     ('3',): [[0.1, 0.2, 0.3]],

--- a/lilac/signals/semantic_similarity_test.py
+++ b/lilac/signals/semantic_similarity_test.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from typing_extensions import override
 
 from ..data.dataset_test_utils import make_vector_index
-from ..embeddings.vector_store import VectorStore
+from ..embeddings.vector_store import VectorStore, register_vector_store
 from ..schema import Item, RichData, VectorKey, lilac_embedding, lilac_span
 from .semantic_similarity import SemanticSimilaritySignal
 from .signal import TextEmbeddingSignal, clear_signal_registry, register_signal
@@ -28,6 +28,16 @@ STR_EMBEDDINGS: dict[str, list[float]] = {
 
 class TestVectorStore(VectorStore):
   """A test vector store with fixed embeddings."""
+
+  name = 'test_vector_store'
+
+  @override
+  def load(self, base_path: str) -> None:
+    raise NotImplementedError
+
+  @override
+  def save(self, base_path: str) -> None:
+    raise NotImplementedError
 
   @override
   def keys(self) -> list[VectorKey]:
@@ -59,6 +69,7 @@ class TestEmbedding(TextEmbeddingSignal):
 def setup_teardown() -> Iterable[None]:
   # Setup.
   register_signal(TestEmbedding)
+  register_vector_store(TestVectorStore)
 
   # Unit test runs.
   yield
@@ -68,7 +79,7 @@ def setup_teardown() -> Iterable[None]:
 
 
 def test_semantic_similarity_compute_keys(mocker: MockerFixture) -> None:
-  vector_index = make_vector_index(TestVectorStore, EMBEDDINGS)
+  vector_index = make_vector_index('test_vector_store', EMBEDDINGS)
 
   embed_mock = mocker.spy(TestEmbedding, 'compute')
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -120,3 +120,6 @@ follow_imports = skip
 [mypy-authlib.*]
 ignore_missing_imports = True
 follow_imports = skip
+
+[mypy-hnswlib.*]
+ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -2006,6 +2006,19 @@ files = [
 ]
 
 [[package]]
+name = "hnswlib"
+version = "0.7.0"
+description = "hnswlib"
+optional = false
+python-versions = "*"
+files = [
+    {file = "hnswlib-0.7.0.tar.gz", hash = "sha256:bc459668e7e44bb7454b256b90c98c5af750653919d9a91698dafcf416cf64c4"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[[package]]
 name = "httpcore"
 version = "0.17.3"
 description = "A minimal low-level HTTP client."
@@ -6382,4 +6395,4 @@ text-stats = ["spacy", "textacy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "375d10b056812af5d4bb6b7d102dc05d3a655eae5ce51ea13245f9fc745d5cd9"
+content-hash = "f8913df8bc3a15d933f4cd1ba74211e306934e9612880827b75ac1efa3c80fac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ types-psutil = "^5.9.5.12"
 typing-extensions = "^4.7.1"
 uvicorn = { extras = ["standard"], version = "^0.22.0" }
 click = "^8.1.3"
+hnswlib = "^0.7.0"                                       # Fast KNN vector store.
 
 ### Optional dependencies. ###
 

--- a/web/blueprint/src/lib/components/Navigation.svelte
+++ b/web/blueprint/src/lib/components/Navigation.svelte
@@ -15,9 +15,7 @@
     signalLink
   } from '$lib/utils';
   import {getSortedConcepts, getSortedDatasets} from '$lib/view_utils';
-  import type {SignalInfoWithTypedSchema} from '$lilac';
   import {AddAlt, Settings, SidePanelClose} from 'carbon-icons-svelte';
-  import type {NavigationGroupItem} from './NavigationGroup.svelte';
   import NavigationGroup from './NavigationGroup.svelte';
   import {Command, triggerCommand} from './commands/Commands.svelte';
   import {hoverTooltip} from './common/HoverTooltip';
@@ -33,36 +31,30 @@
   // Datasets.
   const datasets = queryDatasets();
   $: namespaceDatasets = getSortedDatasets($datasets.data || []);
-  let datasetNavGroups: NavigationGroupItem[];
-  $: {
-    datasetNavGroups = namespaceDatasets.map(({namespace, datasets}) => ({
-      group: namespace,
-      items: datasets.map(c => ({
-        name: c.dataset_name,
-        link: datasetLink(c.namespace, c.dataset_name),
-        isSelected:
-          $urlHashContext.page === 'datasets' &&
-          $urlHashContext.identifier === datasetIdentifier(c.namespace, c.dataset_name)
-      }))
-    }));
-  }
+  $: datasetNavGroups = namespaceDatasets.map(({namespace, datasets}) => ({
+    group: namespace,
+    items: datasets.map(c => ({
+      name: c.dataset_name,
+      link: datasetLink(c.namespace, c.dataset_name),
+      isSelected:
+        $urlHashContext.page === 'datasets' &&
+        $urlHashContext.identifier === datasetIdentifier(c.namespace, c.dataset_name)
+    }))
+  }));
 
   // Concepts.
   const concepts = queryConcepts();
   $: namespaceConcepts = getSortedConcepts($concepts.data || [], userId);
-  let conceptNavGroups: NavigationGroupItem[];
-  $: {
-    conceptNavGroups = namespaceConcepts.map(({namespace, concepts}) => ({
-      group: namespace === userId ? `${username}'s concepts` : namespace,
-      items: concepts.map(c => ({
-        name: c.name,
-        link: conceptLink(c.namespace, c.name),
-        isSelected:
-          $urlHashContext.page === 'concepts' &&
-          $urlHashContext.identifier === conceptIdentifier(c.namespace, c.name)
-      }))
-    }));
-  }
+  $: conceptNavGroups = namespaceConcepts.map(({namespace, concepts}) => ({
+    group: namespace === userId ? `${username}'s concepts` : namespace,
+    items: concepts.map(c => ({
+      name: c.name,
+      link: conceptLink(c.namespace, c.name),
+      isSelected:
+        $urlHashContext.page === 'concepts' &&
+        $urlHashContext.identifier === conceptIdentifier(c.namespace, c.name)
+    }))
+  }));
 
   // Signals.
   const signals = querySignals();
@@ -73,27 +65,20 @@
     'near_dup'
   ];
 
-  let sortedSignals: SignalInfoWithTypedSchema[];
-  $: {
-    if ($signals.data != null) {
-      sortedSignals = $signals.data
-        .filter(s => !SIGNAL_EXCLUDE_LIST.includes(s.name))
-        .sort((a, b) => a.name.localeCompare(b.name));
+  $: sortedSignals = $signals.data
+    ?.filter(s => !SIGNAL_EXCLUDE_LIST.includes(s.name))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  $: signalNavGroups = [
+    {
+      group: 'lilac',
+      items: (sortedSignals || []).map(s => ({
+        name: s.name,
+        link: signalLink(s.name),
+        isSelected: $urlHashContext.page === 'signals' && $urlHashContext.identifier === s.name
+      }))
     }
-  }
-  let signalNavGroups: NavigationGroupItem[];
-  $: {
-    signalNavGroups = [
-      {
-        group: 'lilac',
-        items: (sortedSignals || []).map(s => ({
-          name: s.name,
-          link: signalLink(s.name),
-          isSelected: $urlHashContext.page === 'signals' && $urlHashContext.identifier === s.name
-        }))
-      }
-    ];
-  }
+  ];
 
   // Settings.
   $: settingsSelected = $urlHashContext.page === 'settings';
@@ -113,7 +98,7 @@
       >
     </div>
   </div>
-  <NavigationGroup title="Datasets" groups={datasetNavGroups} isFetching={$concepts.isFetching}>
+  <NavigationGroup title="Datasets" groups={datasetNavGroups} isFetching={$datasets.isFetching}>
     <div slot="add" class="w-full">
       {#if canCreateDataset}
         <button
@@ -123,7 +108,7 @@
       {/if}
     </div>
   </NavigationGroup>
-  <NavigationGroup title="Concepts" groups={conceptNavGroups} isFetching={$datasets.isFetching}>
+  <NavigationGroup title="Concepts" groups={conceptNavGroups} isFetching={$concepts.isFetching}>
     <div slot="add" class="w-full">
       <button
         class="mr-1 flex w-full flex-row px-1 py-1 text-black hover:bg-gray-200"

--- a/web/blueprint/src/lib/components/datasetView/RowView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowView.svelte
@@ -40,6 +40,8 @@
 
   $: items = $rows.data?.pages.flatMap(x => x.rows);
 
+  $: console.log(items?.length);
+
   $: visibleFields = ($datasetStore.visibleFields || []).sort((a, b) =>
     serializePath(a.path) > serializePath(b.path) ? 1 : -1
   );

--- a/web/blueprint/src/lib/components/datasetView/RowView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowView.svelte
@@ -40,8 +40,6 @@
 
   $: items = $rows.data?.pages.flatMap(x => x.rows);
 
-  $: console.log(items?.length);
-
   $: visibleFields = ($datasetStore.visibleFields || []).sort((a, b) =>
     serializePath(a.path) > serializePath(b.path) ? 1 : -1
   );

--- a/web/blueprint/src/lib/components/datasetView/RowView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowView.svelte
@@ -8,7 +8,7 @@
   import {getDatasetContext} from '$lib/stores/datasetStore';
   import {getDatasetViewContext, getSelectRowsOptions} from '$lib/stores/datasetViewStore';
   import {ITEM_SCROLL_CONTAINER_CTX_KEY, getMediaFields, getVisibleSchema} from '$lib/view_utils';
-  import {L, UUID_COLUMN, serializePath} from '$lilac';
+  import {serializePath} from '$lilac';
   import {InlineNotification, SkeletonText} from 'carbon-components-svelte';
   import {setContext} from 'svelte';
   import InfiniteScroll from 'svelte-infinite-scroll';
@@ -85,7 +85,7 @@
     class="flex h-full w-full flex-col gap-y-10 overflow-y-scroll px-5 pb-32"
     bind:this={itemScrollContainer}
   >
-    {#each items as row (L.value(row[UUID_COLUMN]))}
+    {#each items as row}
       <RowItem {visibleFields} {row} {mediaFields} />
     {/each}
     {#if items.length > 0}


### PR DESCRIPTION
- Add a registry for vector stores, analogous to signals and sources
- Set the default vector store to `hnsw`.
- Let vector stores write their own index to disk and read from disk (since index creation can take a while)
- Fix the placeholders for the LHS menu. Server slowed down on purpose:

https://github.com/lilacai/lilac/assets/2294279/53a76eed-3e2a-47fe-8417-d035b4f063cd

