### PR TITLE
Add  allowing non-admin users to add labels, but not create label types.

### DIFF
--- a/lilac/auth.py
+++ b/lilac/auth.py
@@ -23,6 +23,8 @@ class DatasetUserAccess(BaseModel):
   delete_signals: bool
   # Whether the user can update settings.
   update_settings: bool
+  # Whether the user can create a new label type.
+  create_label_type: bool
   # Whether the user can add or remove labels.
   edit_labels: bool
 
@@ -101,7 +103,8 @@ def get_user_access(user_info: Optional[UserInfo]) -> UserAccess:
         delete_dataset=False,
         delete_signals=False,
         update_settings=False,
-        edit_labels=False),
+        create_label_type=False,
+        edit_labels=bool(env('LILAC_AUTH_USER_EDIT_LABELS', False))),
       concept=ConceptUserAccess(delete_any_concept=False))
   return UserAccess(
     is_admin=is_admin,
@@ -111,5 +114,6 @@ def get_user_access(user_info: Optional[UserInfo]) -> UserAccess:
       delete_dataset=True,
       delete_signals=True,
       update_settings=True,
+      create_label_type=True,
       edit_labels=True),
     concept=ConceptUserAccess(delete_any_concept=True))

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -497,6 +497,11 @@ class Dataset(abc.ABC):
     pass
 
   @abc.abstractmethod
+  def get_label_names(self) -> list[str]:
+    """Returns the list of label names that have been added to the dataset."""
+    pass
+
+  @abc.abstractmethod
   def remove_labels(self,
                     name: str,
                     row_ids: Optional[Sequence[str]] = None,

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1382,6 +1382,7 @@ class DatasetDuckDB(Dataset):
 
     # Check if the label file exists.
     labels_filepath = get_labels_sqlite_filename(self.dataset_path, name)
+
     if labels_filepath not in self._label_file_lock:
       self._label_file_lock[labels_filepath] = threading.Lock()
 
@@ -1412,6 +1413,11 @@ class DatasetDuckDB(Dataset):
       sqlite_con.close()
 
     return num_labels
+
+  @override
+  def get_label_names(self) -> list[str]:
+    self.manifest()
+    return list(self._label_schemas.keys())
 
   @override
   def remove_labels(self,

--- a/lilac/data/dataset_labels_test.py
+++ b/lilac/data/dataset_labels_test.py
@@ -95,6 +95,8 @@ def test_add_single_label(make_test_data: TestDataMaker, mocker: MockerFixture) 
       }
     }]
 
+  assert dataset.get_label_names() == ['test_label']
+
 
 @freeze_time(TEST_TIME)
 def test_add_row_labels(make_test_data: TestDataMaker, mocker: MockerFixture) -> None:
@@ -125,6 +127,7 @@ def test_add_row_labels(make_test_data: TestDataMaker, mocker: MockerFixture) ->
     'int': 3,
     'test_label': None
   }]
+  assert dataset.get_label_names() == ['test_label']
 
 
 @freeze_time(TEST_TIME)
@@ -159,6 +162,8 @@ def test_add_row_labels_no_filters(make_test_data: TestDataMaker, mocker: Mocker
       'created': TEST_TIME
     }
   }]
+
+  assert dataset.get_label_names() == ['test_label']
 
 
 @freeze_time(TEST_TIME)
@@ -212,6 +217,8 @@ def test_remove_labels(make_test_data: TestDataMaker, mocker: MockerFixture) -> 
     'test_label': None
   }]
 
+  assert dataset.get_label_names() == ['test_label']
+
 
 @freeze_time(TEST_TIME)
 def test_remove_labels_no_filters(make_test_data: TestDataMaker, mocker: MockerFixture) -> None:
@@ -242,6 +249,8 @@ def test_remove_labels_no_filters(make_test_data: TestDataMaker, mocker: MockerF
     'int': 3,
     'test_label': None
   }]
+
+  assert dataset.get_label_names() == ['test_label']
 
 
 @freeze_time(TEST_TIME)
@@ -274,6 +283,8 @@ def test_label_overwrites(make_test_data: TestDataMaker, mocker: MockerFixture) 
     'int': 3,
     'test_label': None
   }]
+
+  assert dataset.get_label_names() == ['test_label']
 
 
 @freeze_time(TEST_TIME)
@@ -328,6 +339,8 @@ def test_add_multiple_labels(make_test_data: TestDataMaker, mocker: MockerFixtur
     }
   }]
 
+  assert dataset.get_label_names() == ['test_label']
+
 
 @freeze_time(TEST_TIME)
 def test_labels_select_groups(make_test_data: TestDataMaker, mocker: MockerFixture) -> None:
@@ -347,3 +360,5 @@ def test_labels_select_groups(make_test_data: TestDataMaker, mocker: MockerFixtu
 
   assert dataset.select_groups(('test_label', 'label')) == SelectGroupsResult(
     too_many_distinct=False, counts=[('yes', 2), ('no', 1)])
+
+  assert dataset.get_label_names() == ['test_label']

--- a/lilac/env.py
+++ b/lilac/env.py
@@ -67,6 +67,9 @@ class LilacEnvironment(BaseModel):
     'with the `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` environment flags to authenticate '
     'users.')
 
+  LILAC_AUTH_USER_EDIT_LABELS: str = PydanticField(
+    description='Set to true to allow non-admin users to edit labels.')
+
   GOOGLE_CLIENT_ID: str = PydanticField(
     description=
     'The Google OAuth client ID. Required when `LILAC_AUTH_ENABLED=true`. Details can be found at '

--- a/lilac/router_dataset.py
+++ b/lilac/router_dataset.py
@@ -361,6 +361,10 @@ def add_labels(namespace: str, dataset_name: str, options: AddLabelsOptions,
   ]
 
   dataset = get_dataset(namespace, dataset_name)
+  if (not get_user_access(user).dataset.create_label_type and
+      options.label_name not in dataset.get_label_names()):
+    raise HTTPException(401, 'User does not have access to create label types in this dataset.')
+
   return dataset.add_labels(
     name=options.label_name,
     value=options.label_value,

--- a/web/blueprint/src/lib/components/datasetView/AddLabel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/AddLabel.svelte
@@ -32,10 +32,11 @@
   $: datasetName = $datasetViewStore.datasetName;
 
   const authInfo = queryAuthInfo();
+  $: canCreateLabelTypes = $authInfo.data?.access.dataset.create_label_type;
   $: canEditLabels = $authInfo.data?.access.dataset.edit_labels;
 
   $: schemaLabels = $datasetStore.schema && getSchemaLabels($datasetStore.schema);
-  $: newLabelAllowed = /^[A-Za-z0-9_-]+$/.test(comboBoxText);
+  $: newLabelAllowed = /^[A-Za-z0-9_-]+$/.test(comboBoxText) && canCreateLabelTypes;
   $: newLabelItem = {
     id: 'new-label',
     text: comboBoxText,

--- a/web/lib/fastapi_client/models/DatasetUserAccess.ts
+++ b/web/lib/fastapi_client/models/DatasetUserAccess.ts
@@ -11,6 +11,7 @@ export type DatasetUserAccess = {
     delete_dataset: boolean;
     delete_signals: boolean;
     update_settings: boolean;
+    create_label_type: boolean;
     edit_labels: boolean;
 };
 


### PR DESCRIPTION
Now we can set:

```
LILAC_AUTH_ENABLED=True
LILAC_AUTH_ADMIN_EMAILS=hello@world.com
LILAC_AUTH_USER_EDIT_LABELS=True
```

This will give hello@world.com full edit access. Non-admin users can label results, but cannot create label types.

Towards https://github.com/lilacai/lilac/issues/730