### PR TITLE
Remove the explicit cache directory for sentence transformers.

### DIFF
--- a/lilac/embeddings/transformer_utils.py
+++ b/lilac/embeddings/transformer_utils.py
@@ -1,10 +1,8 @@
 """Utils for transformer embeddings."""
 
 import functools
-import os
 from typing import TYPE_CHECKING, Optional
 
-from ..env import data_path
 from ..utils import log
 
 if TYPE_CHECKING:
@@ -28,8 +26,7 @@ def get_model(model_name: str,
 
   @functools.cache
   def _get_model(model_name: str) -> 'SentenceTransformer':
-    return SentenceTransformer(
-      model_name, device=preferred_device, cache_folder=os.path.join(data_path(), '.cache'))
+    return SentenceTransformer(model_name, device=preferred_device)
 
   batch_size = optimal_batch_sizes[preferred_device or '']
   return batch_size, _get_model(model_name)


### PR DESCRIPTION
This allows us to share the transformer cache across projects.