### PR TITLE
Add LILAC_AUTH_ADMIN_EMAILS to set admins.

### DIFF
--- a/lilac/auth.py
+++ b/lilac/auth.py
@@ -35,6 +35,8 @@ class ConceptUserAccess(BaseModel):
 
 class UserAccess(BaseModel):
   """User access."""
+  is_admin: bool = False
+
   create_dataset: bool
 
   # TODO(nsthorat): Make this keyed to each dataset and concept.
@@ -73,13 +75,27 @@ def get_session_user(request: Request) -> Optional[UserInfo]:
   return None
 
 
-def get_user_access() -> UserAccess:
+def get_admin_emails() -> list[str]:
+  """Return the admin emails."""
+  admin_emails = env('LILAC_AUTH_ADMIN_EMAILS', None)
+  if admin_emails:
+    return admin_emails.split(',')
+  return []
+
+
+def get_user_access(user_info: Optional[UserInfo]) -> UserAccess:
   """Get the user access."""
   auth_enabled = env('LILAC_AUTH_ENABLED')
   if isinstance(auth_enabled, str):
     auth_enabled = auth_enabled.lower() == 'true'
-  if auth_enabled:
+
+  admin_emails = get_admin_emails()
+  is_admin = not auth_enabled or (user_info is not None and user_info.email in admin_emails)
+
+  print('auth_enabled', auth_enabled, 'is_admin', is_admin)
+  if auth_enabled and not is_admin:
     return UserAccess(
+      is_admin=is_admin,
       create_dataset=False,
       dataset=DatasetUserAccess(
         compute_signals=False,
@@ -89,6 +105,7 @@ def get_user_access() -> UserAccess:
         edit_labels=False),
       concept=ConceptUserAccess(delete_any_concept=False))
   return UserAccess(
+    is_admin=is_admin,
     create_dataset=True,
     dataset=DatasetUserAccess(
       compute_signals=True,

--- a/lilac/auth.py
+++ b/lilac/auth.py
@@ -92,7 +92,6 @@ def get_user_access(user_info: Optional[UserInfo]) -> UserAccess:
   admin_emails = get_admin_emails()
   is_admin = not auth_enabled or (user_info is not None and user_info.email in admin_emails)
 
-  print('auth_enabled', auth_enabled, 'is_admin', is_admin)
   if auth_enabled and not is_admin:
     return UserAccess(
       is_admin=is_admin,

--- a/lilac/env.py
+++ b/lilac/env.py
@@ -59,6 +59,14 @@ class LilacEnvironment(BaseModel):
     description='Set to true to enable read-only mode, disabling the ability to add datasets & '
     'compute dataset signals. When enabled, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` and '
     '`LILAC_OAUTH_SECRET_KEY` should also be set.')
+
+  LILAC_AUTH_ADMIN_EMAILS: str = PydanticField(
+    description=
+    'A comma-separated list of Google emails that are allowed full edit-access, as if the '
+    '`LILAC_AUTH_ENABLED` environment flag was disabled. These email addresses are used in concert'
+    'with the `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` environment flags to authenticate '
+    'users.')
+
   GOOGLE_CLIENT_ID: str = PydanticField(
     description=
     'The Google OAuth client ID. Required when `LILAC_AUTH_ENABLED=true`. Details can be found at '

--- a/lilac/router_dataset.py
+++ b/lilac/router_dataset.py
@@ -74,9 +74,11 @@ class ComputeSignalOptions(BaseModel):
 
 
 @router.delete('/{namespace}/{dataset_name}')
-def delete_dataset(namespace: str, dataset_name: str) -> None:
+def delete_dataset(namespace: str, dataset_name: str,
+                   user: Annotated[Optional[UserInfo],
+                                   Depends(get_session_user)]) -> None:
   """Delete the dataset."""
-  if not get_user_access().dataset.delete_dataset:
+  if not get_user_access(user).dataset.delete_dataset:
     raise HTTPException(401, 'User does not have access to delete this dataset.')
 
   dataset = get_dataset(namespace, dataset_name)
@@ -90,10 +92,12 @@ class ComputeSignalResponse(BaseModel):
 
 
 @router.post('/{namespace}/{dataset_name}/compute_signal')
-def compute_signal(namespace: str, dataset_name: str,
-                   options: ComputeSignalOptions) -> ComputeSignalResponse:
+def compute_signal(
+    namespace: str, dataset_name: str, options: ComputeSignalOptions,
+    user: Annotated[Optional[UserInfo], Depends(get_session_user)]) -> ComputeSignalResponse:
   """Compute a signal for a dataset."""
-  if not get_user_access().dataset.compute_signals:
+  print('user=', user)
+  if not get_user_access(user).dataset.compute_signals:
     raise HTTPException(401, 'User does not have access to compute signals over this dataset.')
 
   def _task_compute_signal(namespace: str, dataset_name: str, options_dict: dict,
@@ -126,10 +130,11 @@ class DeleteSignalResponse(BaseModel):
 
 
 @router.delete('/{namespace}/{dataset_name}/delete_signal')
-def delete_signal(namespace: str, dataset_name: str,
-                  options: DeleteSignalOptions) -> DeleteSignalResponse:
+def delete_signal(
+    namespace: str, dataset_name: str, options: DeleteSignalOptions,
+    user: Annotated[Optional[UserInfo], Depends(get_session_user)]) -> DeleteSignalResponse:
   """Delete a signal from a dataset."""
-  if not get_user_access().dataset.delete_signals:
+  if not get_user_access(user).dataset.delete_signals:
     raise HTTPException(401, 'User does not have access to delete this signal.')
 
   dataset = get_dataset(namespace, dataset_name)
@@ -324,9 +329,11 @@ def get_settings(namespace: str, dataset_name: str) -> DatasetSettings:
 
 
 @router.post('/{namespace}/{dataset_name}/settings', response_model_exclude_none=True)
-def update_settings(namespace: str, dataset_name: str, settings: DatasetSettings) -> None:
+def update_settings(namespace: str, dataset_name: str, settings: DatasetSettings,
+                    user: Annotated[Optional[UserInfo],
+                                    Depends(get_session_user)]) -> None:
   """Update settings for the dataset."""
-  if not get_user_access().dataset.compute_signals:
+  if not get_user_access(user).dataset.compute_signals:
     raise HTTPException(401, 'User does not have access to update the settings of this dataset.')
 
   dataset = get_dataset(namespace, dataset_name)
@@ -344,9 +351,10 @@ class AddLabelsOptions(BaseModel):
 
 
 @router.post('/{namespace}/{dataset_name}/labels', response_model_exclude_none=True)
-def add_labels(namespace: str, dataset_name: str, options: AddLabelsOptions) -> int:
+def add_labels(namespace: str, dataset_name: str, options: AddLabelsOptions,
+               user: Annotated[Optional[UserInfo], Depends(get_session_user)]) -> int:
   """"Add a label to the dataset."""
-  if not get_user_access().dataset.edit_labels:
+  if not get_user_access(user).dataset.edit_labels:
     raise HTTPException(401, 'User does not have access to add labels to this dataset.')
 
   sanitized_filters = [
@@ -371,9 +379,10 @@ class RemoveLabelsOptions(BaseModel):
 
 
 @router.delete('/{namespace}/{dataset_name}/labels', response_model_exclude_none=True)
-def remove_labels(namespace: str, dataset_name: str, options: RemoveLabelsOptions) -> int:
+def remove_labels(namespace: str, dataset_name: str, options: RemoveLabelsOptions,
+                  user: Annotated[Optional[UserInfo], Depends(get_session_user)]) -> int:
   """"Add a label to the dataset."""
-  if not get_user_access().dataset.edit_labels:
+  if not get_user_access(user).dataset.edit_labels:
     raise HTTPException(401, 'User does not have access to remove labels from this dataset.')
 
   sanitized_filters = [

--- a/lilac/router_dataset.py
+++ b/lilac/router_dataset.py
@@ -96,7 +96,6 @@ def compute_signal(
     namespace: str, dataset_name: str, options: ComputeSignalOptions,
     user: Annotated[Optional[UserInfo], Depends(get_session_user)]) -> ComputeSignalResponse:
   """Compute a signal for a dataset."""
-  print('user=', user)
   if not get_user_access(user).dataset.compute_signals:
     raise HTTPException(401, 'User does not have access to compute signals over this dataset.')
 

--- a/lilac/server_dataset_test.py
+++ b/lilac/server_dataset_test.py
@@ -1,12 +1,10 @@
-"""Test our public REST API."""
+"""Test our public dataset REST API."""
 import os
 from typing import ClassVar, Iterable, Optional, Type
 
 import pytest
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
-
-from lilac.sources.source_registry import clear_source_registry, register_source
 
 from .config import DatasetSettings
 from .data.dataset import Dataset, DatasetManifest, SelectRowsSchemaResult, SelectRowsSchemaUDF
@@ -30,6 +28,7 @@ from .router_dataset import (
 from .schema import Field, Item, RichData, field, schema
 from .server import app
 from .signal import TextSignal, clear_signal_registry, register_signal
+from .sources.source_registry import clear_source_registry, register_source
 
 client = TestClient(app)
 

--- a/lilac/server_test.py
+++ b/lilac/server_test.py
@@ -1,0 +1,75 @@
+"""Test our public REST API."""
+import os
+
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+from .auth import (
+  AuthenticationInfo,
+  ConceptUserAccess,
+  DatasetUserAccess,
+  UserAccess,
+  UserInfo,
+  get_session_user,
+)
+from .server import app
+
+client = TestClient(app)
+
+
+def test_compute_signal_auth_admin(mocker: MockerFixture) -> None:
+  mocker.patch.dict(os.environ, {'LILAC_AUTH_ENABLED': 'True'})
+  mocker.patch.dict(os.environ, {'LILAC_AUTH_ADMIN_EMAILS': 'test@test.com,test2@test2.com'})
+
+  # Override the session user so we make them an admin.
+  def admin_user() -> UserInfo:
+    return UserInfo(
+      id='1', email='test@test.com', name='test', given_name='test', family_name='test')
+
+  app.dependency_overrides[get_session_user] = admin_user
+
+  url = '/auth_info'
+  response = client.get(url)
+  assert response.status_code == 200
+  assert AuthenticationInfo.model_validate(response.json()) == AuthenticationInfo(
+    user=admin_user(),
+    access=UserAccess(
+      is_admin=True,
+      create_dataset=True,
+      dataset=DatasetUserAccess(
+        compute_signals=True,
+        delete_dataset=True,
+        delete_signals=True,
+        update_settings=True,
+        edit_labels=True),
+      concept=ConceptUserAccess(delete_any_concept=True)),
+    auth_enabled=True)
+
+
+def test_compute_signal_auth_nonadmin(mocker: MockerFixture) -> None:
+  mocker.patch.dict(os.environ, {'LILAC_AUTH_ENABLED': 'True'})
+  mocker.patch.dict(os.environ, {'LILAC_AUTH_ADMIN_EMAILS': 'test@test.com,test2@test2.com'})
+
+  # Override the session user so we make them an admin.
+  def user() -> UserInfo:
+    return UserInfo(
+      id='1', email='test_user@test.com', name='test', given_name='test', family_name='test')
+
+  app.dependency_overrides[get_session_user] = user
+
+  url = '/auth_info'
+  response = client.get(url)
+  assert response.status_code == 200
+  assert AuthenticationInfo.model_validate(response.json()) == AuthenticationInfo(
+    user=user(),
+    access=UserAccess(
+      is_admin=False,
+      create_dataset=False,
+      dataset=DatasetUserAccess(
+        compute_signals=False,
+        delete_dataset=False,
+        delete_signals=False,
+        update_settings=False,
+        edit_labels=False),
+      concept=ConceptUserAccess(delete_any_concept=False)),
+    auth_enabled=True)

--- a/lilac/tasks.py
+++ b/lilac/tasks.py
@@ -29,6 +29,7 @@ from distributed import Future, get_client, get_worker, wait
 from pydantic import BaseModel, TypeAdapter
 from tqdm import tqdm
 
+from .env import env
 from .utils import log, pretty_timedelta
 
 # Disable the heartbeats of the dask workers to avoid dying after computer goes to sleep.
@@ -105,7 +106,7 @@ class TaskManager:
 
     total_memory_gb = psutil.virtual_memory().total / (1024**3)
     self._dask_client = dask_client or Client(
-      asynchronous=True, memory_limit=f'{total_memory_gb} GB', processes=False)
+      asynchronous=not env('LILAC_TEST'), memory_limit=f'{total_memory_gb} GB', processes=False)
 
   async def _update_tasks(self) -> None:
     adapter = TypeAdapter(list[TaskStepInfo])

--- a/web/blueprint/src/lib/components/Page.svelte
+++ b/web/blueprint/src/lib/components/Page.svelte
@@ -70,7 +70,9 @@
               <div
                 class="ml-2 mr-1 flex"
                 use:hoverTooltip={{
-                  text: `Logged into Google as ${$authInfo.data?.user.name} with email ${$authInfo.data?.user.email}`
+                  text:
+                    `Logged into Google as ${$authInfo.data?.user.name} with email ${$authInfo.data?.user.email}.` +
+                    ($authInfo.data?.access.is_admin ? `\n\nLogged in as an adminstrator.` : '')
                 }}
               >
                 {$authInfo.data?.user.given_name}

--- a/web/lib/fastapi_client/models/UserAccess.ts
+++ b/web/lib/fastapi_client/models/UserAccess.ts
@@ -10,6 +10,7 @@ import type { DatasetUserAccess } from './DatasetUserAccess';
  * User access.
  */
 export type UserAccess = {
+    is_admin?: boolean;
     create_dataset: boolean;
     dataset: DatasetUserAccess;
     concept: ConceptUserAccess;


### PR DESCRIPTION
`LILAC_AUTH_ADMIN_EMAILS` is a comma-separated list of Google OAuth emails. When this variable is defined and a user is in the list, they will have full edit access to everything.

When the user is not in the list, it is as if LILAC_AUTH_ENABLED=False.

Towards https://github.com/lilacai/lilac/issues/730