### PR TITLE
Use iterables for compute_signal and compute_embedding.

### DIFF
--- a/lilac.yml
+++ b/lilac.yml
@@ -1,0 +1,4 @@
+# Lilac project config.
+# See https://lilacml.com/api_reference/index.html#lilac.Config for details.
+
+{}

--- a/lilac/batch_utils.py
+++ b/lilac/batch_utils.py
@@ -46,9 +46,15 @@ def _deep_unflatten(flat_input: Iterator[list[object]], original_input: Union[It
 
 def deep_unflatten(flat_input: Union[Iterable, Iterator],
                    original_input: Union[Iterable, object],
-                   is_primitive_predicate: Callable[[object], bool] = is_primitive) -> list:
+                   is_primitive_predicate: Callable[[object], bool] = is_primitive) -> Iterable:
   """Unflattens a deeply flattened iterable according to the original iterable's structure."""
-  return cast(list, _deep_unflatten(iter(flat_input), original_input, is_primitive_predicate))
+  flat_input_iter = iter(flat_input)
+  if isinstance(original_input, Iterable) and not is_primitive_predicate(original_input):
+    for o in original_input:
+      yield _deep_unflatten(flat_input_iter, o, is_primitive_predicate)
+    return
+
+  yield cast(list, _deep_unflatten(iter(flat_input), original_input, is_primitive_predicate))
 
 
 TFlatten = TypeVar('TFlatten')

--- a/lilac/batch_utils.py
+++ b/lilac/batch_utils.py
@@ -46,7 +46,7 @@ def _deep_unflatten(flat_input: Iterator[list[object]], original_input: Union[It
 
 def deep_unflatten(flat_input: Union[Iterable, Iterator],
                    original_input: Union[Iterable, object],
-                   is_primitive_predicate: Callable[[object], bool] = is_primitive) -> Iterable:
+                   is_primitive_predicate: Callable[[object], bool] = is_primitive) -> Generator:
   """Unflattens a deeply flattened iterable according to the original iterable's structure."""
   flat_input_iter = iter(flat_input)
   if isinstance(original_input, Iterable) and not is_primitive_predicate(original_input):
@@ -54,7 +54,7 @@ def deep_unflatten(flat_input: Union[Iterable, Iterator],
       yield _deep_unflatten(flat_input_iter, o, is_primitive_predicate)
     return
 
-  yield cast(list, _deep_unflatten(iter(flat_input), original_input, is_primitive_predicate))
+  yield _deep_unflatten(iter(flat_input), original_input, is_primitive_predicate)
 
 
 TFlatten = TypeVar('TFlatten')

--- a/lilac/batch_utils_test.py
+++ b/lilac/batch_utils_test.py
@@ -1,4 +1,5 @@
 """Test batch_utils.py."""
+import itertools
 from typing import Iterable
 
 import numpy as np
@@ -67,19 +68,29 @@ def test_deep_flatten_np() -> None:
 def test_deep_unflatten() -> None:
   a = [[1, 2], [[3]], [4, 5, 5]]
   flat_a = list(deep_flatten(a))
-  result = deep_unflatten(flat_a, a)
-  assert result == [[1, 2], [[3]], [4, 5, 5]]
+  flat_f_a = [a * 2 for a in flat_a]
+  result = list(deep_unflatten(flat_f_a, a))
+  assert result == [[2, 4], [[6]], [8, 10, 10]]
+
+
+def test_deep_unflatten_generator() -> None:
+  a = ([1, 2], [[3]], [4, 5, 5])
+  a_0, a_1 = itertools.tee(a, 2)
+  flat_a = list(deep_flatten(a_0))
+  flat_f_a = [a * 2 for a in flat_a]
+  result = list(deep_unflatten(flat_f_a, a_1))
+  assert result == [[2, 4], [[6]], [8, 10, 10]]
 
 
 def test_deep_unflatten_primitive() -> None:
   original = 'hello'
-  result = deep_unflatten(['hello'], original)
+  result = next(iter(deep_unflatten(['hello'], original)))
   assert result == 'hello'
 
 
 def test_deep_unflatten_primitive_list() -> None:
   original = ['hello', 'world']
-  result = deep_unflatten(['hello', 'world'], original)
+  result = list(deep_unflatten(['hello', 'world'], original))
   assert result == ['hello', 'world']
 
 

--- a/lilac/data/dataset_compute_signal_chain_test.py
+++ b/lilac/data/dataset_compute_signal_chain_test.py
@@ -192,25 +192,3 @@ class NamedEntity(TextSignal):
         yield None
         continue
       yield [lilac_span(m.start(0), m.end(0)) for m in re.finditer(ENTITY_REGEX, text)]
-
-
-def test_entity_on_split_signal(make_test_data: TestDataMaker) -> None:
-  text = 'Hello nik@test. Here are some other entities like pii@gmail and all@lilac.'
-  dataset = make_test_data([{'text': text}])
-  entity = NamedEntity()
-  dataset.compute_signal(TestSplitter(), 'text')
-  dataset.compute_signal(entity, ('text', 'test_splitter', '*'))
-
-  result = dataset.select_rows(['text'], combine_columns=True)
-  assert list(result) == [{
-    'text': enriched_item(
-      text, {
-        'test_splitter': [
-          lilac_span(0, 15, {'entity': [lilac_span(6, 14)]}),
-          lilac_span(16, 74, {'entity': [
-            lilac_span(50, 59),
-            lilac_span(64, 73),
-          ]}),
-        ]
-      })
-  }]

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -542,6 +542,7 @@ def test_compute_embedding_over_non_string(make_test_data: TestDataMaker) -> Non
   with pytest.raises(ValueError, match='Cannot compute embedding over a non-string field.'):
     dataset.compute_signal(test_embedding, ('text', 'test_split', '*'))
 
+
 def test_compute_signal_over_non_string(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data([{
     'text': 'hello. hello2.',
@@ -553,7 +554,7 @@ def test_compute_signal_over_non_string(make_test_data: TestDataMaker) -> None:
   dataset.compute_signal(test_splitter, 'text')
 
   test_embedding = TestEmbedding()
-  with pytest.raises(ValueError, match='Cannot compute embedding over a non-string field.'):
+  with pytest.raises(ValueError, match='Cannot compute signal over a non-string field.'):
     dataset.compute_signal(test_splitter, ('text', 'test_split', '*'))
 
 

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -528,6 +528,35 @@ def test_embedding_signal(make_test_data: TestDataMaker) -> None:
   assert list(result) == expected_result
 
 
+def test_compute_embedding_over_non_string(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data([{
+    'text': 'hello. hello2.',
+  }, {
+    'text': 'hello world. hello world2.',
+  }])
+
+  test_splitter = TestSplitSignal()
+  dataset.compute_signal(test_splitter, 'text')
+
+  test_embedding = TestEmbedding()
+  with pytest.raises(ValueError, match='Cannot compute embedding over a non-string field.'):
+    dataset.compute_signal(test_embedding, ('text', 'test_split', '*'))
+
+def test_compute_signal_over_non_string(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data([{
+    'text': 'hello. hello2.',
+  }, {
+    'text': 'hello world. hello world2.',
+  }])
+
+  test_splitter = TestSplitSignal()
+  dataset.compute_signal(test_splitter, 'text')
+
+  test_embedding = TestEmbedding()
+  with pytest.raises(ValueError, match='Cannot compute embedding over a non-string field.'):
+    dataset.compute_signal(test_splitter, ('text', 'test_split', '*'))
+
+
 def test_is_computed_signal_key(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data([{'text': 'hello.'}, {'text': 'hello2.'}])
 

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -215,7 +215,7 @@ def test_signal_output_validation(make_test_data: TestDataMaker) -> None:
   }])
 
   with pytest.raises(
-      ValueError, match='The signal generated 0 values but the input data had 2 values.'):
+      ValueError, match='The signal generated a different number of values than was input.'):
     dataset.compute_signal(signal, 'text')
 
 

--- a/lilac/data/dataset_config_test.py
+++ b/lilac/data/dataset_config_test.py
@@ -109,7 +109,6 @@ def test_config_compute_signal(make_test_data: TestDataMaker) -> None:
     )],
     settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('text',)])))
 
-  print('computing the signal again')
   # Computing the same signal again should not change the config.
   dataset.compute_signal(TestSignal(), 'text')
 

--- a/lilac/data/dataset_config_test.py
+++ b/lilac/data/dataset_config_test.py
@@ -109,6 +109,7 @@ def test_config_compute_signal(make_test_data: TestDataMaker) -> None:
     )],
     settings=DatasetSettings(ui=DatasetUISettings(media_paths=[('text',)])))
 
+  print('computing the signal again')
   # Computing the same signal again should not change the config.
   dataset.compute_signal(TestSignal(), 'text')
 

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -431,6 +431,7 @@ class DatasetDuckDB(Dataset):
 
     output_dir = os.path.join(self.dataset_path, _signal_dir(enriched_path))
     signal_schema = create_signal_schema(signal, source_path, manifest.data_schema)
+    print('signal schema=', signal_schema)
     parquet_filename, _ = write_items_to_parquet(
       items=output_items,
       output_dir=output_dir,

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -394,13 +394,14 @@ class DatasetDuckDB(Dataset):
     source_values = self._select_iterable_values(source_path, data_schema)
 
     # Tee the results so we can zip the row ids with the outputs.
-    inputs_0, inputs_1, inputs_2 = itertools.tee(source_values, 3)
+    inputs_0, inputs_1 = itertools.tee(source_values, 2)
 
     # Tee the values so we can use them for the deep flatten and the deep unflatten.
     input_values = (value for (_, value) in inputs_0)
     input_values_0, input_values_1 = itertools.tee(input_values, 2)
 
     if isinstance(signal, VectorSignal):
+      inputs_1, inputs_2 = itertools.tee(inputs_1, 2)
       embedding_signal = signal
       vector_store = self._get_vector_db_index(embedding_signal.embedding, source_path)
       flat_keys = list(flatten_keys((rowid for (rowid, _) in inputs_2), input_values_0))

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -381,15 +381,20 @@ class DatasetDuckDB(Dataset):
       yield from zip(row_ids, values)
       is_empty = df_chunk.empty
 
-  def _compute_signal_items(self, signal: Signal, path: Path,
-                            data_schema: Schema) -> Iterable[Item]:
+  def _compute_signal_items(self,
+                            signal: Signal,
+                            path: Path,
+                            data_schema: Schema,
+                            num_items: int,
+                            task_step_id: Optional[TaskStepId] = None) -> Iterable[Item]:
     signal.setup()
 
     source_path = normalize_path(path)
 
     source_values = self._select_iterable_values(source_path, data_schema)
+
     # Tee the results so we can zip the row ids with the outputs.
-    inputs_0, inputs_1, inputs_dbg = itertools.tee(source_values, 3)
+    inputs_0, inputs_1, inputs_2 = itertools.tee(source_values, 3)
 
     # Tee the values so we can use them for the deep flatten and the deep unflatten.
     input_values = (value for (_, value) in inputs_0)
@@ -398,7 +403,7 @@ class DatasetDuckDB(Dataset):
     if isinstance(signal, VectorSignal):
       embedding_signal = signal
       vector_store = self._get_vector_db_index(embedding_signal.embedding, source_path)
-      flat_keys = list(flatten_keys(df[ROWID], input))
+      flat_keys = list(flatten_keys((rowid for (rowid, _) in inputs_2), input_values_0))
       signal_out = sparse_to_dense_compute(
         iter(flat_keys), lambda keys: embedding_signal.vector_compute(keys, vector_store))
     else:
@@ -406,19 +411,20 @@ class DatasetDuckDB(Dataset):
       signal_out = sparse_to_dense_compute(flat_input,
                                            lambda x: signal.compute(cast(Iterable[RichData], x)))
 
-    try:
-      nested_out = deep_unflatten(signal_out, input_values_1)
-    except StopIteration as e:
-      raise ValueError('The signal generated a different number of values than was input. '
-                       'Please yield `None` in signals when there is no value.') from e
+    nested_out = deep_unflatten(signal_out, input_values_1)
 
     signal_col = Column(path=source_path, alias='value', signal_udf=signal)
     enriched_path = _col_destination_path(signal_col, is_computed_signal=True)
     spec = _split_path_into_subpaths_of_lists(enriched_path)
+
     enriched_signal_items = cast(Iterable[Item], wrap_in_dicts(nested_out, spec))
 
-    for (rowid, _), item in zip(inputs_1, enriched_signal_items):
-      yield {**item, ROWID: rowid}
+    try:
+      for (rowid, _), item in zip(inputs_1, enriched_signal_items):
+        yield {**item, ROWID: rowid}
+    except Exception as e:
+      raise ValueError('The signal generated a different number of values than was input. '
+                       'Please yield `None` in signals when there is no value.') from e
 
   @override
   def compute_signal(self,
@@ -443,17 +449,33 @@ class DatasetDuckDB(Dataset):
       # Make a dummy task step so we report progress via tqdm.
       task_step_id = ('', 0)
 
-    output_items = self._compute_signal_items(signal, path, manifest.data_schema)
-
-    # output_items = list(output_items)
-    # print('OI:', output_items)
+    output_items = self._compute_signal_items(signal, path, manifest.data_schema,
+                                              manifest.num_items, task_step_id)
 
     signal_col = Column(path=source_path, alias='value', signal_udf=signal)
     enriched_path = _col_destination_path(signal_col, is_computed_signal=True)
 
     output_dir = os.path.join(self.dataset_path, _signal_dir(enriched_path))
 
+    signal_manifest_filepath = os.path.join(output_dir, SIGNAL_MANIFEST_FILENAME)
+    # If the signal manifest already exists, delete it as it will be rewritten after the new signal
+    # outputs are run.
+    if os.path.exists(signal_manifest_filepath):
+      os.remove(signal_manifest_filepath)
+      # Call manifest() to recreate all the views, otherwise this could be stale and point to a non
+      # existent file.
+      self.manifest()
+
     signal_schema = create_signal_schema(signal, source_path, manifest.data_schema)
+
+    # Add progress.
+    if task_step_id is not None:
+      output_items = progress(
+        output_items,
+        task_step_id=task_step_id,
+        estimated_len=manifest.num_items,
+        step_description=f'Computing signal {signal} over {source_path}')
+
     parquet_filename, _ = write_items_to_parquet(
       items=output_items,
       output_dir=output_dir,
@@ -462,15 +484,12 @@ class DatasetDuckDB(Dataset):
       shard_index=0,
       num_shards=1)
 
-    print('PQ FILENAME', parquet_filename)
-
     signal_manifest = SignalManifest(
       files=[parquet_filename],
       data_schema=signal_schema,
       signal=signal,
       enriched_path=source_path,
       parquet_id=make_signal_parquet_id(signal, source_path, is_computed_signal=True))
-    signal_manifest_filepath = os.path.join(output_dir, SIGNAL_MANIFEST_FILENAME)
     with open_file(signal_manifest_filepath, 'w') as f:
       f.write(signal_manifest.model_dump_json(exclude_none=True, indent=2))
 
@@ -496,8 +515,8 @@ class DatasetDuckDB(Dataset):
 
     signal = get_signal_by_type(embedding, TextEmbeddingSignal)()
 
-    print('source path=', source_path)
-    output_items = self._compute_signal_items(signal, path, manifest.data_schema)
+    output_items = self._compute_signal_items(signal, path, manifest.data_schema,
+                                              manifest.num_items, task_step_id)
 
     signal_col = Column(path=source_path, alias='value', signal_udf=signal)
 
@@ -506,6 +525,14 @@ class DatasetDuckDB(Dataset):
     signal_schema = create_signal_schema(signal, source_path, manifest.data_schema)
 
     row_ids = (item[ROWID] for item in output_items)
+
+    if task_step_id is not None:
+      output_items = progress(
+        output_items,
+        task_step_id=task_step_id,
+        estimated_len=manifest.num_items,
+        step_description=f'Computing embedding {signal} over {source_path}')
+
     write_embeddings_to_disk(
       vector_store=self.vector_store,
       rowids=row_ids,
@@ -514,6 +541,15 @@ class DatasetDuckDB(Dataset):
 
     gc.collect()
 
+    signal_manifest_filepath = os.path.join(output_dir, SIGNAL_MANIFEST_FILENAME)
+    # If the signal manifest already exists, delete it as it will be rewritten after the new signal
+    # outputs are run.
+    if os.path.exists(signal_manifest_filepath):
+      os.remove(signal_manifest_filepath)
+      # Call manifest() to recreate all the views, otherwise this could be stale and point to a non
+      # existent file.
+      self.manifest()
+
     signal_manifest = SignalManifest(
       files=[],
       data_schema=signal_schema,
@@ -521,7 +557,6 @@ class DatasetDuckDB(Dataset):
       enriched_path=source_path,
       parquet_id=make_signal_parquet_id(signal, source_path, is_computed_signal=True),
       vector_store=self.vector_store)
-    signal_manifest_filepath = os.path.join(output_dir, SIGNAL_MANIFEST_FILENAME)
 
     with open_file(signal_manifest_filepath, 'w') as f:
       f.write(signal_manifest.model_dump_json(exclude_none=True, indent=2))
@@ -1145,7 +1180,7 @@ class DatasetDuckDB(Dataset):
               task_step_id=task_step_id,
               estimated_len=len(flat_keys),
               step_description=step_description)
-          df[signal_column] = deep_unflatten(signal_out, input)
+          df[signal_column] = list(deep_unflatten(signal_out, input))
         else:
           num_rich_data = count_primitives(input)
           flat_input = cast(Iterator[Optional[RichData]], deep_flatten(input))
@@ -1172,7 +1207,7 @@ class DatasetDuckDB(Dataset):
               f"{num_rich_data} values. This means the signal either didn't generate a "
               '"None" for a sparse output, or generated too many items.')
 
-          df[signal_column] = deep_unflatten(signal_out_list, input)
+          df[signal_column] = list(deep_unflatten(signal_out_list, input))
 
         signal.teardown()
 
@@ -1214,7 +1249,7 @@ class DatasetDuckDB(Dataset):
         if combine_columns:
           dest_path = _col_destination_path(column)
           spec = _split_path_into_subpaths_of_lists(dest_path)
-          df[temp_col_name] = wrap_in_dicts(df[temp_col_name], spec)
+          df[temp_col_name] = list(wrap_in_dicts(df[temp_col_name], spec))
 
         # If the temp col name is the same as the final name, we can skip merging. This happens when
         # we select a source leaf column.

--- a/lilac/data/dataset_select_rows_schema_test.py
+++ b/lilac/data/dataset_select_rows_schema_test.py
@@ -114,7 +114,6 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
     """Call the embedding function."""
     for example in data:
-      print('example=', example)
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 

--- a/lilac/data/dataset_select_rows_schema_test.py
+++ b/lilac/data/dataset_select_rows_schema_test.py
@@ -114,6 +114,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
     """Call the embedding function."""
     for example in data:
+      print('example=', example)
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
@@ -301,56 +302,6 @@ def test_udf_chained_with_combine_cols(make_test_data: TestDataMaker) -> None:
     udfs=[
       SelectRowsSchemaUDF(path=('text', add_space_signal.key())),
     ],
-  )
-
-
-def test_udf_embedding_chained_with_combine_cols(make_test_data: TestDataMaker) -> None:
-  dataset = make_test_data([{
-    'text': 'hello. hello2.',
-  }, {
-    'text': 'hello world. hello world2.',
-  }])
-
-  test_splitter = TestSplitter()
-  dataset.compute_signal(test_splitter, 'text')
-  test_embedding = TestEmbedding()
-  dataset.compute_signal(test_embedding, ('text', 'test_splitter', '*'))
-
-  embedding_sum_signal = TestEmbeddingSumSignal(embedding='test_embedding')
-  udf_col = Column(('text', 'test_splitter', '*'), signal_udf=embedding_sum_signal)
-  result = dataset.select_rows_schema([('text'), udf_col], combine_columns=True)
-
-  expected_schema = schema({
-    'text': field(
-      'string',
-      fields={
-        'test_splitter': field(
-          signal=test_splitter.model_dump(),
-          fields=[
-            field(
-              'string_span',
-              fields={
-                'test_embedding': field(
-                  signal=test_embedding.model_dump(),
-                  fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})]),
-                embedding_sum_signal.key(): field(
-                  'float32', signal=embedding_sum_signal.model_dump())
-              })
-          ])
-      })
-  })
-  output_path = ('text', 'test_splitter', '*', embedding_sum_signal.key())
-  assert result == SelectRowsSchemaResult(
-    data_schema=expected_schema,
-    udfs=[SelectRowsSchemaUDF(path=output_path)],
-  )
-
-  # Alias the udf.
-  udf_col.alias = 'udf1'
-  result = dataset.select_rows_schema([('text'), udf_col], combine_columns=True)
-  assert result == SelectRowsSchemaResult(
-    data_schema=expected_schema,
-    udfs=[SelectRowsSchemaUDF(path=output_path, alias='udf1')],
   )
 
 

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -156,6 +156,8 @@ def write_embeddings_to_disk(vector_store: str, rowids: Iterable[str], signal_it
             EMBEDDING_KEY in input[0])
 
   signal_items_0, signal_items_1 = itertools.tee(signal_items, 2)
+  # for signal_item in signal_items_0:
+
   # print('INPUT ITEMS:', list(signal_items_0))
   # path_keys = flatten_keys(rowids, signal_items_0, is_primitive_predicate=embedding_predicate)
   path_embedding_items = (

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -131,11 +131,13 @@ def create_signal_schema(signal: Signal, source_path: PathTuple, current_schema:
 
 def _flat_embeddings(
   input: Union[Item, Iterable[Item]], path: PathKey = ()) -> Iterator[tuple[PathKey, Item]]:
-  if isinstance(input, dict) and EMBEDDING_KEY in input:
-    yield path, input
+  if (isinstance(input, list) and len(input) > 0 and isinstance(input[0], dict) and
+      EMBEDDING_KEY in input[0]):
+    for v in input:
+      yield path, v
   elif isinstance(input, dict):
     for k, v in input.items():
-      yield from _flat_embeddings(v, (*path, k))
+      yield from _flat_embeddings(v, path)
   elif isinstance(input, list):
     for i, v in enumerate(input):
       print('v=', v, i, 'i', (*path, i))
@@ -177,6 +179,7 @@ def write_embeddings_to_disk(vector_store: str, rowids: Iterable[str], signal_it
         continue
 
       spans: list[tuple[int, int]] = []
+      print('embedding item:', embedding_item)
       span = embedding_item[VALUE_KEY]
       vector = embedding_item[EMBEDDING_KEY]
       # We squeeze here because embedding functions can return outer dimensions of 1.

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -160,6 +160,7 @@ def write_embeddings_to_disk(vector_store: str, rowids: Iterable[str], signal_it
 
   # print('INPUT ITEMS:', list(signal_items_0))
   # path_keys = flatten_keys(rowids, signal_items_0, is_primitive_predicate=embedding_predicate)
+  # print('path_keys = ', list(path_keys))
   path_embedding_items = (
     _flat_embeddings(signal_item, path=(signal_item[ROWID],)) for signal_item in signal_items)
 

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -8,7 +8,7 @@ import os
 import pprint
 import secrets
 from collections.abc import Iterable
-from typing import Callable, Iterator, Optional, TypeVar, Union, cast
+from typing import Callable, Generator, Iterator, Optional, TypeVar, Union, cast
 
 import numpy as np
 import pyarrow as pa
@@ -85,7 +85,7 @@ def _wrap_in_dicts(input: Union[object, Iterable[object]],
   return _wrap_value_in_dict(res, props)
 
 
-def wrap_in_dicts(input: Iterable[object], spec: list[PathTuple]) -> Iterable[object]:
+def wrap_in_dicts(input: Iterable[object], spec: list[PathTuple]) -> Generator:
   """Wraps an object or iterable in a dict according to the spec."""
   return (_wrap_in_dicts(elem, spec) for elem in input)
 

--- a/lilac/data/dataset_utils_test.py
+++ b/lilac/data/dataset_utils_test.py
@@ -16,7 +16,7 @@ def test_wrap_in_dicts_with_spec_of_one_repeated() -> None:
   a = [[1, 2], [3], [4, 5, 5]]
   spec: list[PathTuple] = [('a', 'b', 'c'), ('d',)]  # Corresponds to a.b.c.*.d.
   result = wrap_in_dicts(a, spec)
-  assert result == [{
+  assert list(result) == [{
     'a': {
       'b': {
         'c': [{
@@ -53,7 +53,7 @@ def test_wrap_in_dicts_with_spec_of_double_repeated() -> None:
   a = [[[1, 2], [3, 4, 5]], [[6]], [[7], [8], [9, 10]]]
   spec: list[PathTuple] = [('a', 'b'), tuple(), ('c',)]  # Corresponds to a.b.*.*.c.
   result = wrap_in_dicts(a, spec)
-  assert result == [{
+  assert list(result) == [{
     'a': {
       'b': [[{
         'c': 1

--- a/scripts/test_py.sh
+++ b/scripts/test_py.sh
@@ -15,7 +15,7 @@ if [ "$CI" ]; then
 fi
 
 # Disables log() statements.
-#export DISABLE_LOGS=True
+export DISABLE_LOGS=True
 export LILAC_TEST=True
 
 # -vv enables verbose outputs.

--- a/scripts/test_py.sh
+++ b/scripts/test_py.sh
@@ -14,8 +14,6 @@ if [ "$CI" ]; then
   PYTEST_MARKS="(not largedownload)"
 fi
 
-# Disables log() statements.
-#export DISABLE_LOGS=True
 export LILAC_TEST=True
 
 # -vv enables verbose outputs.

--- a/scripts/test_py.sh
+++ b/scripts/test_py.sh
@@ -15,7 +15,7 @@ if [ "$CI" ]; then
 fi
 
 # Disables log() statements.
-export DISABLE_LOGS=True
+#export DISABLE_LOGS=True
 export LILAC_TEST=True
 
 # -vv enables verbose outputs.


### PR DESCRIPTION
High-level:
- compute_signal() and compute_embedding() now directly call duckdb to get source values. We use `fetch_df_chunk` to iteratively get chunks of the response of the query.
- Downstream, everything is now iterable, which means all of the batch & dataset utils are now generators.

This is the first step towards https://github.com/lilacai/lilac/issues/660

A follow up will actually write embeddings iteratively.

Regression: now we do not support running signals over span fields. This isn't really supported anywhere, but easy to fix if we decide we want it later.

https://lilacai-nikhil-staging.hf.space/