### PR TITLE
Fix NaT bug

### DIFF
--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -67,7 +67,9 @@ class SelectRowsResult:
     self._next_iter: Optional[Iterator] = None
 
   def __iter__(self) -> Iterator:
-    return (row.to_dict() for _, row in self._df.iterrows())
+    # Replace NaT timestamps with Nones.
+    df = self._df.replace({pd.NaT: None})  # type: ignore
+    return (row.to_dict() for _, row in df.iterrows())
 
   def __next__(self) -> Item:
     if not self._next_iter:


### PR DESCRIPTION
When there is a timestamp column with null values, in select_rows(), DuckDB's pandas adapter returns a column that contains Panda's NaT type. That type is not JSON-serializable. The error manifests at the FastAPI/pydantic serialization layer as "TypeError: 'float' object cannot be interpreted as an integer" which is not even wrong. 

No unit tests in this change.

