### PR TITLE
Allow results of tanstack queries to contain non-serializable data

### DIFF
--- a/web/blueprint/src/lib/queries/queryUtils.ts
+++ b/web/blueprint/src/lib/queries/queryUtils.ts
@@ -32,6 +32,7 @@ export function createApiQuery<
     createQuery<TQueryFnData, TError, TData>({
       queryKey: apiQueryKey(tags as string[], endpoint.name, ...args),
       queryFn: () => endpoint(...args),
+      structuralSharing: false,
       ...queryArgs
     });
 }

--- a/web/blueprint/src/lib/queries/queryUtils.ts
+++ b/web/blueprint/src/lib/queries/queryUtils.ts
@@ -32,6 +32,8 @@ export function createApiQuery<
     createQuery<TQueryFnData, TError, TData>({
       queryKey: apiQueryKey(tags as string[], endpoint.name, ...args),
       queryFn: () => endpoint(...args),
+      // Allow the result of the query to contain non-serializable data, such as `LilacField` which
+      // has pointers to parents: https://tanstack.com/query/v4/docs/react/reference/useQuery
       structuralSharing: false,
       ...queryArgs
     });


### PR DESCRIPTION
This fixes the P0 bug and protects us in the future from other query results that have pointers.