### PR TITLE
Write embeddings to the vector store iteratively

### DIFF
--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -4,6 +4,7 @@ from typing import ClassVar, Iterable, Optional, Union, cast
 
 import numpy as np
 import pytest
+from pytest_mock import MockerFixture
 from typing_extensions import override
 
 from lilac.sources.source_registry import clear_source_registry, register_source
@@ -29,6 +30,7 @@ from ..signal import (
   register_signal,
 )
 from ..signals.concept_scorer import ConceptSignal
+from . import dataset_utils as dataset_utils_module
 from .dataset import Column, DatasetManifest, GroupsSortBy, SortOrder
 from .dataset_test_utils import (
   TEST_DATASET_NAME,
@@ -502,8 +504,11 @@ def test_text_splitter(make_test_data: TestDataMaker) -> None:
   assert list(result) == expected_result
 
 
-def test_embedding_signal(make_test_data: TestDataMaker) -> None:
+def test_embedding_signal(make_test_data: TestDataMaker, mocker: MockerFixture) -> None:
   dataset = make_test_data([{'text': 'hello.'}, {'text': 'hello2.'}])
+
+  # Reduce the chunk size to 1 so we test iteratively writing to the embedding index.
+  mocker.patch(f'{dataset_utils_module.__name__}.EMBEDDINGS_WRITE_CHUNK_SIZE', 1)
 
   embedding_signal = TestEmbedding()
   dataset.compute_signal(embedding_signal, 'text')

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -39,8 +39,8 @@ from ..signal import Signal
 from ..utils import chunks, is_primitive, log, open_file
 
 # The embedding write chunk sizes keeps the memory pressure lower as we iteratively write to the
-# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~40MB of RAM pressure.
-EMBEDDINGS_WRITE_CHUNK_SIZE = 10_000
+# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~64MB of RAM pressure.
+EMBEDDINGS_WRITE_CHUNK_SIZE = 16_384
 
 
 def _replace_embeddings_with_none(input: Union[Item, Item]) -> Union[Item, Item]:

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -36,7 +36,9 @@ from ..schema import (
   schema_to_arrow_schema,
 )
 from ..signal import Signal
-from ..utils import is_primitive, log, open_file
+from ..utils import chunks, is_primitive, log, open_file
+
+EMBEDDINGS_WRITE_CHUNK_SIZE = 10_000
 
 
 def _replace_embeddings_with_none(input: Union[Item, Item]) -> Union[Item, Item]:
@@ -151,30 +153,43 @@ def write_embeddings_to_disk(vector_store: str, rowids: Iterable[str], signal_it
   path_embedding_items = (
     _flat_embeddings(signal_item, path=(signal_item[ROWID],)) for signal_item in signal_items)
 
-  embedding_vectors: list[np.ndarray] = []
-  all_spans: list[tuple[PathKey, list[tuple[int, int]]]] = []
-  for path_item in path_embedding_items:
-    for path_key, embedding_items in path_item:
-      if not path_key or not embedding_items:
-        # Sparse embeddings may not have an embedding for every key.
-        continue
+  def _get_span_vectors() -> Generator:
+    nonlocal path_embedding_items
+    for path_item in path_embedding_items:
+      for path_key, embedding_items in path_item:
+        if not path_key or not embedding_items:
+          # Sparse embeddings may not have an embedding for every key.
+          continue
 
-      spans: list[tuple[int, int]] = []
-      for e in embedding_items:
-        span = e[VALUE_KEY]
-        vector = e[EMBEDDING_KEY]
-        # We squeeze here because embedding functions can return outer dimensions of 1.
-        embedding_vectors.append(vector.reshape(-1))
-        spans.append((span[TEXT_SPAN_START_FEATURE], span[TEXT_SPAN_END_FEATURE]))
-      all_spans.append((path_key, spans))
-  embedding_matrix = np.array(embedding_vectors, dtype=np.float32)
-  del path_embedding_items, embedding_vectors
-  gc.collect()
+        embedding_vectors: list[np.ndarray] = []
+        spans: list[tuple[int, int]] = []
 
-  # Write to disk.
+        for e in embedding_items:
+          span = e[VALUE_KEY]
+          vector = e[EMBEDDING_KEY]
+          # We squeeze here because embedding functions can return outer dimensions of 1.
+          embedding_vectors.append(vector.reshape(-1))
+          spans.append((span[TEXT_SPAN_START_FEATURE], span[TEXT_SPAN_END_FEATURE]))
+
+        yield (path_key, spans, embedding_vectors)
+
+  span_vectors = _get_span_vectors()
+
   vector_index = VectorDBIndex(vector_store)
-  vector_index.add(all_spans, embedding_matrix)
-  vector_index.save(output_dir)
+  for span_vectors_chunk in chunks(span_vectors, EMBEDDINGS_WRITE_CHUNK_SIZE):
+    chunk_spans: list[tuple[PathKey, list[tuple[int, int]]]] = []
+    chunk_embedding_vectors: list[np.ndarray] = []
+    for path_key, spans, vectors in span_vectors_chunk:
+      chunk_spans.append((path_key, spans))
+      chunk_embedding_vectors.extend(vectors)
+
+    embedding_matrix = np.array(chunk_embedding_vectors, dtype=np.float32)
+
+    vector_index.add(chunk_spans, embedding_matrix)
+    vector_index.save(output_dir)
+
+    del embedding_matrix, chunk_embedding_vectors, chunk_spans
+    gc.collect()
 
   del vector_index
   gc.collect()

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -38,6 +38,8 @@ from ..schema import (
 from ..signal import Signal
 from ..utils import chunks, is_primitive, log, open_file
 
+# The embedding write chunk sizes keeps the memory pressure lower as we iteratively write to the
+# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~40MB of RAM pressure.
 EMBEDDINGS_WRITE_CHUNK_SIZE = 10_000
 
 

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -39,7 +39,8 @@ from ..signal import Signal
 from ..utils import chunks, is_primitive, log, open_file
 
 # The embedding write chunk sizes keeps the memory pressure lower as we iteratively write to the
-# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~64MB of RAM pressure.
+# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~64MB * dims of RAM
+# pressure.
 EMBEDDINGS_WRITE_CHUNK_SIZE = 16_384
 
 

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -39,9 +39,9 @@ from ..signal import Signal
 from ..utils import chunks, is_primitive, log, open_file
 
 # The embedding write chunk sizes keeps the memory pressure lower as we iteratively write to the
-# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~16MB * dims of RAM
+# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~130K * dims of RAM
 # pressure.
-EMBEDDINGS_WRITE_CHUNK_SIZE = 4_096
+EMBEDDINGS_WRITE_CHUNK_SIZE = 32_768
 
 
 def _replace_embeddings_with_none(input: Union[Item, Item]) -> Union[Item, Item]:

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -39,9 +39,9 @@ from ..signal import Signal
 from ..utils import chunks, is_primitive, log, open_file
 
 # The embedding write chunk sizes keeps the memory pressure lower as we iteratively write to the
-# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~64MB * dims of RAM
+# vector store. Embeddings are float32, taking up 4 bytes, so this results in ~16MB * dims of RAM
 # pressure.
-EMBEDDINGS_WRITE_CHUNK_SIZE = 16_384
+EMBEDDINGS_WRITE_CHUNK_SIZE = 4_096
 
 
 def _replace_embeddings_with_none(input: Union[Item, Item]) -> Union[Item, Item]:

--- a/lilac/embeddings/vector_store.py
+++ b/lilac/embeddings/vector_store.py
@@ -112,7 +112,6 @@ class VectorDBIndex:
       all_spans: The spans to initialize the index with.
       embeddings: The embeddings to initialize the index with.
     """
-    assert not self._id_to_spans, 'Cannot add to a non-empty index.'
     self._id_to_spans.update(all_spans)
     vector_keys = [(*path_key, i) for path_key, spans in all_spans for i in range(len(spans))]
     assert len(vector_keys) == len(embeddings), (


### PR DESCRIPTION
We now allow the vector store to add elements in chunks, reducing the overall memory pressure as we don't have to keep all the embeddings in RAM.

Fixes https://github.com/lilacai/lilac/issues/660