### PR TITLE
Make db.select_groups work with python 3.11

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,15 +18,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.11']
     timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
         run: pipx install poetry
-      - uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           cache: 'poetry'
       - name: Install dependencies
         # Re-install pytorch for cpu to avoid errors that cuda was not found

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,3 +1,4 @@
+name: Python lint and test
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-name: Python lint and test
+name: Backend
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -18,6 +18,7 @@ on:
 
 jobs:
   build:
+    name: 'Python lint and test'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,7 @@ jobs:
         run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
           cache: 'poetry'
       - name: Install dependencies
         # Re-install pytorch for cpu to avoid errors that cuda was not found

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,3 +1,4 @@
+name: UI lint and test
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -1,10 +1,11 @@
-name: UI lint and test
+name: UI
 on:
   pull_request:
     types: [opened, reopened, synchronize]
 
 jobs:
   build:
+    name: 'front-end lint and test'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -657,6 +657,8 @@ class DatasetDuckDB(Dataset):
       bins: Optional[Union[Sequence[Bin], Sequence[float]]] = None) -> SelectGroupsResult:
     if not leaf_path:
       raise ValueError('leaf_path must be provided')
+    sort_by = sort_by or GroupsSortBy.COUNT
+    sort_order = sort_order or SortOrder.DESC
     path = normalize_path(leaf_path)
     manifest = self.manifest()
     leaf = manifest.data_schema.get_field(path)

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -705,8 +705,8 @@ class DatasetDuckDB(Dataset):
       if stats.approx_count_distinct >= dataset.TOO_MANY_DISTINCT:
         return SelectGroupsResult(too_many_distinct=True, counts=[], bins=named_bins)
 
-    count_column = 'count'
-    value_column = 'value'
+    count_column = GroupsSortBy.COUNT.value
+    value_column = GroupsSortBy.VALUE.value
 
     limit_query = f'LIMIT {limit}' if limit else ''
     duckdb_path = self._leaf_path_to_duckdb_path(path, manifest.data_schema)
@@ -724,7 +724,7 @@ class DatasetDuckDB(Dataset):
       SELECT {outer_select} AS {value_column}, COUNT() AS {count_column}
       FROM (SELECT {inner_select} AS {inner_val} FROM t {where_query})
       GROUP BY {value_column}
-      ORDER BY {sort_by} {sort_order}
+      ORDER BY {sort_by.value} {sort_order.value}
       {limit_query}
     """
     df = self._query_df(query)

--- a/lilac/schema.py
+++ b/lilac/schema.py
@@ -436,7 +436,7 @@ def _str_field(field: Field, indent: int) -> str:
     return f'{prefix}{_str_fields(field.fields, indent)}'
   if field.repeated_field:
     return f' list({_str_field(field.repeated_field, indent)})'
-  return f' {cast(DataType, field.dtype.value)}'
+  return f' {cast(DataType, field.dtype).value}'
 
 
 def dtype_to_arrow_schema(dtype: DataType) -> Union[pa.Schema, pa.DataType]:

--- a/lilac/schema.py
+++ b/lilac/schema.py
@@ -436,7 +436,7 @@ def _str_field(field: Field, indent: int) -> str:
     return f'{prefix}{_str_fields(field.fields, indent)}'
   if field.repeated_field:
     return f' list({_str_field(field.repeated_field, indent)})'
-  return f' {cast(DataType, field.dtype)}'
+  return f' {cast(DataType, field.dtype.value)}'
 
 
 def dtype_to_arrow_schema(dtype: DataType) -> Union[pa.Schema, pa.DataType]:


### PR DESCRIPTION
Also add 3.11 to the github python workflow. We unfortunately can't use [StrEnum](https://docs.python.org/3/library/enum.html#enum.StrEnum) since it was introduced in 3.11

Thanks @zach-brockway for the find

Fixes https://github.com/lilacai/lilac/issues/602