### PR TITLE
Remove redundant dataset_cache call

### DIFF
--- a/lilac/router_dataset.py
+++ b/lilac/router_dataset.py
@@ -26,7 +26,7 @@ from .data.dataset import (
 )
 from .data.dataset import Column as DBColumn
 from .data.dataset import Filter as PyFilter
-from .db_manager import DatasetInfo, get_dataset, list_datasets, remove_dataset_from_cache
+from .db_manager import DatasetInfo, get_dataset, list_datasets
 from .env import get_project_dir
 from .router_utils import RouteErrorHandler
 from .schema import Bin, Path, normalize_path
@@ -87,7 +87,6 @@ def delete_dataset(
 
   dataset = get_dataset(namespace, dataset_name)
   dataset.delete()
-  remove_dataset_from_cache(namespace, dataset_name)
 
 
 class ComputeSignalResponse(BaseModel):


### PR DESCRIPTION
This used to cover for the missing call in dataset_duckdb:

https://github.com/lilacai/lilac/commit/c5f6daf4f43507051cab261d5df8371ba7dd4ec3#diff-7c512603aa2ed9b7e20ee415c0055328b0603d282e6470c9c68e1417de2d5539