### PR TITLE
Implement CSV direct to parquet

### DIFF
--- a/lilac/load_dataset_test.py
+++ b/lilac/load_dataset_test.py
@@ -19,7 +19,7 @@ from .project import read_project_config
 from .schema import PARQUET_FILENAME_PREFIX, ROWID, DataType, Field, Item, Schema, schema
 from .source import Source, SourceManifest, SourceSchema, clear_source_registry, register_source
 from .tasks import TaskStepId
-from .test_utils import fake_uuid, read_items
+from .test_utils import fake_uuid, retrieve_parquet_rows
 from .utils import DATASETS_DIR_NAME
 
 
@@ -119,7 +119,7 @@ def test_data_loader(
     source=source,
   )
 
-  items = read_items(output_dir, source_manifest.files, source_manifest.data_schema)
+  items = retrieve_parquet_rows(pathlib.Path(output_dir), source_manifest, retain_rowid=True)
 
   assert items == [
     {ROWID: fake_uuid(b'1').hex, 'x': 1, 'y': 'ten'},

--- a/lilac/sources/csv_source.py
+++ b/lilac/sources/csv_source.py
@@ -95,7 +95,7 @@ class CSVSource(Source):
     os.makedirs(output_dir, exist_ok=True)
 
     self._con.sql(
-      f"""SELECT replace(CAST(uuid() AS VARCHAR), ' - ', ' ') AS {ROWID}, * FROM t"""
+      f"SELECT replace(CAST(uuid() AS VARCHAR), ' - ', ' ') AS {ROWID}, * FROM t"
     ).write_parquet(filepath, compression='zstd')
     schema = Schema(fields=self.source_schema().fields.copy())
     return SourceManifest(files=[out_filename], data_schema=schema, source=self)

--- a/lilac/sources/csv_source.py
+++ b/lilac/sources/csv_source.py
@@ -1,13 +1,16 @@
 """CSV source."""
-from typing import ClassVar, Iterable, Optional, cast
+import os
+from typing import ClassVar, Optional, cast
 
 import duckdb
 import pyarrow as pa
 from pydantic import Field
 from typing_extensions import override
 
-from ..schema import Item, arrow_schema_to_schema
-from ..source import Source, SourceSchema
+from ..data import dataset_utils
+from ..schema import PARQUET_FILENAME_PREFIX, ROWID, Schema, arrow_schema_to_schema
+from ..source import Source, SourceManifest, SourceSchema
+from ..tasks import TaskStepId
 from ..utils import download_http_files
 from .duckdb_utils import convert_path_to_duckdb, duckdb_setup
 
@@ -82,13 +85,17 @@ class CSVSource(Source):
     return self._source_schema
 
   @override
-  def yield_items(self) -> Iterable[Item]:
-    """Process the source."""
-    if not self._reader or not self._con:
-      raise RuntimeError('CSV source is not initialized.')
+  def load_to_parquet(self, output_dir: str, task_step_id: Optional[TaskStepId]) -> SourceManifest:
+    del task_step_id
 
-    for batch in self._reader:
-      yield from batch.to_pylist()
+    assert self._con, 'setup() must be called first.'
 
-    self._reader.close()
-    self._con.close()
+    out_filename = dataset_utils.get_parquet_filename(PARQUET_FILENAME_PREFIX, 0, 1)
+    filepath = os.path.join(output_dir, out_filename)
+    os.makedirs(output_dir, exist_ok=True)
+
+    self._con.sql(
+      f"""SELECT replace(CAST(uuid() AS VARCHAR), ' - ', ' ') AS {ROWID}, * FROM t"""
+    ).write_parquet(filepath, compression='zstd')
+    schema = Schema(fields=self.source_schema().fields.copy())
+    return SourceManifest(files=[out_filename], data_schema=schema, source=self)

--- a/lilac/sources/csv_source_test.py
+++ b/lilac/sources/csv_source_test.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 
 from ..schema import schema
 from ..source import SourceSchema
+from ..test_utils import retrieve_parquet_rows
 from .csv_source import LINE_NUMBER_COLUMN, CSVSource
 
 
@@ -35,10 +36,38 @@ def test_csv(tmp_path: pathlib.Path) -> None:
     fields=schema({LINE_NUMBER_COLUMN: 'int64', 'x': 'int64', 'y': 'string'}).fields, num_items=3
   )
 
-  items = list(source.yield_items())
+  manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
+  items = retrieve_parquet_rows(tmp_path, manifest)
 
   assert items == [
     {LINE_NUMBER_COLUMN: 1, 'x': 1, 'y': 'ten'},
     {LINE_NUMBER_COLUMN: 2, 'x': 2, 'y': 'twenty'},
     {LINE_NUMBER_COLUMN: 3, 'x': 3, 'y': 'thirty'},
   ]
+
+
+def test_csv_multifile(tmp_path: pathlib.Path) -> None:
+  csv_rows = [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}, {'x': 3, 'y': 'thirty'}]
+
+  filepaths = []
+  for i in range(3):
+    filename = f'test-dataset-{i}.csv'
+    filepath = os.path.join(tmp_path, filename)
+    with open(filepath, 'w') as f:
+      writer = csv.DictWriter(f, fieldnames=list(csv_rows[0].keys()))
+      writer.writeheader()
+      writer.writerows(csv_rows)
+    filepaths.append(filepath)
+
+  source = CSVSource(filepaths=filepaths)
+  source.setup()
+
+  source_schema = source.source_schema()
+  assert source_schema == SourceSchema(
+    fields=schema({LINE_NUMBER_COLUMN: 'int64', 'x': 'int64', 'y': 'string'}).fields, num_items=9
+  )
+
+  manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
+  items = retrieve_parquet_rows(tmp_path, manifest)
+
+  assert len(items) == 9


### PR DESCRIPTION
Processing is about 6x faster, but because the row counting necessitates a full pass over the data, the actual time savings is only 3x faster. A redesign of the Source api could allow the source to not provide length information until later in the process. That would let the length get sniffed from the finished parquet file's metadata, which is O(1).

Performance comparison:
```
Total time: 31.9333 s
File: /Users/brian/dev/lilac/lilac/load_dataset.py
Function: process_source at line 56

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    56                                           @profile
    57                                           def process_source(
    58                                             project_dir: Union[str, pathlib.Path],
    59                                             config: DatasetConfig,
    60                                             task_step_id: Optional[TaskStepId] = None,
    61                                           ) -> str:
    62                                             """Process a source."""
    63         1         10.0     10.0      0.0    output_dir = get_dataset_output_dir(project_dir, config.namespace, config.name)
    64                                           
    65         1    4330219.0    4e+06     13.6    config.source.setup()
    66         1          0.0      0.0      0.0    try:
    67         1          2.0      2.0      0.0      manifest = config.source.load_to_parquet(output_dir, task_step_id=task_step_id)
    68         1          0.0      0.0      0.0    except NotImplementedError:
    69         1   27292428.0    3e+07     85.5      manifest = slow_process(config.source, output_dir, task_step_id=task_step_id)
    70                                           
    71         2        262.0    131.0      0.0    with open_file(os.path.join(output_dir, MANIFEST_FILENAME), 'w') as f:
    72         1         78.0     78.0      0.0      f.write(manifest.model_dump_json(indent=2, exclude_none=True))
    73                                           
    74         1          1.0      1.0      0.0    if not config.settings:
    75         1       6634.0   6634.0      0.0      dataset = get_dataset(config.namespace, config.name, project_dir)
    76         1     298616.0 298616.0      0.9      settings = default_settings(dataset)
    77         1       4969.0   4969.0      0.0      update_project_dataset_settings(config.namespace, config.name, settings, project_dir)
    78                                           
    79         1         99.0     99.0      0.0    log(f'Dataset "{config.name}" written to {output_dir}')
    80                                           
    81         1          0.0      0.0      0.0    return output_dir



Total time: 10.1912 s
File: /Users/brian/dev/lilac/lilac/load_dataset.py
Function: process_source at line 56

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    56                                           @profile
    57                                           def process_source(
    58                                             project_dir: Union[str, pathlib.Path],
    59                                             config: DatasetConfig,
    60                                             task_step_id: Optional[TaskStepId] = None,
    61                                           ) -> str:
    62                                             """Process a source."""
    63         1         10.0     10.0      0.0    output_dir = get_dataset_output_dir(project_dir, config.namespace, config.name)
    64                                           
    65         1    4371129.0    4e+06     42.9    config.source.setup()
    66         1          0.0      0.0      0.0    try:
    67         1    5533321.0    6e+06     54.3      manifest = config.source.load_to_parquet(output_dir, task_step_id=task_step_id)
    68                                             except NotImplementedError:
    69                                               manifest = slow_process(config.source, output_dir, task_step_id=task_step_id)
    70                                           
    71         2        236.0    118.0      0.0    with open_file(os.path.join(output_dir, MANIFEST_FILENAME), 'w') as f:
    72         1         87.0     87.0      0.0      f.write(manifest.model_dump_json(indent=2, exclude_none=True))
    73                                           
    74         1          2.0      2.0      0.0    if not config.settings:
    75         1      10044.0  10044.0      0.1      dataset = get_dataset(config.namespace, config.name, project_dir)
    76         1     271297.0 271297.0      2.7      settings = default_settings(dataset)
    77         1       5009.0   5009.0      0.0      update_project_dataset_settings(config.namespace, config.name, settings, project_dir)
    78                                           
    79         1         80.0     80.0      0.0    log(f'Dataset "{config.name}" written to {output_dir}')
    80                                           
    81         1          0.0      0.0      0.0    return output_dir
```

Data sanity check / null handling:
```
>>> before.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1120868 entries, 0 to 1120867
Data columns (total 16 columns):
 #   Column            Non-Null Count    Dtype         
---  ------            --------------    -----         
 0   __line_number__   1120868 non-null  int64         
 1   id                1120868 non-null  int64         
 2   type              1120867 non-null  object        
 3   by                1088913 non-null  object        
 4   time              1118699 non-null  datetime64[us]
 5   title             222638 non-null   object        
 6   text              902189 non-null   object        
 7   url               205655 non-null   object        
 8   score             224841 non-null   float64       
 9   parent            886815 non-null   float64       
 10  top_level_parent  1120868 non-null  int64         
 11  descendants       222323 non-null   float64       
 12  kids              457547 non-null   object        
 13  deleted           29787 non-null    object        
 14  dead              43435 non-null    object        
 15  __rowid__         1120868 non-null  object        
dtypes: datetime64[us](1), float64(3), int64(3), object(9)
memory usage: 136.8+ MB
>>> after.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1120868 entries, 0 to 1120867
Data columns (total 16 columns):
 #   Column            Non-Null Count    Dtype         
---  ------            --------------    -----         
 0   __rowid__         1120868 non-null  object        
 1   __line_number__   1120868 non-null  int64         
 2   id                1120868 non-null  int64         
 3   type              1120867 non-null  object        
 4   by                1088913 non-null  object        
 5   time              1118699 non-null  datetime64[us]
 6   title             222638 non-null   object        
 7   text              902189 non-null   object        
 8   url               205655 non-null   object        
 9   score             224841 non-null   float64       
 10  parent            886815 non-null   float64       
 11  top_level_parent  1120868 non-null  int64         
 12  descendants       222323 non-null   float64       
 13  kids              457547 non-null   object        
 14  deleted           29787 non-null    object        
 15  dead              43435 non-null    object        
dtypes: datetime64[us](1), float64(3), int64(3), object(9)
memory usage: 136.8+ MB

```