### PR TITLE
Add debouncing to file watcher recompilation

### DIFF
--- a/lilac/sources/langsmith.py
+++ b/lilac/sources/langsmith.py
@@ -16,7 +16,7 @@ DEFAULT_LANGCHAIN_ENDPOINT = 'https://api.smith.langchain.com'
 
 
 @router.get('/datasets')
-def get_datasets() -> list[str]:
+def get_langsmith_datasets() -> list[str]:
   """List the datasets in LangSmith."""
   from langsmith import Client
 

--- a/run_server_dev.sh
+++ b/run_server_dev.sh
@@ -15,11 +15,13 @@ poetry run uvicorn lilac.server:app --reload --port 5432 --host 0.0.0.0 \
   --reload-dir lilac &
 pid[1]=$!
 
-poetry run watchmedo shell-command \
+poetry run watchmedo auto-restart \
   --patterns="*.py" \
+  --debounce-interval=1 \
+  --no-restart-on-command-exit \
   --recursive \
-  --command='poetry run python -m scripts.make_fastapi_client' \
-  ./lilac &
+  --directory=lilac \
+  poetry -- -- run python -m scripts.make_fastapi_client &
 pid[0]=$!
 
 # When control+c is pressed, kill all process ids.

--- a/web/blueprint/src/lib/queries/langsmithQueries.ts
+++ b/web/blueprint/src/lib/queries/langsmithQueries.ts
@@ -2,4 +2,8 @@ import {LangsmithService} from '$lilac';
 import {createApiQuery} from './queryUtils';
 
 const LANGSMITH_TAG = 'langsmith';
-export const queryDatasets = createApiQuery(LangsmithService.getDatasets, LANGSMITH_TAG, {});
+export const queryDatasets = createApiQuery(
+  LangsmithService.getLangsmithDatasets,
+  LANGSMITH_TAG,
+  {}
+);

--- a/web/lib/fastapi_client/services/LangsmithService.ts
+++ b/web/lib/fastapi_client/services/LangsmithService.ts
@@ -9,12 +9,12 @@ import { request as __request } from '../core/request';
 export class LangsmithService {
 
     /**
-     * Get Datasets
+     * Get Langsmith Datasets
      * List the datasets in LangSmith.
      * @returns string Successful Response
      * @throws ApiError
      */
-    public static getDatasets(): CancelablePromise<Array<string>> {
+    public static getLangsmithDatasets(): CancelablePromise<Array<string>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/langsmith/datasets',


### PR DESCRIPTION
I also renamed a function that was creating logspam every time the fastapi recompiled - 

/Users/brian/dev/lilac/.venv/lib/python3.11/site-packages/fastapi/openapi/utils.py:207: UserWarning: Duplicate Operation ID get_datasets for function get_datasets at /Users/brian/dev/lilac/lilac/sources/langsmith.py
  warnings.warn(message, stacklevel=1)
