### PR TITLE
Update the global project config during changes.

### DIFF
--- a/lilac/config.py
+++ b/lilac/config.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Extra, ValidationError, validator
 
 from .schema import Path, PathTuple, normalize_path
 from .signal import Signal, TextEmbeddingSignal, get_signal_by_type, resolve_signal
-from .sources.source import Source
+from .source import Source
 from .sources.source_registry import resolve_source
 
 CONFIG_FILENAME = 'config.yml'
@@ -228,6 +228,16 @@ class Config(BaseModel):
   def parse_signal(cls, signals: list[dict]) -> list[Signal]:
     """Parse alist of signals to their specific subclass instances."""
     return [resolve_signal(signal) for signal in signals]
+
+
+def get_dataset_config(config: Config, dataset_namespace: str,
+                       dataset_name: str) -> Optional[DatasetConfig]:
+  """Returns the dataset config."""
+  for dataset_config in config.datasets:
+    if dataset_config.namespace == dataset_namespace and dataset_config.name == dataset_name:
+      return dataset_config
+
+  return None
 
 
 def read_config(config_path: str) -> Config:

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -540,7 +540,11 @@ def default_settings(dataset: Dataset) -> DatasetSettings:
 
 
 def dataset_config_from_manifest(manifest: DatasetManifest) -> DatasetConfig:
-  """Computes a DatasetConfig from a manifest. Used for diffing the results to the config."""
+  """Computes a DatasetConfig from a manifest.
+
+  NOTE: This is only used for backwards compatibility. Once we remove the back-compat logic, this
+  method can be removed.
+  """
   all_fields = manifest.data_schema.all_fields
 
   all_signals = [

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -21,13 +21,23 @@ from pydantic import (
 from typing_extensions import TypeAlias
 
 from ..auth import UserInfo
-from ..config import DatasetConfig, DatasetSettings, DatasetUISettings
+from ..config import (
+  DatasetConfig,
+  DatasetSettings,
+  DatasetUISettings,
+  EmbeddingConfig,
+  SignalConfig,
+  get_dataset_config,
+)
+from ..env import data_path
+from ..project import read_project_config, update_project_dataset_settings
 from ..schema import (
   PATH_WILDCARD,
   ROWID,
   VALUE_KEY,
   Bin,
   DataType,
+  ImageInfo,
   Path,
   PathTuple,
   Schema,
@@ -35,6 +45,8 @@ from ..schema import (
 )
 from ..signal import Signal, TextEmbeddingSignal, get_signal_by_type, resolve_signal
 from ..signals.concept_scorer import ConceptSignal
+from ..source import Source
+from ..sources.source_registry import resolve_source
 from ..tasks import TaskStepId
 
 # Threshold for rejecting certain queries (e.g. group by) for columns with large cardinality.
@@ -173,13 +185,41 @@ class Column(BaseModel):
 ColumnId = Union[Path, Column]
 
 
+class NoSource(Source):
+  """A dummy source that is used when no source is defined, for backwards compat."""
+  name = 'no_source'
+
+
+class SourceManifest(BaseModel):
+  """The manifest that describes the dataset run, including schema and parquet files."""
+  # List of a parquet filepaths storing the data. The paths can be relative to `manifest.json`.
+  files: list[str]
+  # The data schema.
+  data_schema: Schema
+  source: Source = NoSource()
+
+  # Image information for the dataset.
+  images: Optional[list[ImageInfo]] = None
+
+  @validator('source', pre=True)
+  def parse_source(cls, source: dict) -> Source:
+    """Parse a source to its specific subclass instance."""
+    return resolve_source(source)
+
+
 class DatasetManifest(BaseModel):
   """The manifest for a dataset."""
   namespace: str
   dataset_name: str
   data_schema: Schema
+  source: Source
   # Number of items in the dataset.
   num_items: int
+
+  @validator('source', pre=True)
+  def parse_source(cls, source: dict) -> Source:
+    """Parse a source to its specific subclass instance."""
+    return resolve_source(source)
 
 
 def column_from_identifier(column: ColumnId) -> Column:
@@ -270,20 +310,25 @@ class Dataset(abc.ABC):
     """Return the manifest for the dataset."""
     pass
 
-  @abc.abstractmethod
   def config(self) -> DatasetConfig:
     """Return the dataset config for this dataset."""
-    pass
+    # This line is only for
 
-  @abc.abstractmethod
+    project_config = read_project_config(data_path())
+    dataset_config = get_dataset_config(project_config, self.namespace, self.dataset_name)
+    if not dataset_config:
+      raise ValueError('Dataset not found in project config.')
+    return dataset_config
+
   def settings(self) -> DatasetSettings:
     """Return the persistent settings for the dataset."""
-    pass
+    settings = self.config().settings
+    assert settings is not None
+    return settings
 
-  @abc.abstractmethod
   def update_settings(self, settings: DatasetSettings) -> None:
-    """Update the settings for the dataset."""
-    pass
+    """Update the persistent settings for the dataset."""
+    update_project_dataset_settings(self.namespace, self.dataset_name, settings)
 
   @abc.abstractmethod
   def compute_signal(self,
@@ -495,6 +540,33 @@ def default_settings(dataset: Dataset) -> DatasetSettings:
     media_paths = [sorted_stats[-1].path]
 
   return DatasetSettings(ui=DatasetUISettings(media_paths=media_paths))
+
+
+def dataset_config_from_manifest(manifest: DatasetManifest) -> DatasetConfig:
+  """Computes a DatasetConfig from a manifest. Used for diffing the results to the config."""
+  all_fields = manifest.data_schema.all_fields
+
+  all_signals = [
+    (path, resolve_signal(field.signal)) for (path, field) in all_fields if field.signal
+  ]
+  signals: list[tuple[PathTuple, Signal]] = []
+  embeddings: list[tuple[PathTuple, TextEmbeddingSignal]] = []
+  for (path, s) in all_signals:
+    source_path = path[0:-1]  # Remove the signal name from the path.
+    if isinstance(s, TextEmbeddingSignal):
+      embeddings.append((source_path, s))
+    else:
+      signals.append((source_path, s))
+
+  return DatasetConfig(
+    namespace=manifest.namespace,
+    name=manifest.dataset_name,
+    source=manifest.source,
+    signals=[SignalConfig(path=path, signal=signal) for path, signal in signals],
+    embeddings=[
+      EmbeddingConfig(path=path, embedding=embedding.name) for path, embedding in embeddings
+    ],
+  )
 
 
 def make_parquet_id(signal: Signal,

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -312,8 +312,6 @@ class Dataset(abc.ABC):
 
   def config(self) -> DatasetConfig:
     """Return the dataset config for this dataset."""
-    # This line is only for
-
     project_config = read_project_config(data_path())
     dataset_config = get_dataset_config(project_config, self.namespace, self.dataset_name)
     if not dataset_config:
@@ -323,8 +321,7 @@ class Dataset(abc.ABC):
   def settings(self) -> DatasetSettings:
     """Return the persistent settings for the dataset."""
     settings = self.config().settings
-    assert settings is not None
-    return settings
+    return settings or DatasetSettings()
 
   def update_settings(self, settings: DatasetSettings) -> None:
     """Update the persistent settings for the dataset."""

--- a/lilac/data/dataset_compute_signal_chain_test.py
+++ b/lilac/data/dataset_compute_signal_chain_test.py
@@ -30,7 +30,13 @@ from ..signal import (
   register_signal,
 )
 from .dataset import DatasetManifest
-from .dataset_test_utils import TEST_DATASET_NAME, TEST_NAMESPACE, TestDataMaker, enriched_item
+from .dataset_test_utils import (
+  TEST_DATASET_NAME,
+  TEST_NAMESPACE,
+  TestDataMaker,
+  TestSource,
+  enriched_item,
+)
 
 SIMPLE_ITEMS: list[Item] = [{
   'str': 'a',
@@ -139,7 +145,8 @@ def test_manual_embedding_signal(make_test_data: TestDataMaker, mocker: MockerFi
             fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})]),
         }),
     }),
-    num_items=2)
+    num_items=2,
+    source=TestSource())
 
   result = dataset.select_rows(combine_columns=True)
   expected_result = [{

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -28,7 +28,13 @@ from ..signal import (
 )
 from ..signals.concept_scorer import ConceptSignal
 from .dataset import Column, DatasetManifest, GroupsSortBy, SortOrder
-from .dataset_test_utils import TEST_DATASET_NAME, TEST_NAMESPACE, TestDataMaker, enriched_item
+from .dataset_test_utils import (
+  TEST_DATASET_NAME,
+  TEST_NAMESPACE,
+  TestDataMaker,
+  TestSource,
+  enriched_item,
+)
 
 SIMPLE_ITEMS: list[Item] = [{
   'str': 'a',
@@ -258,7 +264,8 @@ def test_source_joined_with_signal(make_test_data: TestDataMaker) -> None:
       'bool': 'boolean',
       'float': 'float32',
     }),
-    num_items=3)
+    num_items=3,
+    source=TestSource())
 
   test_signal = TestSignal()
   dataset.compute_signal(test_signal, 'str')
@@ -281,7 +288,8 @@ def test_source_joined_with_signal(make_test_data: TestDataMaker) -> None:
       'bool': 'boolean',
       'float': 'float32',
     }),
-    num_items=3)
+    num_items=3,
+    source=TestSource())
 
   result = dataset.select_rows(['str'], combine_columns=True)
   assert list(result) == [{
@@ -355,7 +363,8 @@ def test_parameterized_signal(make_test_data: TestDataMaker) -> None:
           'param_signal(param=b)': field('string', test_signal_b.dict()),
         }),
     }),
-    num_items=2)
+    num_items=2,
+    source=TestSource())
 
   result = dataset.select_rows(['text'], combine_columns=True)
   assert list(result) == [{
@@ -388,7 +397,8 @@ def test_split_signal(make_test_data: TestDataMaker) -> None:
       'text': field(
         'string', fields={'test_split': field(signal=signal.dict(), fields=[field('string_span')])})
     }),
-    num_items=2)
+    num_items=2,
+    source=TestSource())
 
   result = dataset.select_rows(['text'], combine_columns=True)
   expected_result = [{
@@ -431,7 +441,8 @@ def test_signal_on_repeated_field(make_test_data: TestDataMaker) -> None:
           })
       ])
     }),
-    num_items=2)
+    num_items=2,
+    source=TestSource())
 
   result = dataset.select_rows([('text', '*')], combine_columns=True)
 
@@ -504,7 +515,8 @@ def test_embedding_signal(make_test_data: TestDataMaker) -> None:
             fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})])
         }),
     }),
-    num_items=2)
+    num_items=2,
+    source=TestSource())
 
   result = dataset.select_rows(combine_columns=True)
   expected_result = [{'text': 'hello.'}, {'text': 'hello2.'}]
@@ -523,7 +535,8 @@ def test_is_computed_signal_key(make_test_data: TestDataMaker) -> None:
     data_schema=schema({
       'text': field('string', fields={'key_True': field('int64', signal=signal.dict())}),
     }),
-    num_items=2)
+    num_items=2,
+    source=TestSource())
 
   result = dataset.select_rows(combine_columns=True)
 

--- a/lilac/data/dataset_config_test.py
+++ b/lilac/data/dataset_config_test.py
@@ -169,7 +169,7 @@ def test_config_compute_embedding(make_test_data: TestDataMaker) -> None:
       path=('text',),
       embedding='test_embedding',
     )],
-    settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('text',)]))).dict()
+    settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('text',)])))
 
   # Computing another embedding should add another config.
   dataset.compute_embedding('test_embedding2', 'text')

--- a/lilac/data/dataset_project_test.py
+++ b/lilac/data/dataset_project_test.py
@@ -1,0 +1,203 @@
+"""Implementation-agnostic tests of the Dataset DB API working with projects."""
+
+from pathlib import Path
+from typing import Iterable, Optional, cast
+
+import numpy as np
+import pytest
+from typing_extensions import override
+
+from ..config import (
+  Config,
+  DatasetConfig,
+  DatasetSettings,
+  DatasetUISettings,
+  EmbeddingConfig,
+  SignalConfig,
+)
+from ..data_loader import create_dataset
+from ..db_manager import get_dataset
+from ..env import data_path
+from ..project import create_project_and_set_env, read_project_config
+from ..schema import Field, Item, RichData, field, lilac_embedding
+from ..signal import TextEmbeddingSignal, TextSignal, clear_signal_registry, register_signal
+from ..source import Source, SourceSchema
+from ..sources.source_registry import clear_source_registry, register_source
+
+SIMPLE_ITEMS: list[Item] = [{
+  'str': 'a',
+  'int': 1,
+  'bool': False,
+  'float': 3.0
+}, {
+  'str': 'b',
+  'int': 2,
+  'bool': True,
+  'float': 2.0
+}, {
+  'str': 'c',
+  'int': 3,
+  'bool': True,
+  'float': 1.0
+}]
+
+EMBEDDINGS: list[tuple[str, list[float]]] = [('a', [1.0, 0.0, 0.0]), ('b', [1.0, 1.0, 0.0]),
+                                             ('c', [1.0, 1.0, 0.0])]
+
+STR_EMBEDDINGS: dict[str, list[float]] = {text: embedding for text, embedding in EMBEDDINGS}
+
+
+class TestSource(Source):
+  """A test source."""
+  name = 'test_source'
+
+  @override
+  def source_schema(self) -> SourceSchema:
+    """Yield all items."""
+    return SourceSchema(
+      fields={
+        'str': field('string'),
+        'int': field('int32'),
+        'bool': field('boolean'),
+        'float': field('float32')
+      },
+      num_items=len(SIMPLE_ITEMS))
+
+  @override
+  def process(self) -> Iterable[Item]:
+    """Yield all items."""
+    yield from SIMPLE_ITEMS
+
+
+class TestEmbedding(TextEmbeddingSignal):
+  """A test embed function."""
+  name = 'test_embedding'
+
+  @override
+  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+    """Call the embedding function."""
+    for example in data:
+      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+
+
+class TestSignal(TextSignal):
+  name = 'test_signal'
+
+  _call_count: int = 0
+
+  def fields(self) -> Field:
+    return field('int32')
+
+  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+    for text_content in data:
+      self._call_count += 1
+      yield len(text_content)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_teardown() -> Iterable[None]:
+  # Setup.
+  register_source(TestSource)
+  register_signal(TestSignal)
+  register_signal(TestEmbedding)
+
+  # Unit test runs.
+  yield
+
+  # Teardown.
+  clear_source_registry()
+  clear_signal_registry()
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_data_dir(tmp_path: Path) -> None:
+  create_project_and_set_env(str(tmp_path))
+
+  dataset_config = DatasetConfig(namespace='namespace', name='test', source=TestSource())
+  create_dataset(dataset_config)
+
+
+def test_load_dataset_updates_project() -> None:
+  config = read_project_config(data_path())
+
+  assert config == Config(datasets=[
+    DatasetConfig(
+      namespace='namespace',
+      name='test',
+      source=TestSource(),
+      # Settings are automatically computed when not provided.
+      settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('str',)], markdown_paths=[])))
+  ])
+
+
+def test_delete_dataset_updates_project() -> None:
+  config = read_project_config(data_path())
+
+  # TODO: nsthorat do this.
+  pass
+
+
+def test_compute_signal_updates_project() -> None:
+  dataset = get_dataset('namespace', 'test')
+  dataset.compute_signal(TestSignal(), path='str')
+
+  config = read_project_config(data_path())
+
+  assert config == Config(datasets=[
+    DatasetConfig(
+      namespace='namespace',
+      name='test',
+      source=TestSource(),
+      # Settings are automatically computed when not provided.
+      settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('str',)], markdown_paths=[])),
+      signals=[SignalConfig(path=('str',), signal=TestSignal())])
+  ])
+
+
+def test_delete_signal_updates_project() -> None:
+  dataset = get_dataset('namespace', 'test')
+  dataset.compute_signal(TestSignal(), path='str')
+
+  config = read_project_config(data_path())
+
+  assert config == Config(datasets=[
+    DatasetConfig(
+      namespace='namespace',
+      name='test',
+      source=TestSource(),
+      # Settings are automatically computed when not provided.
+      settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('str',)], markdown_paths=[])),
+      signals=[SignalConfig(path=('str',), signal=TestSignal())])
+  ])
+
+  dataset.delete_signal(signal_path=('str', TestSignal.name))
+
+  config = read_project_config(data_path())
+
+  assert config == Config(datasets=[
+    DatasetConfig(
+      namespace='namespace',
+      name='test',
+      source=TestSource(),
+      # Settings are automatically computed when not provided.
+      settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('str',)], markdown_paths=[])),
+      # Signals should be deleted.
+      signals=[])
+  ])
+
+
+def test_compute_embedding_updates_project() -> None:
+  dataset = get_dataset('namespace', 'test')
+  dataset.compute_embedding('test_embedding', path='str')
+
+  config = read_project_config(data_path())
+
+  assert config == Config(datasets=[
+    DatasetConfig(
+      namespace='namespace',
+      name='test',
+      source=TestSource(),
+      # Settings are automatically computed when not provided.
+      settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('str',)], markdown_paths=[])),
+      embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding')])
+  ])

--- a/lilac/data/dataset_test_utils.py
+++ b/lilac/data/dataset_test_utils.py
@@ -9,6 +9,7 @@ from typing_extensions import Protocol
 
 from ..config import CONFIG_FILENAME, DatasetConfig
 from ..embeddings.vector_store import VectorDBIndex
+from ..project import add_project_dataset_config, create_project
 from ..schema import (
   MANIFEST_FILENAME,
   PARQUET_FILENAME_PREFIX,
@@ -17,12 +18,11 @@ from ..schema import (
   Item,
   PathKey,
   Schema,
-  SourceManifest,
   infer_schema,
 )
-from ..sources.source import Source
+from ..source import Source
 from ..utils import get_dataset_output_dir, open_file, to_yaml
-from .dataset import Dataset, default_settings
+from .dataset import Dataset, SourceManifest, default_settings
 from .dataset_utils import write_items_to_parquet
 
 TEST_NAMESPACE = 'test_namespace'
@@ -49,6 +49,7 @@ def make_dataset(dataset_cls: Type[Dataset],
   """Create a test dataset."""
   schema = schema or infer_schema(items)
   _write_items(tmp_path, TEST_DATASET_NAME, items, schema)
+  create_project(str(tmp_path))
   dataset = dataset_cls(TEST_NAMESPACE, TEST_DATASET_NAME)
 
   config = DatasetConfig(
@@ -56,6 +57,7 @@ def make_dataset(dataset_cls: Type[Dataset],
     name=TEST_DATASET_NAME,
     source=TestSource(),
     settings=default_settings(dataset))
+  add_project_dataset_config(config)
   config_filepath = os.path.join(
     get_dataset_output_dir(str(tmp_path), TEST_NAMESPACE, TEST_DATASET_NAME), CONFIG_FILENAME)
   with open_file(config_filepath, 'w') as f:
@@ -77,7 +79,7 @@ def _write_items(tmpdir: pathlib.Path, dataset_name: str, items: list[Item],
 
   simple_parquet_files, _ = write_items_to_parquet(
     items, source_dir, schema, filename_prefix=PARQUET_FILENAME_PREFIX, shard_index=0, num_shards=1)
-  manifest = SourceManifest(files=[simple_parquet_files], data_schema=schema)
+  manifest = SourceManifest(files=[simple_parquet_files], data_schema=schema, source=TestSource())
   with open_file(os.path.join(source_dir, MANIFEST_FILENAME), 'w') as f:
     f.write(manifest.json(indent=2, exclude_none=True))
 

--- a/lilac/data_loader_test.py
+++ b/lilac/data_loader_test.py
@@ -10,11 +10,12 @@ from pytest_mock import MockerFixture
 from typing_extensions import override
 
 from .config import CONFIG_FILENAME, DatasetConfig, DatasetSettings, DatasetUISettings
+from .data.dataset import SourceManifest
 from .data.dataset_duckdb import read_source_manifest
 from .data.dataset_utils import parquet_filename
 from .data_loader import process_source
-from .schema import PARQUET_FILENAME_PREFIX, ROWID, Item, SourceManifest, schema
-from .sources.source import Source, SourceSchema
+from .schema import PARQUET_FILENAME_PREFIX, ROWID, Item, schema
+from .source import Source, SourceSchema
 from .test_utils import fake_uuid, read_items
 from .utils import DATASETS_DIR_NAME
 
@@ -62,7 +63,7 @@ def test_data_loader(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
       'x': 'int64',
       'y': 'string'
     }),
-  )
+    source=source)
 
   items = read_items(output_dir, source_manifest.files, source_manifest.data_schema)
 

--- a/lilac/data_loader_test.py
+++ b/lilac/data_loader_test.py
@@ -5,15 +5,15 @@ import pathlib
 import uuid
 from typing import Iterable
 
-import yaml
 from pytest_mock import MockerFixture
 from typing_extensions import override
 
-from .config import CONFIG_FILENAME, DatasetConfig, DatasetSettings, DatasetUISettings
+from .config import Config, DatasetConfig, DatasetSettings, DatasetUISettings
 from .data.dataset import SourceManifest
 from .data.dataset_duckdb import read_source_manifest
 from .data.dataset_utils import parquet_filename
 from .data_loader import process_source
+from .project import read_project_config
 from .schema import PARQUET_FILENAME_PREFIX, ROWID, Item, schema
 from .source import Source, SourceSchema
 from .test_utils import fake_uuid, read_items
@@ -77,16 +77,12 @@ def test_data_loader(tmp_path: pathlib.Path, mocker: MockerFixture) -> None:
     'y': 'twenty'
   }]
 
-  # Make sure the config yml file was written.
-  config_filepath = os.path.join(output_dir, CONFIG_FILENAME)
-  assert os.path.exists(config_filepath)
-
-  with open(config_filepath) as f:
-    config = DatasetConfig(**yaml.safe_load(f))
-
-  assert config.dict() == DatasetConfig(
-    namespace='test_namespace',
-    name='test_dataset',
-    source=source,
-    # 'y' is the longest path, so should be set as the default setting.
-    settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('y',)]))).dict()
+  project_config = read_project_config(str(tmp_path))
+  assert project_config == Config(datasets=[
+    DatasetConfig(
+      namespace='test_namespace',
+      name='test_dataset',
+      source=source,
+      # 'y' is the longest path, so should be set as the default setting.
+      settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('y',)])))
+  ])

--- a/lilac/load.py
+++ b/lilac/load.py
@@ -22,7 +22,7 @@ from .data.dataset_duckdb import DatasetDuckDB
 from .data_loader import process_source
 from .db_manager import get_dataset, list_datasets, remove_dataset_from_cache
 from .schema import ROWID, PathTuple
-from .tasks import TaskManager, TaskStepId, TaskType, get_task_manager
+from .tasks import TaskManager, TaskStepId, TaskType
 from .utils import DebugTimer, get_datasets_dir
 
 
@@ -64,8 +64,6 @@ def load(output_dir: str,
 
   # Use threads instead of processes to avoid running out of RAM.
   if not task_manager:
-    task_manager = get_task_manager()
-  else:
     # Explicitly create a dask client in sync mode.
     total_memory_gb = psutil.virtual_memory().total / (1024**3) * 2 / 3
     task_manager = TaskManager(Client(memory_limit=f'{total_memory_gb} GB', processes=False))

--- a/lilac/project.py
+++ b/lilac/project.py
@@ -20,7 +20,7 @@ PROJECT_CONFIG_LOCK = threading.Lock()
 
 
 def add_project_dataset_config(dataset_config: DatasetConfig) -> None:
-  """Add a dataset signal to the project config."""
+  """Add a dataset to the project config."""
   with PROJECT_CONFIG_LOCK:
     config = read_project_config(data_path())
     existing_dataset_config = get_dataset_config(config, dataset_config.namespace,
@@ -33,7 +33,7 @@ def add_project_dataset_config(dataset_config: DatasetConfig) -> None:
 
 
 def delete_project_dataset_config(namespace: str, dataset_name: str) -> None:
-  """Add a dataset signal to the project config."""
+  """Delete a dataset config in a project."""
   with PROJECT_CONFIG_LOCK:
     config = read_project_config(data_path())
     dataset_config = get_dataset_config(config, namespace, dataset_name)
@@ -46,7 +46,7 @@ def delete_project_dataset_config(namespace: str, dataset_name: str) -> None:
 
 def update_project_dataset_settings(dataset_namespace: str, dataset_name: str,
                                     settings: DatasetSettings) -> None:
-  """Add a dataset signal to the project config."""
+  """Update the settings of a dataset config in a project."""
   with PROJECT_CONFIG_LOCK:
     config = read_project_config(data_path())
     dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)
@@ -72,7 +72,7 @@ def add_project_signal_config(dataset_namespace: str, dataset_name: str,
 
 def add_project_embedding_config(dataset_namespace: str, dataset_name: str,
                                  embedding_config: EmbeddingConfig) -> None:
-  """Add a dataset signal to the project config."""
+  """Add a dataset embedding to the project config."""
   with PROJECT_CONFIG_LOCK:
     config = read_project_config(data_path())
     dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)
@@ -88,7 +88,7 @@ def add_project_embedding_config(dataset_namespace: str, dataset_name: str,
 
 def delete_project_signal_config(dataset_namespace: str, dataset_name: str,
                                  signal_config: SignalConfig) -> None:
-  """Add a dataset signal to the project config."""
+  """Delete a dataset signal from the project config."""
   with PROJECT_CONFIG_LOCK:
     config = read_project_config(data_path())
     dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)

--- a/lilac/project.py
+++ b/lilac/project.py
@@ -133,7 +133,10 @@ def read_project_config(project_path: str) -> Config:
 def _write_project_config(project_path: str, config: Config) -> None:
   """Writes the project config."""
   with open(os.path.join(project_path, PROJECT_CONFIG_FILENAME), 'w') as f:
-    f.write(to_yaml(config.dict(exclude_defaults=True, exclude_none=True)))
+    yaml_config = to_yaml(config.dict(exclude_defaults=True, exclude_none=True))
+    f.write('# Lilac project config.\n' +
+            '# See https://lilacml.com/api_reference/index.html#lilac.Config '
+            'for details.\n\n' + yaml_config)
 
 
 def create_project(project_path: str) -> None:
@@ -142,11 +145,7 @@ def create_project(project_path: str) -> None:
     if not os.path.isdir(project_path):
       os.makedirs(project_path)
 
-    with open(os.path.join(project_path, PROJECT_CONFIG_FILENAME), 'w') as f:
-      f.write(
-        '# Lilac project config. See https://lilacml.com/api_reference/index.html#lilac.Config '
-        'for details.\n\n' +
-        to_yaml(Config(datasets=[]).dict(exclude_defaults=True, exclude_none=True)))
+    _write_project_config(project_path, Config(datasets=[]))
 
 
 def create_project_and_set_env(project_path_arg: str) -> None:

--- a/lilac/project.py
+++ b/lilac/project.py
@@ -79,7 +79,7 @@ def add_project_embedding_config(dataset_namespace: str, dataset_name: str,
     if dataset_config is None:
       raise ValueError('Dataset not found in project config.')
 
-    if embedding_config in dataset_config.signals:
+    if embedding_config in dataset_config.embeddings:
       return
 
     dataset_config.embeddings.append(embedding_config)

--- a/lilac/project.py
+++ b/lilac/project.py
@@ -1,11 +1,104 @@
 """Project utilities."""
 import os
+import threading
 
-from .config import Config
-from .env import env
+import yaml
+
+from .config import (
+  Config,
+  DatasetConfig,
+  DatasetSettings,
+  EmbeddingConfig,
+  SignalConfig,
+  get_dataset_config,
+)
+from .env import data_path, env
 from .utils import to_yaml
 
 PROJECT_CONFIG_FILENAME = 'lilac.yml'
+PROJECT_CONFIG_LOCK = threading.Lock()
+
+
+def add_project_dataset_config(dataset_config: DatasetConfig) -> None:
+  """Add a dataset signal to the project config."""
+  with PROJECT_CONFIG_LOCK:
+    config = read_project_config(data_path())
+    existing_dataset_config = get_dataset_config(config, dataset_config.namespace,
+                                                 dataset_config.name)
+    if existing_dataset_config is not None:
+      raise ValueError(f'{dataset_config} has already been added.')
+
+    config.datasets.append(dataset_config)
+    _write_project_config(data_path(), config)
+
+
+def delete_project_dataset_config(namespace: str, dataset_name: str) -> None:
+  """Add a dataset signal to the project config."""
+  with PROJECT_CONFIG_LOCK:
+    config = read_project_config(data_path())
+    dataset_config = get_dataset_config(config, namespace, dataset_name)
+    if dataset_config is None:
+      raise ValueError(f'{dataset_config} not found in project config.')
+
+    config.datasets.remove(dataset_config)
+    _write_project_config(data_path(), config)
+
+
+def update_project_dataset_settings(dataset_namespace: str, dataset_name: str,
+                                    settings: DatasetSettings) -> None:
+  """Add a dataset signal to the project config."""
+  with PROJECT_CONFIG_LOCK:
+    config = read_project_config(data_path())
+    dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)
+    if dataset_config is None:
+      raise ValueError('Dataset not found in project config.')
+    dataset_config.settings = settings
+    _write_project_config(data_path(), config)
+
+
+def add_project_signal_config(dataset_namespace: str, dataset_name: str,
+                              signal_config: SignalConfig) -> None:
+  """Add a dataset signal to the project config."""
+  with PROJECT_CONFIG_LOCK:
+    config = read_project_config(data_path())
+    dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)
+    if dataset_config is None:
+      raise ValueError('Dataset not found in project config.')
+    if signal_config in dataset_config.signals:
+      return
+    dataset_config.signals.append(signal_config)
+    _write_project_config(data_path(), config)
+
+
+def add_project_embedding_config(dataset_namespace: str, dataset_name: str,
+                                 embedding_config: EmbeddingConfig) -> None:
+  """Add a dataset signal to the project config."""
+  with PROJECT_CONFIG_LOCK:
+    config = read_project_config(data_path())
+    dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)
+    if dataset_config is None:
+      raise ValueError('Dataset not found in project config.')
+
+    if embedding_config in dataset_config.signals:
+      return
+
+    dataset_config.embeddings.append(embedding_config)
+    _write_project_config(data_path(), config)
+
+
+def delete_project_signal_config(dataset_namespace: str, dataset_name: str,
+                                 signal_config: SignalConfig) -> None:
+  """Add a dataset signal to the project config."""
+  with PROJECT_CONFIG_LOCK:
+    config = read_project_config(data_path())
+    dataset_config = get_dataset_config(config, dataset_namespace, dataset_name)
+    if dataset_config is None:
+      raise ValueError(f'{dataset_config} not found in project config.')
+    if signal_config not in dataset_config.signals:
+      raise ValueError(f'{signal_config} not found in project config.')
+
+    dataset_config.signals.remove(signal_config)
+    _write_project_config(data_path(), config)
 
 
 def project_path_from_args(project_path_arg: str) -> str:
@@ -27,21 +120,38 @@ def dir_is_project(project_path: str) -> bool:
   return os.path.exists(os.path.join(project_path, PROJECT_CONFIG_FILENAME))
 
 
-def create_project(project_path: str) -> None:
-  """Creates an empty lilac project."""
+def read_project_config(project_path: str) -> Config:
+  """Reads the project config."""
+  project_config_filepath = os.path.join(project_path, PROJECT_CONFIG_FILENAME)
+  if not os.path.exists(project_config_filepath):
+    create_project(project_path)
+
+  with open(os.path.join(project_path, PROJECT_CONFIG_FILENAME), 'r') as f:
+    return Config(**yaml.safe_load(f.read()))
+
+
+def _write_project_config(project_path: str, config: Config) -> None:
+  """Writes the project config."""
   with open(os.path.join(project_path, PROJECT_CONFIG_FILENAME), 'w') as f:
-    f.write('# Lilac project config. See https://lilacml.com/api_reference/index.html#lilac.Config '
-            'for details.\n\n' +
-            to_yaml(Config(datasets=[]).dict(exclude_defaults=True, exclude_none=True)))
+    f.write(to_yaml(config.dict(exclude_defaults=True, exclude_none=True)))
+
+
+def create_project(project_path: str) -> None:
+  """Creates an empty lilac project if it's not already a project."""
+  if not dir_is_project(project_path):
+    if not os.path.isdir(project_path):
+      os.makedirs(project_path)
+
+    with open(os.path.join(project_path, PROJECT_CONFIG_FILENAME), 'w') as f:
+      f.write(
+        '# Lilac project config. See https://lilacml.com/api_reference/index.html#lilac.Config '
+        'for details.\n\n' +
+        to_yaml(Config(datasets=[]).dict(exclude_defaults=True, exclude_none=True)))
 
 
 def create_project_and_set_env(project_path_arg: str) -> None:
   """Creates a Lilac project if it doesn't exist and set the environment variable."""
   project_path = project_path_from_args(project_path_arg)
-  if not dir_is_project(project_path):
-    if not os.path.isdir(project_path):
-      os.makedirs(project_path)
-
-    create_project(project_path)
+  create_project(project_path)
 
   os.environ['LILAC_DATA_PATH'] = project_path

--- a/lilac/project_test.py
+++ b/lilac/project_test.py
@@ -1,15 +1,11 @@
 """Tests for server.py."""
 
 import os
-from typing import Iterable
 
 import pytest
-from typing_extensions import override
 
-from ..source import Source, SourceSchema
 from .env import data_path
 from .project import PROJECT_CONFIG_FILENAME, create_project_and_set_env
-from .schema import Item, schema
 
 
 async def test_create_project_and_set_env(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -33,21 +29,3 @@ async def test_create_project_and_set_env_from_env(
 
   assert os.path.exists(os.path.join(tmp_path, PROJECT_CONFIG_FILENAME))
   assert data_path() == tmp_path
-
-
-class TestSource(Source):
-  """A test source."""
-  name = 'test_source'
-
-  @override
-  def setup(self) -> None:
-    pass
-
-  @override
-  def source_schema(self) -> SourceSchema:
-    """Return the source schema."""
-    return SourceSchema(fields=schema({'x': 'int64', 'y': 'string'}).fields, num_items=2)
-
-  @override
-  def process(self) -> Iterable[Item]:
-    return [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}]

--- a/lilac/project_test.py
+++ b/lilac/project_test.py
@@ -1,11 +1,15 @@
 """Tests for server.py."""
 
 import os
+from typing import Iterable
 
 import pytest
+from typing_extensions import override
 
+from ..source import Source, SourceSchema
 from .env import data_path
 from .project import PROJECT_CONFIG_FILENAME, create_project_and_set_env
+from .schema import Item, schema
 
 
 async def test_create_project_and_set_env(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -29,3 +33,21 @@ async def test_create_project_and_set_env_from_env(
 
   assert os.path.exists(os.path.join(tmp_path, PROJECT_CONFIG_FILENAME))
   assert data_path() == tmp_path
+
+
+class TestSource(Source):
+  """A test source."""
+  name = 'test_source'
+
+  @override
+  def setup(self) -> None:
+    pass
+
+  @override
+  def source_schema(self) -> SourceSchema:
+    """Return the source schema."""
+    return SourceSchema(fields=schema({'x': 'int64', 'y': 'string'}).fields, num_items=2)
+
+  @override
+  def process(self) -> Iterable[Item]:
+    return [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}]

--- a/lilac/schema.py
+++ b/lilac/schema.py
@@ -395,6 +395,11 @@ def column_paths_match(path_match: Path, specific_path: Path) -> bool:
   return True
 
 
+class ImageInfo(BaseModel):
+  """Info about an individual image."""
+  path: Path
+
+
 def normalize_path(path: Path) -> PathTuple:
   """Normalizes a dot seperated path, but ignores dots inside quotes, like regular SQL.
 
@@ -406,22 +411,6 @@ def normalize_path(path: Path) -> PathTuple:
   if isinstance(path, str):
     return tuple(next(csv.reader(io.StringIO(path), delimiter='.')))
   return path
-
-
-class ImageInfo(BaseModel):
-  """Info about an individual image."""
-  path: Path
-
-
-class SourceManifest(BaseModel):
-  """The manifest that describes the dataset run, including schema and parquet files."""
-  # List of a parquet filepaths storing the data. The paths can be relative to `manifest.json`.
-  files: list[str]
-  # The data schema.
-  data_schema: Schema
-
-  # Image information for the dataset.
-  images: Optional[list[ImageInfo]] = None
 
 
 def _str_fields(fields: dict[str, Field], indent: int) -> str:

--- a/lilac/server_dataset_test.py
+++ b/lilac/server_dataset_test.py
@@ -9,7 +9,13 @@ from pytest_mock import MockerFixture
 from .config import DatasetSettings
 from .data.dataset import Dataset, DatasetManifest, SelectRowsSchemaResult, SelectRowsSchemaUDF
 from .data.dataset_duckdb import DatasetDuckDB
-from .data.dataset_test_utils import TEST_DATASET_NAME, TEST_NAMESPACE, enriched_item, make_dataset
+from .data.dataset_test_utils import (
+  TEST_DATASET_NAME,
+  TEST_NAMESPACE,
+  TestSource,
+  enriched_item,
+  make_dataset,
+)
 from .router_dataset import (
   Column,
   ComputeSignalOptions,
@@ -105,7 +111,8 @@ def test_get_manifest() -> None:
           }]
         }]
       }),
-      num_items=3))
+      num_items=3,
+      source=TestSource()))
 
 
 def test_select_rows_no_options() -> None:

--- a/lilac/source.py
+++ b/lilac/source.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 if TYPE_CHECKING:
   from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
-from ..schema import (
+from .schema import (
   Field,
   ImageInfo,
   Item,

--- a/lilac/sources/csv_source.py
+++ b/lilac/sources/csv_source.py
@@ -7,9 +7,9 @@ from pydantic import Field
 from typing_extensions import override
 
 from ..schema import Item
+from ..source import Source, SourceSchema, schema_from_df
 from ..utils import download_http_files
 from .duckdb_utils import duckdb_setup
-from .source import Source, SourceSchema, schema_from_df
 
 LINE_NUMBER_COLUMN = '__line_number__'
 

--- a/lilac/sources/csv_source_test.py
+++ b/lilac/sources/csv_source_test.py
@@ -4,8 +4,8 @@ import os
 import pathlib
 
 from ..schema import schema
+from ..source import SourceSchema
 from .csv_source import LINE_NUMBER_COLUMN, CSVSource
-from .source import SourceSchema
 
 
 def test_csv(tmp_path: pathlib.Path) -> None:

--- a/lilac/sources/gmail_source.py
+++ b/lilac/sources/gmail_source.py
@@ -13,8 +13,8 @@ from typing_extensions import override
 
 from ..env import data_path
 from ..schema import Item, field
+from ..source import Source, SourceSchema
 from ..utils import log
-from .source import Source, SourceSchema
 
 if TYPE_CHECKING:
   from google.oauth2.credentials import Credentials

--- a/lilac/sources/huggingface_source.py
+++ b/lilac/sources/huggingface_source.py
@@ -18,8 +18,8 @@ from pydantic import Field as PydanticField
 from typing_extensions import override
 
 from ..schema import DataType, Field, Item, arrow_dtype_to_dtype
+from ..source import Source, SourceSchema
 from ..utils import log
-from .source import Source, SourceSchema
 
 HF_SPLIT_COLUMN = '__hfsplit__'
 

--- a/lilac/sources/huggingface_source_test.py
+++ b/lilac/sources/huggingface_source_test.py
@@ -6,8 +6,8 @@ import pathlib
 from datasets import Dataset, Features, Sequence, Value
 
 from ..schema import schema
+from ..source import SourceSchema
 from .huggingface_source import HF_SPLIT_COLUMN, HuggingFaceSource
-from .source import SourceSchema
 
 
 def test_hf(tmp_path: pathlib.Path) -> None:

--- a/lilac/sources/json_source.py
+++ b/lilac/sources/json_source.py
@@ -7,9 +7,9 @@ from pydantic import Field as PydanticField
 from typing_extensions import override
 
 from ..schema import Item
+from ..source import Source, SourceSchema, schema_from_df
 from ..utils import download_http_files
 from .duckdb_utils import duckdb_setup
-from .source import Source, SourceSchema, schema_from_df
 
 ROW_ID_COLUMN = '__row_id__'
 

--- a/lilac/sources/json_source_test.py
+++ b/lilac/sources/json_source_test.py
@@ -4,8 +4,8 @@ import os
 import pathlib
 
 from ..schema import schema
+from ..source import SourceSchema
 from .json_source import ROW_ID_COLUMN, JSONSource
-from .source import SourceSchema
 
 
 def test_simple_json(tmp_path: pathlib.Path) -> None:

--- a/lilac/sources/langsmith.py
+++ b/lilac/sources/langsmith.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 
 from ..env import env
 from ..schema import Item, infer_schema
-from .source import Source, SourceSchema
+from ..source import Source, SourceSchema
 
 router = APIRouter()
 

--- a/lilac/sources/pandas_source.py
+++ b/lilac/sources/pandas_source.py
@@ -5,7 +5,7 @@ import pandas as pd
 from typing_extensions import override
 
 from ..schema import Item
-from .source import Source, SourceSchema, schema_from_df
+from ..source import Source, SourceSchema, schema_from_df
 
 PANDAS_INDEX_COLUMN = '__pd_index__'
 

--- a/lilac/sources/pandas_source_test.py
+++ b/lilac/sources/pandas_source_test.py
@@ -3,8 +3,8 @@
 import pandas as pd
 
 from ..schema import schema
+from ..source import SourceSchema
 from .pandas_source import PANDAS_INDEX_COLUMN, PandasSource
-from .source import SourceSchema
 
 
 def test_simple_dataframe() -> None:

--- a/lilac/sources/parquet_source.py
+++ b/lilac/sources/parquet_source.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from typing_extensions import override
 
 from ..schema import Item, arrow_schema_to_schema
-from .source import Source, SourceSchema
+from ..source import Source, SourceSchema
 
 
 class ParquetSource(Source):

--- a/lilac/sources/parquet_source_test.py
+++ b/lilac/sources/parquet_source_test.py
@@ -7,8 +7,8 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from ..schema import schema
+from ..source import SourceSchema
 from .parquet_source import ParquetSource
-from .source import SourceSchema
 
 
 def test_simple_rows(tmp_path: pathlib.Path) -> None:

--- a/lilac/sources/reddit_hf_source.py
+++ b/lilac/sources/reddit_hf_source.py
@@ -5,8 +5,8 @@ from pydantic import Field as PydanticField
 from typing_extensions import override
 
 from ..schema import Item
+from ..source import Source, SourceSchema
 from .huggingface_source import HuggingFaceSource
-from .source import Source, SourceSchema
 
 HF_REDDIT_DATASET_NAME = 'reddit'
 HF_SUBREDDIT_COL = 'subreddit'

--- a/lilac/sources/source_registry.py
+++ b/lilac/sources/source_registry.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, Type, Union
 
-from .source import Source
+from ..source import Source
 
 SOURCE_REGISTRY: dict[str, Type[Source]] = {}
 

--- a/lilac/sources/source_registry_test.py
+++ b/lilac/sources/source_registry_test.py
@@ -5,7 +5,7 @@ import pytest
 from typing_extensions import override
 
 from ..schema import Item
-from .source import Source, SourceSchema
+from ..source import Source, SourceSchema
 from .source_registry import clear_source_registry, get_source_cls, register_source, resolve_source
 
 

--- a/lilac/utils.py
+++ b/lilac/utils.py
@@ -283,9 +283,17 @@ def pretty_timedelta(delta: timedelta) -> str:
     return '%ds' % (seconds,)
 
 
+class IndentDumper(yaml.Dumper):
+  """A yaml dumper that indent lists."""
+
+  def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:
+    """Increase the indent level."""
+    return super(IndentDumper, self).increase_indent(flow, False)
+
+
 def to_yaml(input: dict) -> str:
   """Convert a dictionary to a pretty yaml representation."""
-  return yaml.dump(input, default_flow_style=None)
+  return yaml.dump(input, Dumper=IndentDumper, sort_keys=False)
 
 
 def get_hf_dataset_repo_id(hf_org: str, hf_space_name: str, namespace: str,

--- a/web/lib/fastapi_client/index.ts
+++ b/web/lib/fastapi_client/index.ts
@@ -68,6 +68,7 @@ export type { SignalSchemaOptions } from './models/SignalSchemaOptions';
 export type { SignalSchemaResponse } from './models/SignalSchemaResponse';
 export type { SortOrder } from './models/SortOrder';
 export type { SortResult } from './models/SortResult';
+export type { Source } from './models/Source';
 export type { SourcesList } from './models/SourcesList';
 export type { StatsResult } from './models/StatsResult';
 export type { SubstringSignal } from './models/SubstringSignal';

--- a/web/lib/fastapi_client/models/DatasetManifest.ts
+++ b/web/lib/fastapi_client/models/DatasetManifest.ts
@@ -3,6 +3,7 @@
 /* eslint-disable */
 
 import type { Schema } from './Schema';
+import type { Source } from './Source';
 
 /**
  * The manifest for a dataset.
@@ -11,6 +12,7 @@ export type DatasetManifest = {
     namespace: string;
     dataset_name: string;
     data_schema: Schema;
+    source: Source;
     num_items: number;
 };
 

--- a/web/lib/fastapi_client/models/Source.ts
+++ b/web/lib/fastapi_client/models/Source.ts
@@ -1,0 +1,11 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Interface for sources to implement. A source processes a set of shards and writes files.
+ */
+export type Source = {
+    source_name: string;
+};
+


### PR DESCRIPTION
High-level: lilac.yml now will be updated any time an action is performed on a dataset.

Details:
- Datasets call into methods in `project` which will write to lilac.yml.
- The old config.yml is now gone, however for backwards compat I made sure to have lilac.yml update from dataset configs if they exist.
- `lilac.yml` is written *before* computation. The manifest will reflect the post-computation state. This means that when the server boots up, it will try to call load on the fresh lilac.yml.
