### PR TITLE
Implement fast json source

### DIFF
--- a/lilac/sources/json_source.py
+++ b/lilac/sources/json_source.py
@@ -67,7 +67,6 @@ class JSONSource(Source):
 
     if self.sample_size:
       self._process_sql = f'SELECT * FROM t USING SAMPLE {num_items}'
-      print(self._process_sql)
     else:
       self._process_sql = 'SELECT * FROM t'
     schema = arrow_schema_to_schema(
@@ -92,8 +91,10 @@ class JSONSource(Source):
     os.makedirs(output_dir, exist_ok=True)
 
     self._con.sql(
-      f"""SELECT replace(CAST(uuid() AS VARCHAR), ' - ', ' ') AS {ROWID}, *
-      FROM ({self._process_sql})"""
+      f"""
+      SELECT replace(CAST(uuid() AS VARCHAR), ' - ', ' ') AS {ROWID}, *
+      FROM ({self._process_sql})
+      """
     ).write_parquet(filepath, compression='zstd')
     schema = Schema(fields=self.source_schema().fields.copy())
     return SourceManifest(files=[out_filename], data_schema=schema, source=self)

--- a/lilac/sources/json_source.py
+++ b/lilac/sources/json_source.py
@@ -1,13 +1,16 @@
 """JSON source."""
-from typing import ClassVar, Iterable, Optional, cast
+import os
+from typing import ClassVar, Optional, cast
 
 import duckdb
 import pyarrow as pa
 from pydantic import Field as PydanticField
 from typing_extensions import override
 
-from ..schema import Item, arrow_schema_to_schema
-from ..source import Source, SourceSchema
+from ..data import dataset_utils
+from ..schema import PARQUET_FILENAME_PREFIX, ROWID, Schema, arrow_schema_to_schema
+from ..source import Source, SourceManifest, SourceSchema
+from ..tasks import TaskStepId
 from ..utils import download_http_files
 from .duckdb_utils import convert_path_to_duckdb, duckdb_setup
 
@@ -63,13 +66,13 @@ class JSONSource(Source):
       num_items = min(num_items, self.sample_size)
 
     if self.sample_size:
-      self._reader = self._con.execute(
-        f'SELECT * FROM t USING SAMPLE {num_items}'
-      ).fetch_record_batch(rows_per_batch=10_000)
+      self._process_sql = f'SELECT * FROM t USING SAMPLE {num_items}'
+      print(self._process_sql)
     else:
-      self._reader = self._con.execute('SELECT * FROM t').fetch_record_batch(rows_per_batch=10_000)
-    # Create the source schema in prepare to share it between process and source_schema.
-    schema = arrow_schema_to_schema(self._reader.schema)
+      self._process_sql = 'SELECT * FROM t'
+    schema = arrow_schema_to_schema(
+      self._con.execute('SELECT * FROM t').fetch_record_batch(1).schema
+    )
     self._source_schema = SourceSchema(fields=schema.fields, num_items=num_items)
 
   @override
@@ -79,13 +82,18 @@ class JSONSource(Source):
     return self._source_schema
 
   @override
-  def yield_items(self) -> Iterable[Item]:
-    """Process the source."""
-    if not self._reader or not self._con:
-      raise RuntimeError('JSON source is not initialized.')
+  def load_to_parquet(self, output_dir: str, task_step_id: Optional[TaskStepId]) -> SourceManifest:
+    del task_step_id
 
-    for batch in self._reader:
-      yield from batch.to_pylist()
+    assert self._con, 'setup() must be called first.'
 
-    self._reader.close()
-    self._con.close()
+    out_filename = dataset_utils.get_parquet_filename(PARQUET_FILENAME_PREFIX, 0, 1)
+    filepath = os.path.join(output_dir, out_filename)
+    os.makedirs(output_dir, exist_ok=True)
+
+    self._con.sql(
+      f"""SELECT replace(CAST(uuid() AS VARCHAR), ' - ', ' ') AS {ROWID}, *
+      FROM ({self._process_sql})"""
+    ).write_parquet(filepath, compression='zstd')
+    schema = Schema(fields=self.source_schema().fields.copy())
+    return SourceManifest(files=[out_filename], data_schema=schema, source=self)

--- a/lilac/sources/json_source_test.py
+++ b/lilac/sources/json_source_test.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from ..schema import schema
 from ..source import SourceSchema
 from .json_source import JSONSource
+from .parquet_source_test import _retrieve_parquet_rows
 
 
 @pytest.fixture(autouse=True)
@@ -33,7 +34,8 @@ def test_simple_json(tmp_path: pathlib.Path) -> None:
     fields=schema({'x': 'int64', 'y': 'string'}).fields, num_items=2
   )
 
-  items = list(source.yield_items())
+  manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
+  items = _retrieve_parquet_rows(tmp_path, manifest)
 
   assert items == [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}]
 
@@ -56,7 +58,8 @@ def test_simple_jsonl(tmp_path: pathlib.Path) -> None:
     fields=schema({'x': 'int64', 'y': 'string'}).fields, num_items=2
   )
 
-  items = list(source.yield_items())
+  manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
+  items = _retrieve_parquet_rows(tmp_path, manifest)
 
   assert items == [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}]
 
@@ -78,7 +81,8 @@ def test_sampling_jsonl(tmp_path: pathlib.Path) -> None:
     fields=schema({'x': 'int64', 'y': 'string'}).fields, num_items=2
   )
 
-  items = list(source.yield_items())
+  manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
+  items = _retrieve_parquet_rows(tmp_path, manifest)
   assert len(items) == 2
 
 
@@ -99,5 +103,6 @@ def test_sampling_greater_than_dataset(tmp_path: pathlib.Path) -> None:
     fields=schema({'x': 'int64', 'y': 'string'}).fields, num_items=3
   )
 
-  items = list(source.yield_items())
+  manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
+  items = _retrieve_parquet_rows(tmp_path, manifest)
   assert len(items) == 3

--- a/lilac/sources/json_source_test.py
+++ b/lilac/sources/json_source_test.py
@@ -8,8 +8,8 @@ from pytest_mock import MockerFixture
 
 from ..schema import schema
 from ..source import SourceSchema
+from ..test_utils import retrieve_parquet_rows
 from .json_source import JSONSource
-from .parquet_source_test import _retrieve_parquet_rows
 
 
 @pytest.fixture(autouse=True)
@@ -35,7 +35,7 @@ def test_simple_json(tmp_path: pathlib.Path) -> None:
   )
 
   manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
-  items = _retrieve_parquet_rows(tmp_path, manifest)
+  items = retrieve_parquet_rows(tmp_path, manifest)
 
   assert items == [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}]
 
@@ -59,7 +59,7 @@ def test_simple_jsonl(tmp_path: pathlib.Path) -> None:
   )
 
   manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
-  items = _retrieve_parquet_rows(tmp_path, manifest)
+  items = retrieve_parquet_rows(tmp_path, manifest)
 
   assert items == [{'x': 1, 'y': 'ten'}, {'x': 2, 'y': 'twenty'}]
 
@@ -82,7 +82,7 @@ def test_sampling_jsonl(tmp_path: pathlib.Path) -> None:
   )
 
   manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
-  items = _retrieve_parquet_rows(tmp_path, manifest)
+  items = retrieve_parquet_rows(tmp_path, manifest)
   assert len(items) == 2
 
 
@@ -104,5 +104,5 @@ def test_sampling_greater_than_dataset(tmp_path: pathlib.Path) -> None:
   )
 
   manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
-  items = _retrieve_parquet_rows(tmp_path, manifest)
+  items = retrieve_parquet_rows(tmp_path, manifest)
   assert len(items) == 3


### PR DESCRIPTION
Speed up jsonl processing by 20x (!!!) by implementing load_to_parquet

```
Total time: 25.4908 s
File: /Users/brian/dev/lilac/lilac/load_dataset.py
Function: process_source at line 56

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    56                                           @profile
    57                                           def process_source(
    58                                             project_dir: Union[str, pathlib.Path],
    59                                             config: DatasetConfig,
    60                                             task_step_id: Optional[TaskStepId] = None,
    61                                           ) -> str:
    62                                             """Process a source."""
    63         1         11.0     11.0      0.0    output_dir = get_dataset_output_dir(project_dir, config.namespace, config.name)
    64                                           
    65         1     161909.0 161909.0      0.6    config.source.setup()
    66         1          0.0      0.0      0.0    try:
    67         1          2.0      2.0      0.0      manifest = config.source.load_to_parquet(output_dir, task_step_id=task_step_id)
    68         1          0.0      0.0      0.0    except NotImplementedError:
    69         1   25007495.0    3e+07     98.1      manifest = slow_process(config.source, output_dir, task_step_id=task_step_id)
    70                                           
    71         2        225.0    112.5      0.0    with open_file(os.path.join(output_dir, MANIFEST_FILENAME), 'w') as f:
    72         1         83.0     83.0      0.0      f.write(manifest.model_dump_json(indent=2, exclude_none=True))
    73                                           
    74         1          1.0      1.0      0.0    if not config.settings:
    75         1       7348.0   7348.0      0.0      dataset = get_dataset(config.namespace, config.name, project_dir)
    76         1     306973.0 306973.0      1.2      settings = default_settings(dataset)
    77         1       6715.0   6715.0      0.0      update_project_dataset_settings(config.namespace, config.name, settings, project_dir)
    78                                           
    79         1         84.0     84.0      0.0    log(f'Dataset "{config.name}" written to {output_dir}')
    80                                           
    81         1          0.0      0.0      0.0    return output_dir

Total time: 1.70995 s
File: /Users/brian/dev/lilac/lilac/load_dataset.py
Function: process_source at line 56

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    56                                           @profile
    57                                           def process_source(
    58                                             project_dir: Union[str, pathlib.Path],
    59                                             config: DatasetConfig,
    60                                             task_step_id: Optional[TaskStepId] = None,
    61                                           ) -> str:
    62                                             """Process a source."""
    63         1         15.0     15.0      0.0    output_dir = get_dataset_output_dir(project_dir, config.namespace, config.name)
    64                                           
    65         1     285699.0 285699.0     16.7    config.source.setup()
    66         1          0.0      0.0      0.0    try:
    67         1    1104814.0    1e+06     64.6      manifest = config.source.load_to_parquet(output_dir, task_step_id=task_step_id)
    68                                             except NotImplementedError:
    69                                               manifest = slow_process(config.source, output_dir, task_step_id=task_step_id)
    70                                           
    71         2        239.0    119.5      0.0    with open_file(os.path.join(output_dir, MANIFEST_FILENAME), 'w') as f:
    72         1         69.0     69.0      0.0      f.write(manifest.model_dump_json(indent=2, exclude_none=True))
    73                                           
    74         1          1.0      1.0      0.0    if not config.settings:
    75         1      12977.0  12977.0      0.8      dataset = get_dataset(config.namespace, config.name, project_dir)
    76         1     300023.0 300023.0     17.5      settings = default_settings(dataset)
    77         1       6030.0   6030.0      0.4      update_project_dataset_settings(config.namespace, config.name, settings, project_dir)
    78                                           
    79         1         81.0     81.0      0.0    log(f'Dataset "{config.name}" written to {output_dir}')
    80                                           
    81         1          0.0      0.0      0.0    return output_dir
```

Ran the same sanity checks on dtypes/null handling as in https://github.com/lilacai/lilac/pull/863