### PR TITLE
Add a nest_under field to dataset.map().

### DIFF
--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -589,7 +589,8 @@ class Dataset(abc.ABC):
   def map(
     self,
     map_fn: MapFn,
-    output_path: Optional[Path] = None,
+    output_column: Optional[str] = None,
+    nest_under: Optional[Path] = None,
     overwrite: bool = False,
     combine_columns: bool = False,
     resolve_span: bool = False,
@@ -600,8 +601,11 @@ class Dataset(abc.ABC):
     Args:
       map_fn: A callable that takes a full row item dictionary, and returns an Item for the
         result. The result Item can be a primitive, like a string.
-      output_path: The output path to write the resulting column to. If not defined, does not
-        serialize the output to disk, and returns the result as an iterator.
+      output_column: The name of the output column to write to. When `nest_under` is False
+        (the default), this will be the name of the top-level column. When `nest_under` is True,
+        the output_column will be the name of the column under the path given by `nest_under`.
+      nest_under: The path to nest the output under. This is useful when emitting annotations, like
+        spans, so they will get hierarchically shown in the UI.
       overwrite: Set to true to overwrite this column if it already exists. If this bit is False,
         an error will be thrown if the column already exists.
       combine_columns: When true, the row passed to the map function will be a deeply nested object

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -761,3 +761,9 @@ def make_signal_parquet_id(
   # Remove the wildcards from the parquet id since they are implicit.
   path = [*[p for p in source_path if p != PATH_WILDCARD], signal.key(is_computed_signal)]
   return '.'.join(path)
+
+
+def get_map_parquet_id(output_path: PathTuple) -> str:
+  """Return a unique identifier for this parquet table."""
+  # Remove the wildcards from the parquet id since they are implicit.
+  return 'map.' + '.'.join(output_path)

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -2372,7 +2372,7 @@ class DatasetDuckDB(Dataset):
       if not manifest.data_schema.has_field(nest_under):
         raise ValueError(f'The `nest_under` column {nest_under} does not exist.')
 
-    # If the user didn't provide an output_colum, we make a temporary one so that we can store the
+    # If the user didn't provide an output_column, we make a temporary one so that we can store the
     # output JSON objects in the cache, represented in the right hierarchy.
     if output_column is None:
       output_column = cast(str, getattr(map_fn, 'name', None)) or map_fn.__name__

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -528,7 +528,7 @@ class DatasetDuckDB(Dataset):
     overwrite: bool = False,
     shard_id: Optional[int] = None,
     shard_count: Optional[int] = None,
-  ) -> Iterable[Item]:
+  ) -> Iterable[tuple[str, Item]]:
     """Returns an iterable of (rowid, item), discluding results in the cache filepath."""
     manifest = self.manifest()
 
@@ -668,7 +668,8 @@ class DatasetDuckDB(Dataset):
   def _compute_disk_cached(
     self,
     transform_fn: Union[Signal, Callable[[Iterable[Item]], Iterable[Optional[Item]]]],
-    output_path: Optional[PathTuple] = None,
+    output_path: PathTuple,
+    jsonl_cache_filepath: str,
     unnest_input_path: Optional[PathTuple] = None,
     overwrite: bool = False,
     combine_columns: bool = False,
@@ -680,24 +681,12 @@ class DatasetDuckDB(Dataset):
   ) -> Iterable[Item]:
     manifest = self.manifest()
 
-    output_path = (
-      output_path or (cast(str, getattr(transform_fn, 'name')),) or (transform_fn.__name__,)
-    )
-    shard_cache_filepath = _jsonl_cache_filepath(
-      namespace=self.namespace,
-      dataset_name=self.dataset_name,
-      key=output_path,
-      project_dir=self.project_dir,
-      is_temporary=output_path is None,
-      shard_id=shard_id,
-      shard_count=shard_count,
-    )
-    os.makedirs(os.path.dirname(shard_cache_filepath), exist_ok=True)
+    os.makedirs(os.path.dirname(jsonl_cache_filepath), exist_ok=True)
     # Overwrite the file if overwrite is True.
-    if overwrite and os.path.exists(shard_cache_filepath):
-      delete_file(shard_cache_filepath)
+    if overwrite and os.path.exists(jsonl_cache_filepath):
+      delete_file(jsonl_cache_filepath)
 
-    use_jsonl_cache = not overwrite and os.path.exists(shard_cache_filepath)
+    use_jsonl_cache = not overwrite and os.path.exists(jsonl_cache_filepath)
 
     con = self.con.cursor()
 
@@ -707,7 +696,7 @@ class DatasetDuckDB(Dataset):
       count_result = con.execute(
         f"""
         SELECT COUNT(*) FROM read_json_auto(
-          '{shard_cache_filepath}',
+          '{jsonl_cache_filepath}',
           IGNORE_ERRORS=true,
           format='newline_delimited')
         """
@@ -719,7 +708,7 @@ class DatasetDuckDB(Dataset):
       unnest_input_path=unnest_input_path,
       combine_columns=combine_columns,
       resolve_span=resolve_span,
-      shard_cache_filepath=shard_cache_filepath,
+      shard_cache_filepath=jsonl_cache_filepath,
       overwrite=overwrite,
       shard_id=shard_id,
       shard_count=shard_count,
@@ -730,11 +719,15 @@ class DatasetDuckDB(Dataset):
 
     # Tee the values so we can use them for the deep flatten and the deep unflatten.
     input_values = (value for (_, value) in inputs_0)
-    input_values_0, input_values_1 = itertools.tee(input_values, 2)
 
+    nested_spec = _split_path_into_subpaths_of_lists(output_path or ())
+
+    output_items: Iterable[Optional[Item]]
     # Flatten the outputs back to the shape of the original data.
     # The output values are flat from the signal. This
     if unnest_input_path:
+      input_values_0, input_values_1 = itertools.tee(input_values, 2)
+
       assert unnest_input_path is not None
       source_path = unnest_input_path
 
@@ -743,27 +736,25 @@ class DatasetDuckDB(Dataset):
         inputs_1, inputs_2 = itertools.tee(inputs_1, 2)
         vector_store = self._get_vector_db_index(embedding_signal.embedding, source_path)
         flat_keys = list(flatten_keys((rowid for (rowid, _) in inputs_2), input_values_0))
-        compute_out = sparse_to_dense_compute(
+        dense_out = sparse_to_dense_compute(
           iter(flat_keys), lambda keys: embedding_signal.vector_compute(keys, vector_store)
         )
       elif isinstance(transform_fn, Signal):
         signal = transform_fn
         flat_input = cast(Iterator[Optional[RichData]], deep_flatten(input_values_0))
-        compute_out = sparse_to_dense_compute(
+        dense_out = sparse_to_dense_compute(
           flat_input, lambda x: signal.compute(cast(Iterable[RichData], x))
         )
       else:
         raise ValueError(f'Unknown type of transform_fn: {type(transform_fn)}')
 
-      spec = _split_path_into_subpaths_of_lists(output_path or ())
+      output_items = deep_unflatten(dense_out, input_values_1)
 
-      nested_out = deep_unflatten(compute_out, input_values_1)
-      output_items = cast(Iterable[Item], wrap_in_dicts(nested_out, spec))
     else:
       assert not isinstance(transform_fn, Signal)
-      output_items = transform_fn(input_values_0)
-      output_col = output_path[-1]
-      output_items = ({output_col: item} for item in output_items)
+      output_items = transform_fn(input_values)
+
+    output_items = cast(Iterable[Item], wrap_in_dicts(output_items, nested_spec))
 
     output_items = (
       {**item, ROWID: rowid} for (rowid, _), item in zip(inputs_1, output_items) if item
@@ -783,7 +774,7 @@ class DatasetDuckDB(Dataset):
     # TODO(nsthorat): Support continuation of embeddings.
     if not isinstance(transform_fn, TextEmbeddingSignal):
       try:
-        with open_file(shard_cache_filepath, 'a') as file:
+        with open_file(jsonl_cache_filepath, 'a') as file:
           for item in output_items:
             json.dump(item, file)
             file.write('\n')
@@ -795,22 +786,15 @@ class DatasetDuckDB(Dataset):
   def _reshard_cache(
     self,
     output_path: PathTuple,
+    jsonl_cache_filepaths: list[str],
+    is_tmp_output: bool = False,
     parquet_filename_prefix: Optional[str] = None,
-    shard_count: Optional[int] = None,
     overwrite: bool = False,
   ) -> tuple[pa.RecordBatchReader, Schema, Optional[str]]:
-    shard_output_filepaths = [
-      _jsonl_cache_filepath(
-        namespace=self.namespace,
-        dataset_name=self.dataset_name,
-        key=output_path,
-        project_dir=self.project_dir,
-        shard_id=i if shard_count is not None else None,
-        shard_count=shard_count,
-      )
-      for i in range(shard_count or 1)
-    ]
+    """Reshards the jsonl cache files into a single parquet file.
 
+    When is_tmp_output is true, the results are still merged to a single iterable PyArrow reader.
+    """
     # Merge all the shard outputs.
     jsonl_view_name = 'tmp_output'
     con = self.con.cursor()
@@ -820,7 +804,7 @@ class DatasetDuckDB(Dataset):
       f"""
       CREATE OR REPLACE VIEW {jsonl_view_name} as (
         SELECT * FROM read_json_auto(
-          {shard_output_filepaths},
+          {jsonl_cache_filepaths},
           ignore_errors=true,
           format='newline_delimited'
         )
@@ -832,7 +816,7 @@ class DatasetDuckDB(Dataset):
     reader = con.execute(f'SELECT * from {jsonl_view_name}').fetch_record_batch(
       rows_per_batch=10_000
     )
-    if output_path is not None:
+    if not is_tmp_output:
       parquet_filepath = _get_parquet_filepath(
         dataset_path=self.dataset_path,
         output_path=output_path,
@@ -897,9 +881,16 @@ class DatasetDuckDB(Dataset):
 
     signal.setup()
 
+    jsonl_cache_filepath = _jsonl_cache_filepath(
+      namespace=self.namespace,
+      dataset_name=self.dataset_name,
+      key=output_path,
+      project_dir=self.project_dir,
+    )
     self._compute_disk_cached(
       transform_fn=signal,
       output_path=output_path,
+      jsonl_cache_filepath=jsonl_cache_filepath,
       unnest_input_path=input_path,
       overwrite=overwrite,
       task_step_id=task_step_id,
@@ -907,7 +898,10 @@ class DatasetDuckDB(Dataset):
     )
 
     _, _, parquet_filepath = self._reshard_cache(
-      output_path=output_path, parquet_filename_prefix='data', overwrite=overwrite
+      output_path=output_path,
+      jsonl_cache_filepaths=[jsonl_cache_filepath],
+      parquet_filename_prefix='data',
+      overwrite=overwrite,
     )
     assert parquet_filepath is not None
     parquet_filename = os.path.basename(parquet_filepath)
@@ -963,9 +957,16 @@ class DatasetDuckDB(Dataset):
 
     output_path = _col_destination_path(signal_col, is_computed_signal=True)
 
+    jsonl_cache_filepath = _jsonl_cache_filepath(
+      namespace=self.namespace,
+      dataset_name=self.dataset_name,
+      key=output_path,
+      project_dir=self.project_dir,
+    )
     output_items = self._compute_disk_cached(
       signal,
       output_path=output_path,
+      jsonl_cache_filepath=jsonl_cache_filepath,
       unnest_input_path=input_path,
       overwrite=overwrite,
       task_step_id=task_step_id,
@@ -1955,26 +1956,33 @@ class DatasetDuckDB(Dataset):
 
   def _resolve_span(
     self, span_path: PathTuple, manifest: DatasetManifest
-  ) -> Optional[tuple[SignalManifest, PathTuple]]:
+  ) -> Optional[tuple[Union[SignalManifest, MapManifest], PathTuple]]:
     schema = manifest.data_schema
     leafs = schema.leafs
     is_span = span_path in leafs and leafs[span_path].dtype == DataType.STRING_SPAN
     if not is_span:
       return None
 
-    # Find the signal manifest that contains the span path.
-    signal_manifest = next(
-      filter(lambda s: schema_contains_path(s.data_schema, span_path), self._signal_manifests)
+    # Find the manifest that contains the span path.
+    manifests: list[Union[SignalManifest, MapManifest]] = (
+      self._signal_manifests + self._map_manifests
+    )
+    span_manifest = next(
+      filter(
+        lambda s: schema_contains_path(s.data_schema, span_path),
+        manifests,
+      )
     )
 
     # Find the original text, which is the closest parent of `path` above the signal root.
     text_path: PathTuple
     for i in reversed(range(len(span_path))):
       sub_path = span_path[:i]
-      if schema.get_field(sub_path).signal is not None:
+      sub_field = schema.get_field(sub_path)
+      if sub_field.signal is not None or sub_field.map is not None:
         # Skip the signal name at the end to get the source path that was enriched.
         text_path = sub_path[:-1]
-        return (signal_manifest, text_path)
+        return (span_manifest, text_path)
 
     raise ValueError('Cannot find the source path for the enriched path: {path}')
 
@@ -2339,63 +2347,93 @@ class DatasetDuckDB(Dataset):
   def map(
     self,
     map_fn: MapFn,
-    output_path: Optional[Path] = None,
+    output_column: Optional[str] = None,
+    nest_under: Optional[Path] = None,
     overwrite: bool = False,
     combine_columns: bool = False,
     resolve_span: bool = False,
     num_jobs: int = 1,
   ) -> Iterable[Item]:
-    is_tmp_output = output_path is None
-    if output_path:
-      output_path = normalize_path(output_path)
-      if len(output_path) > 1:
-        raise ValueError(
-          'Mapping to a nested path is not yet supported. If you need this, please '
-          'file an issue and we will fix it. '
-          'For now, the output path needs to be a top-level column.'
-        )
+    is_tmp_output = output_column is None
 
-      output_column = output_path[0]
+    manifest = self.manifest()
 
-      manifest = self.manifest()
+    # Validate output_column and nest_under.
+    if nest_under is not None:
+      nest_under = normalize_path(nest_under)
+      if output_column is None:
+        raise ValueError('When using `nest_under`, you must specify an output column name.')
+
+      # Make sure nest_under does not contain any repeated values.
+      for path_part in nest_under:
+        if path_part == PATH_WILDCARD:
+          raise ValueError('Nesting map outputs under a repeated field is not yet supported.')
+
+      if not manifest.data_schema.has_field(nest_under):
+        raise ValueError(f'The `nest_under` column {nest_under} does not exist.')
+
+    # If the user didn't provide an output_colum, we make a temporary one so that we can store the
+    # output JSON objects in the cache, represented in the right hierarchy.
+    if output_column is None:
+      output_column = cast(str, getattr(map_fn, 'name', None)) or map_fn.__name__
+
+    if nest_under is not None:
+      output_path = (*nest_under, output_column)
+    else:
+      output_path = (output_column,)
+
+    parquet_filepath: Optional[str] = None
+    if not is_tmp_output:
       if manifest.data_schema.has_field(output_path):
         if overwrite:
           field = manifest.data_schema.get_field(output_path)
           if field.map is None:
             raise ValueError(f'{output_path} is not a map column so it cannot be overwritten.')
           # Delete the parquet file and map manifest.
+          assert output_column is not None
           parquet_filepath = os.path.join(
             self.dataset_path, get_parquet_filename(output_column, shard_index=0, num_shards=1)
           )
-          delete_file(parquet_filepath)
+          if os.path.exists(parquet_filepath):
+            delete_file(parquet_filepath)
 
           map_manifest_filepath = os.path.join(
             self.dataset_path, f'{output_column}.{MAP_MANIFEST_SUFFIX}'
           )
-          delete_file(map_manifest_filepath)
+          if os.path.exists(map_manifest_filepath):
+            delete_file(map_manifest_filepath)
 
         else:
           raise ValueError(
-            f'Cannot map to path "{output_path}" which already exists in the dataset.'
+            f'Cannot map to path "{output_column}" which already exists in the dataset. '
+            'Use overwrite=True to overwrite the column.'
           )
-    else:
-      output_column = map_fn.__name__
 
-    output_path = (output_column,)
     num_jobs = get_task_manager().get_num_workers() if num_jobs == -1 else num_jobs
 
     task_ids = []
+    jsonl_cache_filepaths: list[str] = []
     for i in range(num_jobs):
-      output_col_desc_suffix = f' to "{output_column}"' if output_path else ''
+      output_col_desc_suffix = f' to "{output_column}"' if output_column else ''
       task_id = get_task_manager().task_id(
-        name=f'[{self.namespace}/{self.dataset_name}][{i} / {num_jobs}] map '
+        name=f'[{self.namespace}/{self.dataset_name}][shard {i}/{num_jobs}] map '
         f'"{map_fn.__name__}"{output_col_desc_suffix}',
+      )
+      jsonl_cache_filepath = _jsonl_cache_filepath(
+        namespace=self.namespace,
+        dataset_name=self.dataset_name,
+        key=output_path,
+        project_dir=self.project_dir,
+        is_temporary=is_tmp_output,
+        shard_id=i,
+        shard_count=num_jobs,
       )
       get_task_manager().execute(
         task_id,
         self._map_worker,
         map_fn,
-        output_column,
+        output_path,
+        jsonl_cache_filepath,
         i,
         num_jobs,
         overwrite,
@@ -2404,36 +2442,39 @@ class DatasetDuckDB(Dataset):
         (task_id, 0),
       )
       task_ids.append(task_id)
+      jsonl_cache_filepaths.append(jsonl_cache_filepath)
 
     # Wait for the tasks to finish before reading the outputs.
     get_task_manager().wait(task_ids)
 
-    reader, output_schema, parquet_filename = self._reshard_cache(
+    reader, map_schema, parquet_filepath = self._reshard_cache(
       output_path=output_path,
-      shard_count=num_jobs,
+      jsonl_cache_filepaths=jsonl_cache_filepaths,
+      is_tmp_output=is_tmp_output,
     )
 
     if not is_tmp_output:
-      assert parquet_filename is not None
+      assert parquet_filepath is not None
 
-      output_schema.fields[output_column].map = MapInfo(
+      map_field_root = map_schema.get_field(output_path)
+
+      map_field_root.map = MapInfo(
         fn_name=map_fn.__name__, fn_source=inspect.getsource(map_fn), date_created=datetime.now()
       )
 
-      # Write the map data to the root of the dataset.
-      map_manifest_filepath = os.path.join(
-        self.dataset_path, f'{output_column}.{MAP_MANIFEST_SUFFIX}'
-      )
+      parquet_dir = os.path.dirname(parquet_filepath)
+      map_manifest_filepath = os.path.join(parquet_dir, f'{output_column}.{MAP_MANIFEST_SUFFIX}')
+      parquet_filename = os.path.basename(parquet_filepath)
       map_manifest = MapManifest(
         files=[parquet_filename],
-        data_schema=output_schema,
+        data_schema=map_schema,
         parquet_id=output_column,
         py_version=metadata.version('lilac'),
       )
       with open_file(map_manifest_filepath, 'w') as f:
         f.write(map_manifest.model_dump_json(exclude_none=True, indent=2))
 
-      parquet_filepath = os.path.join(self.dataset_path, parquet_filename)
+      parquet_filepath = os.path.join(self.dataset_path, parquet_filepath)
       log(f'Wrote map output to {parquet_filepath}')
 
     return DuckDBMapOutput(pyarrow_reader=reader, output_column=output_column)
@@ -2441,7 +2482,8 @@ class DatasetDuckDB(Dataset):
   def _map_worker(
     self,
     map_fn: MapFn,
-    output_column: str,
+    output_path: PathTuple,
+    jsonl_cache_filepath: str,
     job_id: int,
     job_count: int,
     overwrite: bool = False,
@@ -2455,14 +2497,15 @@ class DatasetDuckDB(Dataset):
 
     self._compute_disk_cached(
       _map_iterable,
-      output_path=(output_column,),
+      output_path=output_path,
+      jsonl_cache_filepath=jsonl_cache_filepath,
       overwrite=overwrite,
       combine_columns=combine_columns,
       resolve_span=resolve_span,
       shard_id=job_id,
       shard_count=job_count,
       task_step_id=task_step_id,
-      task_step_description=f'[{job_id} / {job_count}] map "{map_fn.__name__}"',
+      task_step_description=f'[shard {job_id+1}/{job_count}] map "{map_fn.__name__}"',
     )
 
   @override
@@ -2541,7 +2584,7 @@ def _inner_select(
   sub_paths: list[PathTuple],
   inner_var: Optional[str] = None,
   empty: bool = False,
-  span_from: Optional[tuple[SignalManifest, PathTuple]] = None,
+  span_from: Optional[tuple[Union[SignalManifest, MapManifest], PathTuple]] = None,
 ) -> str:
   """Recursively generate the inner select statement for a list of sub paths."""
   current_sub_path = sub_paths[0]
@@ -2594,7 +2637,7 @@ def _select_sql(
   flatten: bool,
   unnest: bool,
   empty: bool = False,
-  span_from: Optional[tuple[SignalManifest, PathTuple]] = None,
+  span_from: Optional[tuple[Union[SignalManifest, MapManifest], PathTuple]] = None,
 ) -> str:
   """Create a select column for a path.
 

--- a/lilac/data/dataset_export_test.py
+++ b/lilac/data/dataset_export_test.py
@@ -51,8 +51,8 @@ def test_export_to_json(make_test_data: TestDataMaker, tmp_path: pathlib.Path) -
     parsed_items = [json.loads(line) for line in f.readlines()]
 
   assert parsed_items == [
-    {'text': 'hello', 'text.test_signal': {'len': 5, 'flen': 5.0}},
-    {'text': 'everybody', 'text.test_signal': {'len': 9, 'flen': 9.0}},
+    {'text': 'hello', 'text.test_signal.len': 5, 'text.test_signal.flen': 5.0},
+    {'text': 'everybody', 'text.test_signal.len': 9, 'text.test_signal.flen': 9.0},
   ]
 
   # Download a subset of columns with filter.
@@ -74,7 +74,9 @@ def test_export_to_json(make_test_data: TestDataMaker, tmp_path: pathlib.Path) -
   with open(filepath) as f:
     parsed_items = [json.loads(line) for line in f.readlines()]
 
-  assert parsed_items == [{'text': 'hello', 'text.test_signal': {'len': 5, 'flen': 5.0}}]
+  assert parsed_items == [
+    {'text': 'hello', 'text.test_signal.len': 5, 'text.test_signal.flen': 5.0}
+  ]
 
 
 def test_export_to_csv(make_test_data: TestDataMaker, tmp_path: pathlib.Path) -> None:
@@ -89,9 +91,9 @@ def test_export_to_csv(make_test_data: TestDataMaker, tmp_path: pathlib.Path) ->
     rows = list(csv.reader(f))
 
   assert rows == [
-    ['text', 'text.test_signal'],
-    ['hello', "{'len': 5, 'flen': 5.0}"],
-    ['everybody', "{'len': 9, 'flen': 9.0}"],
+    ['text', 'text.test_signal.len', 'text.test_signal.flen'],
+    ['hello', '5', '5.0'],
+    ['everybody', '9', '9.0'],
   ]
 
 
@@ -106,8 +108,16 @@ def test_export_to_parquet(make_test_data: TestDataMaker, tmp_path: pathlib.Path
   df = pd.read_parquet(filepath)
   expected_df = pd.DataFrame(
     [
-      {'text': 'hello', 'text.test_signal': {'len': 5, 'flen': 5.0}},
-      {'text': 'everybody', 'text.test_signal': {'len': 9, 'flen': 9.0}},
+      {
+        'text': 'hello',
+        'text.test_signal.len': 5,
+        'text.test_signal.flen': 5.0,
+      },
+      {
+        'text': 'everybody',
+        'text.test_signal.len': 9,
+        'text.test_signal.flen': 9.0,
+      },
     ]
   )
   pd.testing.assert_frame_equal(df, expected_df)
@@ -121,8 +131,16 @@ def test_export_to_pandas(make_test_data: TestDataMaker) -> None:
   df = dataset.to_pandas()
   expected_df = pd.DataFrame(
     [
-      {'text': 'hello', 'text.test_signal': {'len': 5, 'flen': 5.0}},
-      {'text': 'everybody', 'text.test_signal': {'len': 9, 'flen': 9.0}},
+      {
+        'text': 'hello',
+        'text.test_signal.len': 5,
+        'text.test_signal.flen': 5.0,
+      },
+      {
+        'text': 'everybody',
+        'text.test_signal.len': 9,
+        'text.test_signal.flen': 9.0,
+      },
     ]
   )
   pd.testing.assert_frame_equal(df, expected_df)
@@ -159,7 +177,7 @@ def test_label_and_export_by_excluding(
   with open(filepath) as f:
     parsed_items = [json.loads(line) for line in f.readlines()]
 
-  assert parsed_items == [{'delete': None, 'text': 'a'}]
+  assert parsed_items == [{'delete.created': None, 'delete.label': None, 'text': 'a'}]
 
   # Download only the 'deleted' label.
   filepath = tmp_path / 'dataset.json'
@@ -169,8 +187,8 @@ def test_label_and_export_by_excluding(
     parsed_items = [json.loads(line) for line in f.readlines()]
 
   assert parsed_items == [
-    {'delete': {'created': str(TEST_TIME), 'label': 'true'}, 'text': 'b'},
-    {'delete': {'created': str(TEST_TIME), 'label': 'true'}, 'text': 'c'},
+    {'delete.created': str(TEST_TIME), 'delete.label': 'true', 'text': 'b'},
+    {'delete.created': str(TEST_TIME), 'delete.label': 'true', 'text': 'c'},
   ]
 
 

--- a/lilac/data/dataset_labels_test.py
+++ b/lilac/data/dataset_labels_test.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 import pytest
 from freezegun import freeze_time
+from pandas import Timestamp
 from pytest_mock import MockerFixture
 
 from ..schema import PATH_WILDCARD, ROWID, Item, field, schema
@@ -50,15 +51,37 @@ def test_add_single_label(make_test_data: TestDataMaker, mocker: MockerFixture) 
   )
 
   assert list(dataset.select_rows([PATH_WILDCARD])) == [
-    {'str': 'a', 'int': 1, 'test_label': {'label': 'true', 'created': TEST_TIME}},
-    {'str': 'b', 'int': 2, 'test_label': None},
-    {'str': 'c', 'int': 3, 'test_label': None},
+    {
+      'str': 'a',
+      'int': 1,
+      'test_label.label': 'true',
+      'test_label.created': Timestamp(TEST_TIME),
+    },
+    {
+      'str': 'b',
+      'int': 2,
+      'test_label.label': None,
+      'test_label.created': None,
+    },
+    {
+      'str': 'c',
+      'int': 3,
+      'test_label.label': None,
+      'test_label.created': None,
+    },
   ]
 
   # Make sure we can filter by the label.
   assert list(
     dataset.select_rows([PATH_WILDCARD], filters=[('test_label.label', 'equals', 'true')])
-  ) == [{'str': 'a', 'int': 1, 'test_label': {'label': 'true', 'created': TEST_TIME}}]
+  ) == [
+    {
+      'str': 'a',
+      'int': 1,
+      'test_label.label': 'true',
+      'test_label.created': Timestamp(TEST_TIME),
+    },
+  ]
 
   assert dataset.get_label_names() == ['test_label']
 
@@ -70,9 +93,24 @@ def test_add_row_labels(make_test_data: TestDataMaker, mocker: MockerFixture) ->
   num_labels = dataset.add_labels('test_label', row_ids=['1', '2'])
   assert num_labels == 2
   assert list(dataset.select_rows([PATH_WILDCARD])) == [
-    {'str': 'a', 'int': 1, 'test_label': {'label': 'true', 'created': TEST_TIME}},
-    {'str': 'b', 'int': 2, 'test_label': {'label': 'true', 'created': TEST_TIME}},
-    {'str': 'c', 'int': 3, 'test_label': None},
+    {
+      'str': 'a',
+      'int': 1,
+      'test_label.label': 'true',
+      'test_label.created': Timestamp(TEST_TIME),
+    },
+    {
+      'str': 'b',
+      'int': 2,
+      'test_label.label': 'true',
+      'test_label.created': Timestamp(TEST_TIME),
+    },
+    {
+      'str': 'c',
+      'int': 3,
+      'test_label.label': None,
+      'test_label.created': None,
+    },
   ]
   assert dataset.get_label_names() == ['test_label']
 
@@ -84,9 +122,24 @@ def test_add_row_labels_no_filters(make_test_data: TestDataMaker, mocker: Mocker
   num_labels = dataset.add_labels('test_label')
   assert num_labels == 3
   assert list(dataset.select_rows([PATH_WILDCARD])) == [
-    {'str': 'a', 'int': 1, 'test_label': {'label': 'true', 'created': TEST_TIME}},
-    {'str': 'b', 'int': 2, 'test_label': {'label': 'true', 'created': TEST_TIME}},
-    {'str': 'c', 'int': 3, 'test_label': {'label': 'true', 'created': TEST_TIME}},
+    {
+      'str': 'a',
+      'int': 1,
+      'test_label.label': 'true',
+      'test_label.created': TEST_TIME,
+    },
+    {
+      'str': 'b',
+      'int': 2,
+      'test_label.label': 'true',
+      'test_label.created': TEST_TIME,
+    },
+    {
+      'str': 'c',
+      'int': 3,
+      'test_label.label': 'true',
+      'test_label.created': TEST_TIME,
+    },
   ]
 
   assert dataset.get_label_names() == ['test_label']
@@ -104,9 +157,24 @@ def test_remove_labels(make_test_data: TestDataMaker, mocker: MockerFixture) -> 
   assert num_labels == 1
 
   assert list(dataset.select_rows([PATH_WILDCARD], sort_by=['int'], sort_order=SortOrder.ASC)) == [
-    {'str': 'a', 'int': 1, 'test_label': None},
-    {'str': 'b', 'int': 2, 'test_label': {'label': 'true', 'created': TEST_TIME}},
-    {'str': 'c', 'int': 3, 'test_label': {'label': 'true', 'created': TEST_TIME}},
+    {
+      'str': 'a',
+      'int': 1,
+      'test_label.label': None,
+      'test_label.created': None,
+    },
+    {
+      'str': 'b',
+      'int': 2,
+      'test_label.label': 'true',
+      'test_label.created': Timestamp(TEST_TIME),
+    },
+    {
+      'str': 'c',
+      'int': 3,
+      'test_label.label': 'true',
+      'test_label.created': Timestamp(TEST_TIME),
+    },
   ]
 
   # Remove by a filter.
@@ -152,9 +220,9 @@ def test_label_overwrites(make_test_data: TestDataMaker, mocker: MockerFixture) 
   assert num_labels == 1
 
   assert list(dataset.select_rows([PATH_WILDCARD])) == [
-    {'str': 'a', 'int': 1, 'test_label': {'label': 'no', 'created': TEST_TIME}},
-    {'str': 'b', 'int': 2, 'test_label': None},
-    {'str': 'c', 'int': 3, 'test_label': None},
+    {'str': 'a', 'int': 1, 'test_label.label': 'no', 'test_label.created': Timestamp(TEST_TIME)},
+    {'str': 'b', 'int': 2, 'test_label.label': None, 'test_label.created': None},
+    {'str': 'c', 'int': 3, 'test_label.label': None, 'test_label.created': None},
   ]
 
   assert dataset.get_label_names() == ['test_label']
@@ -186,9 +254,9 @@ def test_add_multiple_labels(make_test_data: TestDataMaker, mocker: MockerFixtur
   )
 
   assert list(dataset.select_rows([PATH_WILDCARD])) == [
-    {'str': 'a', 'int': 1, 'test_label': {'label': 'no', 'created': TEST_TIME}},
-    {'str': 'b', 'int': 2, 'test_label': {'label': 'yes', 'created': TEST_TIME}},
-    {'str': 'c', 'int': 3, 'test_label': {'label': 'yes', 'created': TEST_TIME}},
+    {'str': 'a', 'int': 1, 'test_label.label': 'no', 'test_label.created': TEST_TIME},
+    {'str': 'b', 'int': 2, 'test_label.label': 'yes', 'test_label.created': TEST_TIME},
+    {'str': 'c', 'int': 3, 'test_label.label': 'yes', 'test_label.created': TEST_TIME},
   ]
 
   assert dataset.get_label_names() == ['test_label']

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -1,6 +1,7 @@
 """Tests for dataset.map()."""
 
 import inspect
+import re
 from typing import ClassVar, Iterable, Literal, Optional
 
 import pytest
@@ -8,7 +9,17 @@ from distributed import Client, LocalCluster
 from typing_extensions import override
 
 from .. import tasks
-from ..schema import PATH_WILDCARD, VALUE_KEY, Field, Item, MapInfo, RichData, field, schema
+from ..schema import (
+  PATH_WILDCARD,
+  VALUE_KEY,
+  Field,
+  Item,
+  MapInfo,
+  RichData,
+  field,
+  lilac_span,
+  schema,
+)
 from ..signal import TextSignal, clear_signal_registry, register_signal
 from ..source import clear_source_registry, register_source
 from ..test_utils import (
@@ -68,7 +79,7 @@ def test_map(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMaker) -> None
     return row['text'].upper()
 
   # Write the output to a new column.
-  dataset.map(_map_fn, output_path='text_upper', num_jobs=num_jobs)
+  dataset.map(_map_fn, output_column='text_upper', num_jobs=num_jobs)
 
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
@@ -114,7 +125,7 @@ def test_map_signal(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMaker) 
     return {'result': f'{row["text.test_signal"]["firstchar"]}_{len(row["text"])}'}
 
   # Write the output to a new column.
-  dataset.map(_map_fn, output_path='output_text', num_jobs=num_jobs)
+  dataset.map(_map_fn, output_column='output_text', num_jobs=num_jobs)
 
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
@@ -173,7 +184,7 @@ def test_map_job_id(make_test_data: TestDataMaker, test_dask_logger: TestDaskLog
     test_dask_logger.log_event(job_id)
     return {}
 
-  dataset.map(_map_fn, output_path='map_id', num_jobs=3)
+  dataset.map(_map_fn, output_column='map_id', num_jobs=3)
 
   assert set(test_dask_logger.get_logs()) == set([0, 1, 2])
 
@@ -206,7 +217,7 @@ def test_map_continuation(
 
   # Write the output to a new column.
   with pytest.raises(Exception):
-    dataset.map(_map_fn_1, output_path='map_id', num_jobs=num_jobs)
+    dataset.map(_map_fn_1, output_column='map_id', num_jobs=num_jobs)
 
   # The schema should not reflect the output of the map as it didn't finish.
   assert dataset.manifest() == DatasetManifest(
@@ -226,7 +237,7 @@ def test_map_continuation(
 
   test_dask_logger.clear_logs()
 
-  dataset.map(_map_fn_2, output_path='map_id', num_jobs=num_jobs)
+  dataset.map(_map_fn_2, output_column='map_id', num_jobs=num_jobs)
 
   # The row_id=1 should be called for the continuation.
   assert 1 in test_dask_logger.get_logs()
@@ -286,11 +297,11 @@ def test_map_continuation_overwrite(
 
   # Write the output to a new column.
   with pytest.raises(Exception):
-    dataset.map(_map_fn_1, output_path='map_id', num_jobs=num_jobs)
+    dataset.map(_map_fn_1, output_column='map_id', num_jobs=num_jobs)
 
   test_dask_logger.clear_logs()
 
-  dataset.map(_map_fn_2, output_path='map_id', overwrite=True, num_jobs=num_jobs)
+  dataset.map(_map_fn_2, output_column='map_id', overwrite=True, num_jobs=num_jobs)
 
   # Map should be called for all ids.
   assert sorted(test_dask_logger.get_logs()) == [0, 1, 2]
@@ -333,17 +344,17 @@ def test_map_overwrite(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMake
     return prefix + row['text']
 
   # Write the output to a new column.
-  dataset.map(_map_fn, output_path='map_text', num_jobs=num_jobs)
+  dataset.map(_map_fn, output_column='map_text', num_jobs=num_jobs)
 
   rows = list(dataset.select_rows([PATH_WILDCARD]))
   assert rows == [{'text': 'a', 'map_text': '0a'}, {'text': 'b', 'map_text': '0b'}]
 
   with pytest.raises(ValueError, match=' which already exists in the dataset'):
-    dataset.map(_map_fn, output_path='map_text', combine_columns=False)
+    dataset.map(_map_fn, output_column='map_text', combine_columns=False)
 
   prefix = '1'
   # Overwrite the output
-  dataset.map(_map_fn, output_path='map_text', overwrite=True)
+  dataset.map(_map_fn, output_column='map_text', overwrite=True)
 
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
@@ -370,39 +381,28 @@ def test_map_overwrite(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMake
 def test_map_no_output_col(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data([{'text': 'a sentence'}, {'text': 'b sentence'}])
 
-  signal = TestFirstCharSignal()
-  dataset.compute_signal(signal, 'text')
-
   def _map_fn(row: Item, job_id: int) -> Item:
-    return {'result': f'{row["text.test_signal"]["firstchar"]}_{len(row["text"])}'}
+    return row['text'].upper()
 
-  dataset.map(_map_fn, combine_columns=False)
+  map_output = dataset.map(_map_fn)
+
+  assert list(map_output) == [
+    'A SENTENCE',
+    'B SENTENCE',
+  ]
 
   # The manifest should contain no new columns.
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
     dataset_name=TEST_DATASET_NAME,
-    data_schema=schema(
-      {
-        'text': field(
-          'string',
-          fields={
-            'test_signal': field(
-              fields={'len': 'int32', 'firstchar': 'string'}, signal={'signal_name': 'test_signal'}
-            )
-          },
-        )
-      }
-    ),
+    data_schema=schema({'text': field('string')}),
     num_items=2,
     source=TestSource(),
   )
 
+  # The new columns should not be saved anywhere.
   rows = list(dataset.select_rows([PATH_WILDCARD]))
-  assert rows == [
-    {'text': 'a sentence', 'text.test_signal': {'firstchar': 'a', 'len': 10}},
-    {'text': 'b sentence', 'text.test_signal': {'firstchar': 'b', 'len': 10}},
-  ]
+  assert rows == [{'text': 'a sentence'}, {'text': 'b sentence'}]
 
 
 def test_map_chained(make_test_data: TestDataMaker) -> None:
@@ -411,12 +411,12 @@ def test_map_chained(make_test_data: TestDataMaker) -> None:
   def _split_fn(row: Item, job_id: int) -> Item:
     return row['text'].split(' ')
 
-  dataset.map(_split_fn, output_path='splits', combine_columns=False)
+  dataset.map(_split_fn, output_column='splits', combine_columns=False)
 
   def _rearrange_fn(row: Item, job_id: int) -> Item:
     return row['splits'][1] + ' ' + row['splits'][0]
 
-  dataset.map(_rearrange_fn, output_path='rearrange', combine_columns=False)
+  dataset.map(_rearrange_fn, output_column='rearrange', combine_columns=False)
 
   rows = list(dataset.select_rows([PATH_WILDCARD]))
   assert rows == [
@@ -462,7 +462,7 @@ def test_map_combine_columns(make_test_data: TestDataMaker) -> None:
     return {'result': f'{row["text"]["test_signal"]["firstchar"]}_{len(row["text"][VALUE_KEY])}'}
 
   # Write the output to a new column.
-  dataset.map(_map_fn, output_path='output_text', combine_columns=True)
+  dataset.map(_map_fn, output_column='output_text', combine_columns=True)
 
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
@@ -510,7 +510,7 @@ def test_signal_on_map_output(make_test_data: TestDataMaker) -> None:
   def _map_fn(row: Item, job_id: int) -> Item:
     return row['text'] + ' ' + row['text']
 
-  dataset.map(_map_fn, output_path='double', combine_columns=False)
+  dataset.map(_map_fn, output_column='double', combine_columns=False)
 
   # Compute a signal on the map output.
   signal = TestFirstCharSignal()
@@ -559,11 +559,116 @@ def test_signal_on_map_output(make_test_data: TestDataMaker) -> None:
   ]
 
 
-def test_map_non_root_output_errors(make_test_data: TestDataMaker) -> None:
-  dataset = make_test_data([{'text': 'abcd'}, {'text': 'efghi'}])
+def test_map_nest_under(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data([{'parent': {'text': 'a'}}, {'parent': {'text': 'abc'}}])
+
+  def _map_fn(row: Item, job_id: int) -> Item:
+    return {'value': len(row['parent']['text'])}
+
+  dataset.map(_map_fn, output_column='len', nest_under=('parent', 'text'))
+
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'parent': field(
+          fields={
+            'text': field(
+              'string',
+              fields={
+                'len': field(
+                  fields={'value': 'int64'},
+                  map=MapInfo(
+                    fn_name='_map_fn',
+                    fn_source=inspect.getsource(_map_fn),
+                    date_created=TEST_TIME,
+                  ),
+                )
+              },
+            )
+          }
+        ),
+      }
+    ),
+    num_items=2,
+    source=TestSource(),
+  )
+
+  rows = list(dataset.select_rows([PATH_WILDCARD], combine_columns=True))
+  assert rows == [
+    {
+      'parent': {'text': enriched_item('a', {'len': {'value': 1}})},
+    },
+    {
+      'parent': {'text': enriched_item('abc', {'len': {'value': 3}})},
+    },
+  ]
+
+
+def test_map_span(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data([{'text': 'ab'}, {'text': 'bc'}])
+
+  # Return coordinates of 'b'.
+  def _map_fn(row: dict, job_id: int) -> Item:
+    return [
+      lilac_span(m.start(), m.end(), {'len': m.end() - m.start()})
+      for m in re.finditer('b', row['text'])
+    ]
+
+  dataset.map(_map_fn, output_column='b_span', nest_under='text')
+
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'text': field(
+          'string',
+          fields={
+            'b_span': field(
+              fields=[field(dtype='string_span', fields={'len': 'int64'})],
+              map=MapInfo(
+                fn_name='_map_fn',
+                fn_source=inspect.getsource(_map_fn),
+                date_created=TEST_TIME,
+              ),
+            )
+          },
+        )
+      }
+    ),
+    num_items=2,
+    source=TestSource(),
+  )
+
+  rows = list(dataset.select_rows([PATH_WILDCARD], combine_columns=True))
+  assert rows == [
+    {
+      'text': enriched_item('ab', {'b_span': [lilac_span(1, 2, {'len': 1})]}),
+    },
+    {
+      'text': enriched_item('bc', {'b_span': [lilac_span(0, 1, {'len': 1})]}),
+    },
+  ]
+
+
+def test_map_nest_under_validation(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(
+    [{'text': 'abcd', 'parent': ['a', 'b']}, {'text': 'efghi', 'parent': ['c', 'd']}]
+  )
 
   def _map_fn(row: Item, job_id: int) -> Item:
     return row['text'] + ' ' + row['text']
 
-  with pytest.raises(ValueError, match='Mapping to a nested path is not yet supported'):
-    dataset.map(_map_fn, output_path=('double', 'notroot'), combine_columns=False)
+  with pytest.raises(
+    ValueError, match='Nesting map outputs under a repeated field is not yet supported'
+  ):
+    dataset.map(
+      _map_fn, output_column='output', nest_under=('parent', PATH_WILDCARD), combine_columns=False
+    )
+
+  with pytest.raises(
+    ValueError, match=re.escape("The `nest_under` column ('fake',) does not exist.")
+  ):
+    dataset.map(_map_fn, output_column='output', nest_under=('fake',), combine_columns=False)

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -376,6 +376,23 @@ def test_map_overwrite(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMake
 
   rows = list(dataset.select_rows([PATH_WILDCARD]))
   assert rows == [{'text': 'a', 'map_text': '1a'}, {'text': 'b', 'map_text': '1b'}]
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'text': 'string',
+        'map_text': field(
+          dtype='string',
+          map=MapInfo(
+            fn_name='_map_fn', fn_source=inspect.getsource(_map_fn), date_created=TEST_TIME
+          ),
+        ),
+      }
+    ),
+    num_items=2,
+    source=TestSource(),
+  )
 
 
 def test_map_no_output_col(make_test_data: TestDataMaker) -> None:

--- a/lilac/data/dataset_test.py
+++ b/lilac/data/dataset_test.py
@@ -142,24 +142,24 @@ def test_select_star(make_test_data: TestDataMaker) -> None:
 
   # Select *.
   result = dataset.select_rows(['*'])
-  assert list(result) == items
+  assert list(result) == [{'name': 'A', 'info.age': 40}, {'name': 'B', 'info.age': 42}]
 
   # Select (*,).
   result = dataset.select_rows([('*',)])
-  assert list(result) == items
+  assert list(result) == [{'name': 'A', 'info.age': 40}, {'name': 'B', 'info.age': 42}]
 
   # Select *, plus a redundant `info` column.
   result = dataset.select_rows(['*', 'info'])
   assert list(result) == [
-    {'name': 'A', 'info': {'age': 40}, 'info_2': {'age': 40}},
-    {'name': 'B', 'info': {'age': 42}, 'info_2': {'age': 42}},
+    {'name': 'A', 'info.age': 40, 'info': {'age': 40}},
+    {'name': 'B', 'info.age': 42, 'info': {'age': 42}},
   ]
 
   # Select * plus an inner `info.age` column.
   result = dataset.select_rows(['*', ('info', 'age')])
   assert list(result) == [
-    {'name': 'A', 'info': {'age': 40}, 'info.age': 40},
-    {'name': 'B', 'info': {'age': 42}, 'info.age': 42},
+    {'info.age': 40, 'info.age_2': 40, 'name': 'A'},
+    {'info.age': 42, 'info.age_2': 42, 'name': 'B'},
   ]
 
 
@@ -329,8 +329,18 @@ def test_enriched_select_all(make_test_data: TestDataMaker) -> None:
 
   result = dataset.select_rows()
   assert list(result) == [
-    {'text': 'hello', 'text.length_signal': 5, 'text.test_signal': {'len': 5, 'flen': 5.0}},
-    {'text': 'everybody', 'text.length_signal': 9, 'text.test_signal': {'len': 9, 'flen': 9.0}},
+    {
+      'text': 'hello',
+      'text.length_signal': 5,
+      'text.test_signal.len': 5,
+      'text.test_signal.flen': 5.0,
+    },
+    {
+      'text': 'everybody',
+      'text.length_signal': 9,
+      'text.test_signal.len': 9,
+      'text.test_signal.flen': 9.0,
+    },
   ]
 
 

--- a/lilac/schema_test.py
+++ b/lilac/schema_test.py
@@ -178,6 +178,9 @@ def test_arrow_schema_to_schema() -> None:
         )
       ),
       'blob': pa.binary(),
+      'spans': pa.struct(
+        {SPAN_KEY: pa.struct({'start': pa.int32(), 'end': pa.int32()}), 'metadata': pa.string()}
+      ),
     }
   )
   expected_schema = schema(
@@ -192,6 +195,7 @@ def test_arrow_schema_to_schema() -> None:
         }
       ],
       'blob': 'binary',
+      'spans': field('string_span', fields={'metadata': 'string'}),
     }
   )
   assert arrow_schema_to_schema(arrow_schema) == expected_schema

--- a/lilac/server_dataset_test.py
+++ b/lilac/server_dataset_test.py
@@ -118,7 +118,26 @@ def test_select_rows_no_options() -> None:
   options = SelectRowsOptions()
   response = client.post(url, json=options.model_dump())
   assert response.status_code == 200
-  assert response.json() == {'rows': TEST_DATA, 'total_num_rows': 3}
+  assert response.json() == {
+    'rows': [
+      {
+        'erased': False,
+        'people.*.name': ['A'],
+        'people.*.zipcode': [0],
+        'people.*.locations.*.city': [['city1', 'city2']],
+        'people.*.locations.*.state': [['state1', 'state2']],
+      },
+      {
+        'erased': True,
+        'people.*.name': ['B', 'C'],
+        'people.*.zipcode': [1, 2],
+        'people.*.locations.*.city': [['city3', 'city4', 'city5'], ['city1']],
+        'people.*.locations.*.state': [['state3', None, None], ['state1']],
+      },
+      {'erased': True},
+    ],
+    'total_num_rows': 3,
+  }
 
 
 def test_select_rows_with_cols_and_limit() -> None:

--- a/lilac/tasks.py
+++ b/lilac/tasks.py
@@ -194,7 +194,6 @@ class TaskManager:
         asyncio.get_event_loop().run_until_complete(wait_result)
 
     for task_id in task_ids or []:
-      task = self._tasks[task_id]
       future = self._futures[task_id]
 
       if future.status == 'error':

--- a/notebooks/DatasetMap.ipynb
+++ b/notebooks/DatasetMap.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# Dataset.map()\n",
     "\n",
-    "This notebook shows a workflow for using `Dataset.map`. This method is useful for creating a new column with a custom map function to generate the output.\n"
+    "This notebook shows a workflow for using `Dataset.map`.\n",
+    "\n",
+    "`Dataset.map()` works like a standard map function, creating a new column using a python function that reads the existing rows, with extra API to allow the UI to visualize changes.\n"
    ]
   },
   {
@@ -21,6 +23,16 @@
       "/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:     Started server process [49536]\n",
+      "INFO:     Waiting for application startup.\n",
+      "INFO:     Application startup complete.\n",
+      "INFO:     Uvicorn running on http://127.0.0.1:5432 (Press CTRL+C to quit)\n"
+     ]
     }
    ],
    "source": [
@@ -31,93 +43,174 @@
     "ll.set_project_dir('./data')\n",
     "\n",
     "try:\n",
-    "  glue = ll.get_dataset('local', 'glue_ax_map_2')\n",
-    "except:\n",
+    "  glue = ll.get_dataset('local', 'glue_ax_map')\n",
+    "except Exception as e:\n",
     "  glue = ll.create_dataset(\n",
     "    ll.DatasetConfig(\n",
     "      namespace='local',\n",
-    "      name='glue_ax_map_2',\n",
+    "      name='glue_ax_map',\n",
     "      source=ll.HuggingFaceSource(dataset_name='glue', config_name='ax', sample_size=100),\n",
     "    )\n",
     "  )\n",
     "\n",
-    "# ll.start_server()"
+    "ll.start_server()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Upper case 'premise'\n",
+    "# Simple `map`: upper case 'premise'\n",
     "\n",
-    "The following map will upper case the 'premise' field from the dataset.\n",
+    "The following map will upper case the `premise` field from the dataset. When you have the [Lilac UI](http://localhost:5432) opened in a new tab, you will see the progress as your map is executed.\n",
     "\n",
-    "The output of the map is returned as a generator.\n"
+    "Once it's complete, refresh the UI to see the results.\n",
+    "\n",
+    "The output of the map is also returned as a generator so you can print it easily. The results of the generator are simply what your map outputed.\n",
+    "\n",
+    "You can use `select_rows` to merge it with source data.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Scheduling task \"c8f214c9a2454e569fb2905aa33264ee\": \"[local/glue_ax_map_2] map \"_upper\"\".\n"
+      "Scheduling task \"b687098a1a76499e9aad3da032413845\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\"\".\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/distributed/node.py:182: UserWarning: Port 8787 is already in use.\n",
-      "Perhaps you already have a cluster running?\n",
-      "Hosting the HTTP server on port 58853 instead\n",
-      "  warnings.warn(\n"
+      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\": 100%|██████████| 1104/1104 [00:00<00:00, 51035.61it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "IF THE PIPELINE TOKENIZATION SCHEME DOES NOT CORRESPOND TO THE ONE THAT WAS USED WHEN A MODEL WAS CREATED, IT WOULD BE EXPECTED TO NEGATIVELY IMPACT THE PIPELINE RESULTS.\n",
-      "\n"
+      "A rabbi is at this wedding, standing right there standing behind that tree.\n",
+      "\n",
+      "Scheduling task \"f9eaa3292e0d42f8b67308fd28953afd\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\"\".\n",
+      "Task finished \"b687098a1a76499e9aad3da032413845\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\"\" in 4s.\n",
+      "Wrote map output to ./data/datasets/local/glue_ax_map/./data/datasets/local/glue_ax_map/premise_upper-00000-of-00001.parquet\n",
+      "{'premise_upper': 'The cat sat on the mat.', 'premise': {'__value__': 'The cat sat on the mat.', 'thes': [{'__span__': {'start': 15, 'end': 18}}]}}\n",
+      "{'premise_upper': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 84, 'end': 87}}]}}\n",
+      "{'premise_upper': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 81, 'end': 84}}]}}\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[local/glue_ax_map_2] map \"_upper\": 100%|██████████| 100/100 [00:00<00:00, 17337.57it/s]\n"
+      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\": 100%|██████████| 1104/1104 [00:00<00:00, 53493.58it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Task finished \"c8f214c9a2454e569fb2905aa33264ee\": \"[local/glue_ax_map_2] map \"_upper\"\" in 4s.\n"
+      "Task finished \"f9eaa3292e0d42f8b67308fd28953afd\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\"\" in 4s.\n"
      ]
     }
    ],
    "source": [
-    "# Upper case 'premise' and print the first result\n",
-    "# This call does not save the output to a column.\n",
-    "def _upper(item: dict) -> str:\n",
-    "  # print('premise==>', item['premise'])\n",
-    "  return item['premise'].upper()\n",
+    "# First, let's just run our map function that upper-cases the 'premise' field without writing a\n",
+    "# column to disk until we're happy with the results.\n",
+    "def _upper(row: dict, job_id: int) -> str:\n",
+    "  # TODO(nsthorat): This API is pretty awful because the combin_columns=False logic isn't moving the\n",
+    "  # `the` out.\n",
+    "  premise = row['premise'].get(ll.VALUE_KEY) or row['premise']\n",
+    "  return premise\n",
     "\n",
     "\n",
     "res = glue.map(_upper)\n",
     "print(next(iter(res)))\n",
     "print()\n",
     "\n",
-    "# # # Write the output to a column 'premise_upper'.\n",
-    "# glue.map(lambda item: item['premise'].upper(), output_path='premise_upper', overwrite=True, num_jobs=-1)\n",
+    "# Once we're comfortable with the results, we can write the column to disk.\n",
+    "# To do this, we specify `output_column`.\n",
+    "glue.map(_upper, output_column='premise_upper', overwrite=True)\n",
     "\n",
-    "# rows = glue.select_rows(['premise', 'premise_upper'], limit=3)\n",
-    "# for row in rows:\n",
-    "#   print(row)"
+    "# Print the first three rows.\n",
+    "rows = glue.select_rows(['premise', 'premise_upper'], limit=3)\n",
+    "for row in rows:\n",
+    "  print(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Find all instances of a keyword and highlight it in the UI\n",
+    "\n",
+    "We can also use the `nest_under` to nest the result under a specific field.\n",
+    "\n",
+    "Once a field is nested, we can use `ll.span` to emit the character coordinates, with metadata, of a field we want to highlight from the UI.\n",
+    "\n",
+    "In this example, we'll simply highlight keywords with \"the\". We'll emit metadata with the span so we can filter by it from the UI!\n",
+    "\n",
+    "Run the next cell, and then open [this link](http://localhost:5432/datasets#local/glue_ax_map&schemaCollapsed=false&showMetadataPanel=true&expandedStats=%7B%22premise.thes%22%3Atrue%7D&query=%7B%22filters%22%3A%5B%7B%22path%22%3A%5B%22premise%22%2C%22thes%22%5D%2C%22op%22%3A%22equals%22%2C%22value%22%3A%22the%22%7D%5D%7D). You'll notice we had to apply the filter for 'the' before we get highlighting.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scheduling task \"2fb77863ff5f4ddfb4975a0fb07f4a2b\": \"[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\"\".\n",
+      "Wrote map output to ./data/datasets/local/glue_ax_map/./data/datasets/local/glue_ax_map/premise/thes/thes-00000-of-00001.parquet\n",
+      "{'hypothesis': 'The cat did not sit on the mat.', 'label': 'contradiction', 'idx': 0, '__hfsplit__': 'test', 'premise_upper': 'The cat sat on the mat.', 'premise': {'__value__': 'The cat sat on the mat.', 'thes': [{'__span__': {'start': 15, 'end': 18}}]}}\n",
+      "{'hypothesis': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'label': 'contradiction', 'idx': 2, '__hfsplit__': 'test', 'premise_upper': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 84, 'end': 87}}]}}\n",
+      "{'hypothesis': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'label': 'contradiction', 'idx': 3, '__hfsplit__': 'test', 'premise_upper': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 81, 'end': 84}}]}}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\": 100%|██████████| 1104/1104 [00:00<00:00, 37740.94it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Task finished \"2fb77863ff5f4ddfb4975a0fb07f4a2b\": \"[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\"\" in 4s.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "\n",
+    "# Find instances of 'the'.\n",
+    "MATCH_REGEX = 'the'\n",
+    "\n",
+    "\n",
+    "def _find_the(row: dict, job_id: int) -> ll.Item:\n",
+    "  # TODO(nsthorat): This API is pretty awful because the combin_columns=False logic isn't moving the\n",
+    "  # `the` out.\n",
+    "  premise = row['premise'].get(ll.VALUE_KEY) or row['premise']\n",
+    "  return [ll.lilac_span(m.start(), m.end()) for m in re.finditer(MATCH_REGEX, premise)]\n",
+    "\n",
+    "\n",
+    "glue.map(\n",
+    "  _find_the, output_column='thes', nest_under='premise', overwrite=True, combine_columns=False\n",
+    ")\n",
+    "\n",
+    "# Print the first three rows.\n",
+    "rows = glue.select_rows([ll.PATH_WILDCARD], combine_columns=False, limit=3)\n",
+    "for row in rows:\n",
+    "  print(row)"
    ]
   },
   {
@@ -126,7 +219,9 @@
    "source": [
     "# Map continuation during an error, or computer shutdown\n",
     "\n",
-    "`dataset.map()` will not lose data if an error is thrown when writing to disk. The next time it is called, it will continue from where it left off. Once it is finally complete, the column is written.\n"
+    "`dataset.map()` will not lose data if an error is thrown when writing to disk.\n",
+    "\n",
+    "The next time it is called, it will continue from where it left off. Once it is finally complete, the column is written.\n"
    ]
   },
   {
@@ -315,7 +410,7 @@
     "\n",
     "# This is going to throw after 10 iterations. When we call it again, it will only call _upper()\n",
     "# for the rest of the dataset.\n",
-    "glue.map(_upper, output_path='premise_upper2', overwrite=True, num_jobs=-1)"
+    "glue.map(_upper, output_column='premise_upper2', overwrite=True, num_jobs=-1)"
    ]
   },
   {

--- a/notebooks/DatasetMap.ipynb
+++ b/notebooks/DatasetMap.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "\n",
     "def _find_the(row: dict, job_id: int) -> ll.Item:\n",
-    "  # TODO(nsthorat): This API is pretty awful because the combin_columns=False logic isn't moving the\n",
+    "  # TODO(nsthorat): This API is pretty awful because the combine_columns=False logic isn't moving the\n",
     "  # `the` out.\n",
     "  premise = row['premise'].get(ll.VALUE_KEY) or row['premise']\n",
     "  return [ll.lilac_span(m.start(), m.end()) for m in re.finditer(MATCH_REGEX, premise)]\n",

--- a/notebooks/DatasetMap.ipynb
+++ b/notebooks/DatasetMap.ipynb
@@ -23,16 +23,6 @@
       "/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:     Started server process [49536]\n",
-      "INFO:     Waiting for application startup.\n",
-      "INFO:     Application startup complete.\n",
-      "INFO:     Uvicorn running on http://127.0.0.1:5432 (Press CTRL+C to quit)\n"
-     ]
     }
    ],
    "source": [
@@ -53,7 +43,7 @@
     "    )\n",
     "  )\n",
     "\n",
-    "ll.start_server()"
+    "# ll.start_server()"
    ]
   },
   {
@@ -73,49 +63,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Scheduling task \"b687098a1a76499e9aad3da032413845\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\"\".\n"
+      "Scheduling task \"6c5b363446bf44b9b84b0321e5d7087f\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\"\".\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\": 100%|██████████| 1104/1104 [00:00<00:00, 51035.61it/s]\n"
+      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\": 100%|██████████| 1104/1104 [00:00<00:00, 55017.72it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "A rabbi is at this wedding, standing right there standing behind that tree.\n",
+      "A RABBI IS AT THIS WEDDING, STANDING RIGHT THERE STANDING BEHIND THAT TREE.\n",
       "\n",
-      "Scheduling task \"f9eaa3292e0d42f8b67308fd28953afd\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\"\".\n",
-      "Task finished \"b687098a1a76499e9aad3da032413845\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\"\" in 4s.\n",
+      "Scheduling task \"dee8d22356a2400aba4210667d937bf7\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\"\".\n",
+      "Task finished \"6c5b363446bf44b9b84b0321e5d7087f\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"_upper\"\" in 5s.\n",
       "Wrote map output to ./data/datasets/local/glue_ax_map/./data/datasets/local/glue_ax_map/premise_upper-00000-of-00001.parquet\n",
-      "{'premise_upper': 'The cat sat on the mat.', 'premise': {'__value__': 'The cat sat on the mat.', 'thes': [{'__span__': {'start': 15, 'end': 18}}]}}\n",
-      "{'premise_upper': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 84, 'end': 87}}]}}\n",
-      "{'premise_upper': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 81, 'end': 84}}]}}\n"
+      "{'premise': 'The cat sat on the mat.', 'premise_upper': 'THE CAT SAT ON THE MAT.'}\n",
+      "{'premise': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise_upper': \"WHEN YOU'VE GOT NO SNOW, IT'S REALLY HARD TO LEARN A SNOW SPORT SO WE LOOKED AT ALL THE DIFFERENT WAYS I COULD MIMIC BEING ON SNOW WITHOUT ACTUALLY BEING ON SNOW.\"}\n",
+      "{'premise': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise_upper': \"WHEN YOU'VE GOT SNOW, IT'S REALLY HARD TO LEARN A SNOW SPORT SO WE LOOKED AT ALL THE DIFFERENT WAYS I COULD MIMIC BEING ON SNOW WITHOUT ACTUALLY BEING ON SNOW.\"}\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\": 100%|██████████| 1104/1104 [00:00<00:00, 53493.58it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"f9eaa3292e0d42f8b67308fd28953afd\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\"\" in 4s.\n"
+      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\": 100%|██████████| 1104/1104 [00:00<00:00, 51739.29it/s]\n"
      ]
     }
    ],
@@ -123,10 +106,7 @@
     "# First, let's just run our map function that upper-cases the 'premise' field without writing a\n",
     "# column to disk until we're happy with the results.\n",
     "def _upper(row: dict, job_id: int) -> str:\n",
-    "  # TODO(nsthorat): This API is pretty awful because the combin_columns=False logic isn't moving the\n",
-    "  # `the` out.\n",
-    "  premise = row['premise'].get(ll.VALUE_KEY) or row['premise']\n",
-    "  return premise\n",
+    "  return row['premise'].upper()\n",
     "\n",
     "\n",
     "res = glue.map(_upper)\n",
@@ -160,32 +140,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Scheduling task \"2fb77863ff5f4ddfb4975a0fb07f4a2b\": \"[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\"\".\n",
+      "Scheduling task \"207a165662a04040a58999335bd11bac\": \"[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\"\".\n",
+      "Task finished \"dee8d22356a2400aba4210667d937bf7\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper\"\" in 4s.\n",
       "Wrote map output to ./data/datasets/local/glue_ax_map/./data/datasets/local/glue_ax_map/premise/thes/thes-00000-of-00001.parquet\n",
-      "{'hypothesis': 'The cat did not sit on the mat.', 'label': 'contradiction', 'idx': 0, '__hfsplit__': 'test', 'premise_upper': 'The cat sat on the mat.', 'premise': {'__value__': 'The cat sat on the mat.', 'thes': [{'__span__': {'start': 15, 'end': 18}}]}}\n",
-      "{'hypothesis': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'label': 'contradiction', 'idx': 2, '__hfsplit__': 'test', 'premise_upper': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 84, 'end': 87}}]}}\n",
-      "{'hypothesis': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'label': 'contradiction', 'idx': 3, '__hfsplit__': 'test', 'premise_upper': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'premise': {'__value__': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'thes': [{'__span__': {'start': 81, 'end': 84}}]}}\n"
+      "{'premise': 'The cat sat on the mat.', 'hypothesis': 'The cat did not sit on the mat.', 'label': 'contradiction', 'idx': 0, '__hfsplit__': 'test', 'premise_upper': 'THE CAT SAT ON THE MAT.', 'premise.thes.*': [{'__span__': {'start': 15, 'end': 18}}]}\n",
+      "{'premise': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'hypothesis': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'label': 'contradiction', 'idx': 2, '__hfsplit__': 'test', 'premise_upper': \"WHEN YOU'VE GOT NO SNOW, IT'S REALLY HARD TO LEARN A SNOW SPORT SO WE LOOKED AT ALL THE DIFFERENT WAYS I COULD MIMIC BEING ON SNOW WITHOUT ACTUALLY BEING ON SNOW.\", 'premise.thes.*': [{'__span__': {'start': 84, 'end': 87}}]}\n",
+      "{'premise': \"When you've got snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'hypothesis': \"When you've got no snow, it's really hard to learn a snow sport so we looked at all the different ways I could mimic being on snow without actually being on snow.\", 'label': 'contradiction', 'idx': 3, '__hfsplit__': 'test', 'premise_upper': \"WHEN YOU'VE GOT SNOW, IT'S REALLY HARD TO LEARN A SNOW SPORT SO WE LOOKED AT ALL THE DIFFERENT WAYS I COULD MIMIC BEING ON SNOW WITHOUT ACTUALLY BEING ON SNOW.\", 'premise.thes.*': [{'__span__': {'start': 81, 'end': 84}}]}\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\": 100%|██████████| 1104/1104 [00:00<00:00, 37740.94it/s]\n"
+      "[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\": 100%|██████████| 1104/1104 [00:00<00:00, 38167.75it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Task finished \"2fb77863ff5f4ddfb4975a0fb07f4a2b\": \"[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\"\" in 4s.\n"
+      "Task finished \"207a165662a04040a58999335bd11bac\": \"[local/glue_ax_map][shard 0/1] map \"_find_the\" to \"thes\"\" in 4s.\n"
      ]
     }
    ],
@@ -197,10 +178,7 @@
     "\n",
     "\n",
     "def _find_the(row: dict, job_id: int) -> ll.Item:\n",
-    "  # TODO(nsthorat): This API is pretty awful because the combine_columns=False logic isn't moving the\n",
-    "  # `the` out.\n",
-    "  premise = row['premise'].get(ll.VALUE_KEY) or row['premise']\n",
-    "  return [ll.lilac_span(m.start(), m.end()) for m in re.finditer(MATCH_REGEX, premise)]\n",
+    "  return [ll.lilac_span(m.start(), m.end()) for m in re.finditer(MATCH_REGEX, row['premise'])]\n",
     "\n",
     "\n",
     "glue.map(\n",
@@ -226,170 +204,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Scheduling task \"1da54efcbe0f497e9bd9085cf98144e6\": \"[local/glue_ax_map_2][1/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"e6d7dae5dd5a460e88d2d0e384636380\": \"[local/glue_ax_map_2][2/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"704e030c9c71413881b6539511fe1aa1\": \"[local/glue_ax_map_2][3/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"5621b696af3a4962a08c3da2fdd67fe3\": \"[local/glue_ax_map_2][4/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"2ba96252fefa4200b815c8ddabbf5fed\": \"[local/glue_ax_map_2][5/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"d5a8710fba1647aea11eb1bc96c42111\": \"[local/glue_ax_map_2][6/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"c92841f9775e4071bae1178c675cf8bd\": \"[local/glue_ax_map_2][7/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"15f763466dfe4cd8b6344ed2b43e1ed2\": \"[local/glue_ax_map_2][8/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"a922afdf40b94a638b8dac7b07b62294\": \"[local/glue_ax_map_2][9/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"b2f6b5dbfec247d993c6bd8e409d6c76\": \"[local/glue_ax_map_2][10/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"1f4032a8910c431db311d4bfd874b552\": \"[local/glue_ax_map_2][11/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"c7e6304252154fd8a75f8ad5fc27f66e\": \"[local/glue_ax_map_2][12/12] map \"_upper\" to \"premise_upper2\"\".\n"
+      "Scheduling task \"8720732957904b099176a9f0c7320de1\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper2\"\".\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/distributed/node.py:182: UserWarning: Port 8787 is already in use.\n",
-      "Perhaps you already have a cluster running?\n",
-      "Hosting the HTTP server on port 54248 instead\n",
-      "  warnings.warn(\n",
-      "[local/glue_ax_map_2][1/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1152.95it/s]\n",
-      "[local/glue_ax_map_2][2/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 604.27it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"1da54efcbe0f497e9bd9085cf98144e6\": \"[local/glue_ax_map_2][1/12] map \"_upper\" to \"premise_upper2\"\" in 8s.\n",
-      "Task finished \"e6d7dae5dd5a460e88d2d0e384636380\": \"[local/glue_ax_map_2][2/12] map \"_upper\" to \"premise_upper2\"\" in 8s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][3/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1401.63it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"704e030c9c71413881b6539511fe1aa1\": \"[local/glue_ax_map_2][3/12] map \"_upper\" to \"premise_upper2\"\" in 8s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][4/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1301.91it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"5621b696af3a4962a08c3da2fdd67fe3\": \"[local/glue_ax_map_2][4/12] map \"_upper\" to \"premise_upper2\"\" in 9s.\n",
-      "Task error \"2ba96252fefa4200b815c8ddabbf5fed\": \"[local/glue_ax_map_2][5/12] map \"_upper\" to \"premise_upper2\"\" in 9s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][5/12] map \"_upper\" to \"premise_upper2\":   6%|▌         | 6/100 [00:00<00:00, 937.66it/s]\n",
-      "2023-11-12 20:58:34,016 - distributed.worker - WARNING - Compute Failed\n",
-      "Key:       2ba96252fefa4200b815c8ddabbf5fed\n",
+      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper2\":  38%|███▊      | 414/1104 [00:00<00:00, 23549.44it/s]\n",
+      "2023-11-20 19:13:53,854 - distributed.worker - WARNING - Compute Failed\n",
+      "Key:       8720732957904b099176a9f0c7320de1\n",
       "Function:  _execute_task\n",
-      "args:      (<function _upper at 0x2aef63920>, (36, 45), './data/.cache/lilac/local/glue_ax_map_2/premise_upper2.36-45.jsonl', 'premise_upper2', None, True, False, False, ('2ba96252fefa4200b815c8ddabbf5fed', 0))\n",
+      "args:      (<function _upper at 0x2a7f7b920>, ('premise_upper2',), './data/.cache/lilac/local/glue_ax_map/premise_upper2.00000-of-00001.jsonl', 0, 1, True, False, False, ('8720732957904b099176a9f0c7320de1', 0))\n",
       "kwargs:    {}\n",
-      "Exception: \"ValueError('Throwing for 56505f14f6dc496e807018c3675ac840')\"\n",
-      "\n",
-      "[local/glue_ax_map_2][6/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1587.55it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"d5a8710fba1647aea11eb1bc96c42111\": \"[local/glue_ax_map_2][6/12] map \"_upper\" to \"premise_upper2\"\" in 9s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][7/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1857.99it/s]\n",
-      "[local/glue_ax_map_2][8/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 2045.78it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"c92841f9775e4071bae1178c675cf8bd\": \"[local/glue_ax_map_2][7/12] map \"_upper\" to \"premise_upper2\"\" in 10s.\n",
-      "Task finished \"15f763466dfe4cd8b6344ed2b43e1ed2\": \"[local/glue_ax_map_2][8/12] map \"_upper\" to \"premise_upper2\"\" in 10s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][9/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1299.80it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"a922afdf40b94a638b8dac7b07b62294\": \"[local/glue_ax_map_2][9/12] map \"_upper\" to \"premise_upper2\"\" in 10s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][10/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 2163.50it/s]\n",
-      "[local/glue_ax_map_2][11/12] map \"_upper\" to \"premise_upper2\":   9%|▉         | 9/100 [00:00<00:00, 1947.32it/s]\n",
-      "[local/glue_ax_map_2][12/12] map \"_upper\" to \"premise_upper2\":   1%|          | 1/100 [00:00<00:00, 258.59it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"b2f6b5dbfec247d993c6bd8e409d6c76\": \"[local/glue_ax_map_2][10/12] map \"_upper\" to \"premise_upper2\"\" in 11s.\n",
-      "Task finished \"1f4032a8910c431db311d4bfd874b552\": \"[local/glue_ax_map_2][11/12] map \"_upper\" to \"premise_upper2\"\" in 11s.\n"
+      "Exception: \"ValueError('Throwing for 5c56d63b5f0a401696a8a20ac1f027fa')\"\n",
+      "\n"
      ]
     },
     {
      "ename": "ValueError",
-     "evalue": "Throwing for 56505f14f6dc496e807018c3675ac840",
+     "evalue": "Throwing for 5c56d63b5f0a401696a8a20ac1f027fa",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb Cell 6\u001b[0m line \u001b[0;36m1\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=10'>11</a>\u001b[0m   \u001b[39mreturn\u001b[39;00m item[\u001b[39m'\u001b[39m\u001b[39mpremise\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m.\u001b[39mupper()\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=13'>14</a>\u001b[0m \u001b[39m# This is going to throw after 10 iterations. When we call it again, it will only call _upper()\u001b[39;00m\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=14'>15</a>\u001b[0m \u001b[39m# for the rest of the dataset.\u001b[39;00m\n\u001b[0;32m---> <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=15'>16</a>\u001b[0m glue\u001b[39m.\u001b[39;49mmap(_upper, output_path\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mpremise_upper2\u001b[39;49m\u001b[39m'\u001b[39;49m, overwrite\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m, num_jobs\u001b[39m=\u001b[39;49m\u001b[39m-\u001b[39;49m\u001b[39m1\u001b[39;49m)\n",
-      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:2142\u001b[0m, in \u001b[0;36mDatasetDuckDB.map\u001b[0;34m(self, map_fn, output_path, input_paths, overwrite, combine_columns, resolve_span, num_jobs)\u001b[0m\n\u001b[1;32m   2139\u001b[0m   shard_output_filepaths\u001b[39m.\u001b[39mappend(shard_output_filepath)\n\u001b[1;32m   2141\u001b[0m \u001b[39m# Wait for the tasks to finish before reading the outputs.\u001b[39;00m\n\u001b[0;32m-> 2142\u001b[0m get_task_manager()\u001b[39m.\u001b[39;49mwait(task_ids)\n\u001b[1;32m   2144\u001b[0m \u001b[39m# Merge all the shard outputs.\u001b[39;00m\n\u001b[1;32m   2145\u001b[0m jsonl_view_name \u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39mtmp_output\u001b[39m\u001b[39m'\u001b[39m\n",
-      "File \u001b[0;32m~/Code/lilac/lilac/tasks.py:205\u001b[0m, in \u001b[0;36mTaskManager.wait\u001b[0;34m(self, task_ids)\u001b[0m\n\u001b[1;32m    203\u001b[0m \u001b[39mif\u001b[39;00m asyncio\u001b[39m.\u001b[39miscoroutine(task_error):\n\u001b[1;32m    204\u001b[0m   task_error \u001b[39m=\u001b[39m asyncio\u001b[39m.\u001b[39mget_event_loop()\u001b[39m.\u001b[39mrun_until_complete(task_error)\n\u001b[0;32m--> 205\u001b[0m \u001b[39mraise\u001b[39;00m task_error\n",
+      "\u001b[1;32m/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb Cell 8\u001b[0m line \u001b[0;36m1\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=9'>10</a>\u001b[0m   \u001b[39mreturn\u001b[39;00m row[\u001b[39m'\u001b[39m\u001b[39mpremise\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m.\u001b[39mupper()\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=12'>13</a>\u001b[0m \u001b[39m# This is going to throw after 10 iterations. When we call it again, it will only call _upper()\u001b[39;00m\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=13'>14</a>\u001b[0m \u001b[39m# for the rest of the dataset.\u001b[39;00m\n\u001b[0;32m---> <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=14'>15</a>\u001b[0m glue\u001b[39m.\u001b[39;49mmap(_upper, output_column\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mpremise_upper2\u001b[39;49m\u001b[39m'\u001b[39;49m, overwrite\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m, num_jobs\u001b[39m=\u001b[39;49m\u001b[39m1\u001b[39;49m)\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:2452\u001b[0m, in \u001b[0;36mDatasetDuckDB.map\u001b[0;34m(self, map_fn, output_column, nest_under, overwrite, combine_columns, resolve_span, num_jobs)\u001b[0m\n\u001b[1;32m   2449\u001b[0m   jsonl_cache_filepaths\u001b[39m.\u001b[39mappend(jsonl_cache_filepath)\n\u001b[1;32m   2451\u001b[0m \u001b[39m# Wait for the tasks to finish before reading the outputs.\u001b[39;00m\n\u001b[0;32m-> 2452\u001b[0m get_task_manager()\u001b[39m.\u001b[39;49mwait(task_ids)\n\u001b[1;32m   2454\u001b[0m reader, map_schema, parquet_filepath \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_reshard_cache(\n\u001b[1;32m   2455\u001b[0m   output_path\u001b[39m=\u001b[39moutput_path,\n\u001b[1;32m   2456\u001b[0m   jsonl_cache_filepaths\u001b[39m=\u001b[39mjsonl_cache_filepaths,\n\u001b[1;32m   2457\u001b[0m   is_tmp_output\u001b[39m=\u001b[39mis_tmp_output,\n\u001b[1;32m   2458\u001b[0m )\n\u001b[1;32m   2460\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m is_tmp_output:\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/tasks.py:203\u001b[0m, in \u001b[0;36mTaskManager.wait\u001b[0;34m(self, task_ids)\u001b[0m\n\u001b[1;32m    201\u001b[0m \u001b[39mif\u001b[39;00m asyncio\u001b[39m.\u001b[39miscoroutine(task_error):\n\u001b[1;32m    202\u001b[0m   task_error \u001b[39m=\u001b[39m asyncio\u001b[39m.\u001b[39mget_event_loop()\u001b[39m.\u001b[39mrun_until_complete(task_error)\n\u001b[0;32m--> 203\u001b[0m \u001b[39mraise\u001b[39;00m task_error\n",
       "File \u001b[0;32m~/Code/lilac/.venv/lib/python3.11/site-packages/distributed/worker.py:2983\u001b[0m, in \u001b[0;36mapply_function_simple\u001b[0;34m()\u001b[0m\n\u001b[1;32m   2981\u001b[0m     \u001b[39mwith\u001b[39;00m context_meter\u001b[39m.\u001b[39mmeter(\u001b[39m\"\u001b[39m\u001b[39mthread-noncpu\u001b[39m\u001b[39m\"\u001b[39m, func\u001b[39m=\u001b[39mtime) \u001b[39mas\u001b[39;00m m:\n\u001b[1;32m   2982\u001b[0m         \u001b[39mwith\u001b[39;00m context_meter\u001b[39m.\u001b[39mmeter(\u001b[39m\"\u001b[39m\u001b[39mthread-cpu\u001b[39m\u001b[39m\"\u001b[39m, func\u001b[39m=\u001b[39mthread_time):\n\u001b[0;32m-> 2983\u001b[0m             result \u001b[39m=\u001b[39m function(\u001b[39m*\u001b[39margs, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n\u001b[1;32m   2984\u001b[0m \u001b[39mexcept\u001b[39;00m (\u001b[39mSystemExit\u001b[39;00m, \u001b[39mKeyboardInterrupt\u001b[39;00m):\n\u001b[1;32m   2985\u001b[0m     \u001b[39m# Special-case these, just like asyncio does all over the place. They will pass\u001b[39;00m\n\u001b[1;32m   2986\u001b[0m     \u001b[39m# through `fail_hard` and `_handle_stimulus_from_task`, and eventually be caught\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   2989\u001b[0m     \u001b[39m# Any other `BaseException` types would ultimately be ignored by asyncio if\u001b[39;00m\n\u001b[1;32m   2990\u001b[0m     \u001b[39m# raised here, after messing up the worker state machine along their way.\u001b[39;00m\n\u001b[1;32m   2991\u001b[0m     \u001b[39mraise\u001b[39;00m\n",
-      "File \u001b[0;32m~/Code/lilac/lilac/tasks.py:309\u001b[0m, in \u001b[0;36m_execute_task\u001b[0;34m()\u001b[0m\n\u001b[1;32m    307\u001b[0m annotations \u001b[39m=\u001b[39m cast(\u001b[39mdict\u001b[39m, get_worker()\u001b[39m.\u001b[39mstate\u001b[39m.\u001b[39mtasks[task_id]\u001b[39m.\u001b[39mannotations)\n\u001b[1;32m    308\u001b[0m annotations[\u001b[39m'\u001b[39m\u001b[39mtask_info\u001b[39m\u001b[39m'\u001b[39m] \u001b[39m=\u001b[39m task_info\n\u001b[0;32m--> 309\u001b[0m task(\u001b[39m*\u001b[39margs)\n",
-      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:2345\u001b[0m, in \u001b[0;36m_map_worker\u001b[0;34m()\u001b[0m\n\u001b[1;32m   2342\u001b[0m write_mode \u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39ma\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m   2344\u001b[0m \u001b[39mwith\u001b[39;00m fs\u001b[39m.\u001b[39mopen(shard_output_filepath, write_mode) \u001b[39mas\u001b[39;00m file:\n\u001b[0;32m-> 2345\u001b[0m   \u001b[39mfor\u001b[39;00m item \u001b[39min\u001b[39;00m outputs:\n\u001b[1;32m   2346\u001b[0m     json\u001b[39m.\u001b[39mdump(item, file)\n\u001b[1;32m   2347\u001b[0m     file\u001b[39m.\u001b[39mwrite(\u001b[39m'\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m'\u001b[39m)\n",
-      "File \u001b[0;32m~/Code/lilac/lilac/tasks.py:364\u001b[0m, in \u001b[0;36mprogress\u001b[0;34m()\u001b[0m\n\u001b[1;32m    362\u001b[0m last_emit \u001b[39m=\u001b[39m time\u001b[39m.\u001b[39mtime() \u001b[39m-\u001b[39m emit_every_s\n\u001b[1;32m    363\u001b[0m \u001b[39mwith\u001b[39;00m tqdm(it, desc\u001b[39m=\u001b[39mtask_info\u001b[39m.\u001b[39mname, total\u001b[39m=\u001b[39mestimated_len) \u001b[39mas\u001b[39;00m tq:\n\u001b[0;32m--> 364\u001b[0m   \u001b[39mfor\u001b[39;00m t \u001b[39min\u001b[39;00m tq:\n\u001b[1;32m    365\u001b[0m     cur_time \u001b[39m=\u001b[39m time\u001b[39m.\u001b[39mtime()\n\u001b[1;32m    366\u001b[0m     \u001b[39mif\u001b[39;00m estimated_len \u001b[39mand\u001b[39;00m cur_time \u001b[39m-\u001b[39m last_emit \u001b[39m>\u001b[39m emit_every_s:\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/tasks.py:307\u001b[0m, in \u001b[0;36m_execute_task\u001b[0;34m()\u001b[0m\n\u001b[1;32m    305\u001b[0m annotations \u001b[39m=\u001b[39m cast(\u001b[39mdict\u001b[39m, get_worker()\u001b[39m.\u001b[39mstate\u001b[39m.\u001b[39mtasks[task_id]\u001b[39m.\u001b[39mannotations)\n\u001b[1;32m    306\u001b[0m annotations[\u001b[39m'\u001b[39m\u001b[39mtask_info\u001b[39m\u001b[39m'\u001b[39m] \u001b[39m=\u001b[39m task_info\n\u001b[0;32m--> 307\u001b[0m task(\u001b[39m*\u001b[39margs)\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:2502\u001b[0m, in \u001b[0;36m_map_worker\u001b[0;34m()\u001b[0m\n\u001b[1;32m   2499\u001b[0m   \u001b[39mfor\u001b[39;00m item \u001b[39min\u001b[39;00m items:\n\u001b[1;32m   2500\u001b[0m     \u001b[39myield\u001b[39;00m map_fn(item, job_id\u001b[39m=\u001b[39mjob_id)\n\u001b[0;32m-> 2502\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compute_disk_cached(\n\u001b[1;32m   2503\u001b[0m   _map_iterable,\n\u001b[1;32m   2504\u001b[0m   output_path\u001b[39m=\u001b[39moutput_path,\n\u001b[1;32m   2505\u001b[0m   jsonl_cache_filepath\u001b[39m=\u001b[39mjsonl_cache_filepath,\n\u001b[1;32m   2506\u001b[0m   overwrite\u001b[39m=\u001b[39moverwrite,\n\u001b[1;32m   2507\u001b[0m   combine_columns\u001b[39m=\u001b[39mcombine_columns,\n\u001b[1;32m   2508\u001b[0m   resolve_span\u001b[39m=\u001b[39mresolve_span,\n\u001b[1;32m   2509\u001b[0m   shard_id\u001b[39m=\u001b[39mjob_id,\n\u001b[1;32m   2510\u001b[0m   shard_count\u001b[39m=\u001b[39mjob_count,\n\u001b[1;32m   2511\u001b[0m   task_step_id\u001b[39m=\u001b[39mtask_step_id,\n\u001b[1;32m   2512\u001b[0m   task_step_description\u001b[39m=\u001b[39m\u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39m[shard \u001b[39m\u001b[39m{\u001b[39;00mjob_id\u001b[39m+\u001b[39m\u001b[39m1\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m/\u001b[39m\u001b[39m{\u001b[39;00mjob_count\u001b[39m}\u001b[39;00m\u001b[39m] map \u001b[39m\u001b[39m\"\u001b[39m\u001b[39m{\u001b[39;00mmap_fn\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m'\u001b[39m,\n\u001b[1;32m   2513\u001b[0m )\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:779\u001b[0m, in \u001b[0;36m_compute_disk_cached\u001b[0;34m()\u001b[0m\n\u001b[1;32m    777\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m    778\u001b[0m   \u001b[39mwith\u001b[39;00m open_file(jsonl_cache_filepath, \u001b[39m'\u001b[39m\u001b[39ma\u001b[39m\u001b[39m'\u001b[39m) \u001b[39mas\u001b[39;00m file:\n\u001b[0;32m--> 779\u001b[0m     \u001b[39mfor\u001b[39;00m item \u001b[39min\u001b[39;00m output_items:\n\u001b[1;32m    780\u001b[0m       json\u001b[39m.\u001b[39mdump(item, file)\n\u001b[1;32m    781\u001b[0m       file\u001b[39m.\u001b[39mwrite(\u001b[39m'\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m'\u001b[39m)\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/tasks.py:363\u001b[0m, in \u001b[0;36mprogress\u001b[0;34m()\u001b[0m\n\u001b[1;32m    361\u001b[0m last_emit \u001b[39m=\u001b[39m time\u001b[39m.\u001b[39mtime() \u001b[39m-\u001b[39m emit_every_s\n\u001b[1;32m    362\u001b[0m \u001b[39mwith\u001b[39;00m tqdm(it, initial\u001b[39m=\u001b[39mit_idx, desc\u001b[39m=\u001b[39mtask_info\u001b[39m.\u001b[39mname, total\u001b[39m=\u001b[39mestimated_len) \u001b[39mas\u001b[39;00m tq:\n\u001b[0;32m--> 363\u001b[0m   \u001b[39mfor\u001b[39;00m t \u001b[39min\u001b[39;00m tq:\n\u001b[1;32m    364\u001b[0m     cur_time \u001b[39m=\u001b[39m time\u001b[39m.\u001b[39mtime()\n\u001b[1;32m    365\u001b[0m     \u001b[39mif\u001b[39;00m estimated_len \u001b[39mand\u001b[39;00m cur_time \u001b[39m-\u001b[39m last_emit \u001b[39m>\u001b[39m emit_every_s:\n",
       "File \u001b[0;32m~/Code/lilac/.venv/lib/python3.11/site-packages/tqdm/std.py:1182\u001b[0m, in \u001b[0;36m__iter__\u001b[0;34m()\u001b[0m\n\u001b[1;32m   1179\u001b[0m time \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_time\n\u001b[1;32m   1181\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m-> 1182\u001b[0m     \u001b[39mfor\u001b[39;00m obj \u001b[39min\u001b[39;00m iterable:\n\u001b[1;32m   1183\u001b[0m         \u001b[39myield\u001b[39;00m obj\n\u001b[1;32m   1184\u001b[0m         \u001b[39m# Update and possibly print the progressbar.\u001b[39;00m\n\u001b[1;32m   1185\u001b[0m         \u001b[39m# Note: does not call self.update(1) for speed optimisation.\u001b[39;00m\n",
-      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:2329\u001b[0m, in \u001b[0;36m<genexpr>\u001b[0;34m()\u001b[0m\n\u001b[1;32m   2326\u001b[0m       df_chunk \u001b[39m=\u001b[39m pd\u001b[39m.\u001b[39mDataFrame\u001b[39m.\u001b[39mfrom_records(df_chunk[\u001b[39m'\u001b[39m\u001b[39m*\u001b[39m\u001b[39m'\u001b[39m])\n\u001b[1;32m   2327\u001b[0m     \u001b[39myield from\u001b[39;00m df_chunk\u001b[39m.\u001b[39mto_dict(\u001b[39m'\u001b[39m\u001b[39mrecords\u001b[39m\u001b[39m'\u001b[39m)\n\u001b[0;32m-> 2329\u001b[0m outputs \u001b[39m=\u001b[39m ({ROWID: row[ROWID], output_column: map_fn(row)} \u001b[39mfor\u001b[39;00m row \u001b[39min\u001b[39;00m _rows())\n\u001b[1;32m   2331\u001b[0m \u001b[39m# Add progress.\u001b[39;00m\n\u001b[1;32m   2332\u001b[0m \u001b[39mif\u001b[39;00m task_step_id \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
-      "\u001b[1;32m/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb Cell 6\u001b[0m line \u001b[0;36m8\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m \u001b[39mglobal\u001b[39;00m i, throw_after_n\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m \u001b[39mif\u001b[39;00m throw_for_rowid \u001b[39mand\u001b[39;00m item[ll\u001b[39m.\u001b[39mROWID] \u001b[39m==\u001b[39m random_row_id:\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m   \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39mThrowing for \u001b[39m\u001b[39m{\u001b[39;00mrandom_row_id\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m)\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m throw_for_rowid:\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#W5sZmlsZQ%3D%3D?line=9'>10</a>\u001b[0m   \u001b[39mprint\u001b[39m(item[\u001b[39m'\u001b[39m\u001b[39mpremise\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m.\u001b[39mupper())\n",
-      "\u001b[0;31mValueError\u001b[0m: Throwing for 56505f14f6dc496e807018c3675ac840"
+      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:760\u001b[0m, in \u001b[0;36m<genexpr>\u001b[0;34m()\u001b[0m\n\u001b[1;32m    756\u001b[0m   output_items \u001b[39m=\u001b[39m transform_fn(input_values)\n\u001b[1;32m    758\u001b[0m output_items \u001b[39m=\u001b[39m cast(Iterable[Item], wrap_in_dicts(output_items, nested_spec))\n\u001b[0;32m--> 760\u001b[0m output_items \u001b[39m=\u001b[39m (\n\u001b[1;32m    761\u001b[0m   {\u001b[39m*\u001b[39m\u001b[39m*\u001b[39mitem, ROWID: rowid} \u001b[39mfor\u001b[39;00m (rowid, _), item \u001b[39min\u001b[39;00m \u001b[39mzip\u001b[39m(inputs_1, output_items) \u001b[39mif\u001b[39;00m item\n\u001b[1;32m    762\u001b[0m )\n\u001b[1;32m    764\u001b[0m \u001b[39m# Add progress.\u001b[39;00m\n\u001b[1;32m    765\u001b[0m \u001b[39mif\u001b[39;00m task_step_id \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_utils.py:96\u001b[0m, in \u001b[0;36m<genexpr>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     94\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mwrap_in_dicts\u001b[39m(\u001b[39minput\u001b[39m: Iterable[\u001b[39mobject\u001b[39m], spec: \u001b[39mlist\u001b[39m[PathTuple]) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Generator:\n\u001b[1;32m     95\u001b[0m \u001b[39m  \u001b[39m\u001b[39m\"\"\"Wraps an object or iterable in a dict according to the spec.\"\"\"\u001b[39;00m\n\u001b[0;32m---> 96\u001b[0m   \u001b[39mreturn\u001b[39;00m (_wrap_in_dicts(elem, spec) \u001b[39mfor\u001b[39;00m elem \u001b[39min\u001b[39;00m \u001b[39minput\u001b[39m)\n",
+      "File \u001b[0;32m~/Code/lilac/lilac/data/dataset_duckdb.py:2500\u001b[0m, in \u001b[0;36m_map_iterable\u001b[0;34m()\u001b[0m\n\u001b[1;32m   2498\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_map_iterable\u001b[39m(items: Iterable[RichData]) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Iterable[Optional[Item]]:\n\u001b[1;32m   2499\u001b[0m   \u001b[39mfor\u001b[39;00m item \u001b[39min\u001b[39;00m items:\n\u001b[0;32m-> 2500\u001b[0m     \u001b[39myield\u001b[39;00m map_fn(item, job_id\u001b[39m=\u001b[39mjob_id)\n",
+      "\u001b[1;32m/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb Cell 8\u001b[0m line \u001b[0;36m9\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m \u001b[39mglobal\u001b[39;00m i, throw_after_n\n\u001b[1;32m      <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m \u001b[39mif\u001b[39;00m throw_for_rowid \u001b[39mand\u001b[39;00m row[ll\u001b[39m.\u001b[39mROWID] \u001b[39m==\u001b[39m random_row_id:\n\u001b[0;32m----> <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m   \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\u001b[39mf\u001b[39m\u001b[39m'\u001b[39m\u001b[39mThrowing for \u001b[39m\u001b[39m{\u001b[39;00mrandom_row_id\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m)\n\u001b[1;32m     <a href='vscode-notebook-cell:/Users/nikhil/Code/lilac/notebooks/DatasetMap.ipynb#X60sZmlsZQ%3D%3D?line=9'>10</a>\u001b[0m \u001b[39mreturn\u001b[39;00m row[\u001b[39m'\u001b[39m\u001b[39mpremise\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m.\u001b[39mupper()\n",
+      "\u001b[0;31mValueError\u001b[0m: Throwing for 5c56d63b5f0a401696a8a20ac1f027fa"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Task finished \"c7e6304252154fd8a75f8ad5fc27f66e\": \"[local/glue_ax_map_2][12/12] map \"_upper\" to \"premise_upper2\"\" in 11s.\n"
+      "Task error \"8720732957904b099176a9f0c7320de1\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper2\"\" in 0s.\n"
      ]
     }
    ],
@@ -399,106 +265,45 @@
     "random_row_id = list(glue.select_rows([ll.ROWID], limit=1))[0][ll.ROWID]\n",
     "\n",
     "\n",
-    "def _upper(item):\n",
+    "def _upper(row: dict, job_id: int):\n",
     "  global i, throw_after_n\n",
-    "  if throw_for_rowid and item[ll.ROWID] == random_row_id:\n",
+    "  if throw_for_rowid and row[ll.ROWID] == random_row_id:\n",
     "    raise ValueError(f'Throwing for {random_row_id}')\n",
-    "  if not throw_for_rowid:\n",
-    "    print(item['premise'].upper())\n",
-    "  return item['premise'].upper()\n",
+    "  return row['premise'].upper()\n",
     "\n",
     "\n",
     "# This is going to throw after 10 iterations. When we call it again, it will only call _upper()\n",
     "# for the rest of the dataset.\n",
-    "glue.map(_upper, output_column='premise_upper2', overwrite=True, num_jobs=-1)"
+    "glue.map(_upper, output_column='premise_upper2', overwrite=True, num_jobs=1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Scheduling task \"37d5981f1df24e57932e66c18b451482\": \"[local/glue_ax_map_2][1/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"5427454733a14a16af71c66b30d7cc53\": \"[local/glue_ax_map_2][2/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"3510adb400e040db9eb0656cb16a43f5\": \"[local/glue_ax_map_2][3/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"17367dfd696d486e9a804c260b15d58b\": \"[local/glue_ax_map_2][4/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"a255d661dfb24a8a89e85a058ccd004f\": \"[local/glue_ax_map_2][5/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"d054c47d8ffb4fa7b05dd9ec4c6c1dab\": \"[local/glue_ax_map_2][6/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"c9cfa05c3fc0423285eda0e01a34a6cf\": \"[local/glue_ax_map_2][7/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"fe4f94cc4c0b4ac08cf1b84bdb59722c\": \"[local/glue_ax_map_2][8/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"474178fe84be4234add6574c00e1787d\": \"[local/glue_ax_map_2][9/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"04b7322f687541e7b84bb5a2d25cd94b\": \"[local/glue_ax_map_2][10/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"97a309cd763f46b7bace45709ac5ac76\": \"[local/glue_ax_map_2][11/12] map \"_upper\" to \"premise_upper2\"\".\n",
-      "Scheduling task \"83b94f11c5134242a63f60dee03d1829\": \"[local/glue_ax_map_2][12/12] map \"_upper\" to \"premise_upper2\"\".\n"
+      "Scheduling task \"4130416bb1a5464abebb69d7c6086920\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper2\"\".\n",
+      "Wrote map output to ./data/datasets/local/glue_ax_map/./data/datasets/local/glue_ax_map/premise_upper2-00000-of-00001.parquet\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[local/glue_ax_map_2][1/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][2/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][3/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][4/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "THE CAT SAT ON THE MAT.\n",
-      "SOME DOGS LIKE TO SCRATCH THEIR EARS.\n",
-      "ALL DOGS LIKE TO SCRATCH THEIR EARS.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][5/12] map \"_upper\" to \"premise_upper2\":   3%|▎         | 3/100 [00:00<00:07, 13.79it/s]\n",
-      "[local/glue_ax_map_2][6/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][7/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][9/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][8/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]]\n",
-      "[local/glue_ax_map_2][10/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Task finished \"5427454733a14a16af71c66b30d7cc53\": \"[local/glue_ax_map_2][2/12] map \"_upper\" to \"premise_upper2\"\" in 2s.\n",
-      "Task finished \"37d5981f1df24e57932e66c18b451482\": \"[local/glue_ax_map_2][1/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"3510adb400e040db9eb0656cb16a43f5\": \"[local/glue_ax_map_2][3/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"17367dfd696d486e9a804c260b15d58b\": \"[local/glue_ax_map_2][4/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"a255d661dfb24a8a89e85a058ccd004f\": \"[local/glue_ax_map_2][5/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"c9cfa05c3fc0423285eda0e01a34a6cf\": \"[local/glue_ax_map_2][7/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"d054c47d8ffb4fa7b05dd9ec4c6c1dab\": \"[local/glue_ax_map_2][6/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"474178fe84be4234add6574c00e1787d\": \"[local/glue_ax_map_2][9/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"fe4f94cc4c0b4ac08cf1b84bdb59722c\": \"[local/glue_ax_map_2][8/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"04b7322f687541e7b84bb5a2d25cd94b\": \"[local/glue_ax_map_2][10/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Wrote map output to ./data/datasets/local/glue_ax_map_2/premise_upper2-00000-of-00001.parquet\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[local/glue_ax_map_2][12/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n",
-      "[local/glue_ax_map_2][11/12] map \"_upper\" to \"premise_upper2\":   0%|          | 0/100 [00:00<?, ?it/s]\n"
+      "[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper2\": 100%|██████████| 1104/1104 [00:00<00:00, 36751.49it/s]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<lilac.data.dataset_duckdb.DuckDBMapOutput at 0x3200a3c90>"
+       "<lilac.data.dataset_duckdb.DuckDBMapOutput at 0x2dbcf2e50>"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -506,33 +311,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Task finished \"83b94f11c5134242a63f60dee03d1829\": \"[local/glue_ax_map_2][12/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n",
-      "Task finished \"97a309cd763f46b7bace45709ac5ac76\": \"[local/glue_ax_map_2][11/12] map \"_upper\" to \"premise_upper2\"\" in 3s.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-11-13 08:26:38,312 - tornado.application - ERROR - Exception in callback <bound method SystemMonitor.update of <SystemMonitor: cpu: 2 memory: 86 MB fds: 26>>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/tornado/ioloop.py\", line 919, in _run\n",
-      "    val = self.callback()\n",
-      "          ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/distributed/system_monitor.py\", line 168, in update\n",
-      "    net_ioc = psutil.net_io_counters()\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/psutil/__init__.py\", line 2119, in net_io_counters\n",
-      "    rawdict = _psplatform.net_io_counters()\n",
-      "              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "OSError: [Errno 12] Cannot allocate memory\n"
+      "Task finished \"4130416bb1a5464abebb69d7c6086920\": \"[local/glue_ax_map][shard 0/1] map \"_upper\" to \"premise_upper2\"\" in 0s.\n"
      ]
     }
    ],
    "source": [
     "throw_for_rowid = False\n",
     "# This will finish calling _upper, without calling it for the first 10 items.\n",
-    "glue.map(_upper, output_path='premise_upper2', num_jobs=-1)"
+    "glue.map(_upper, output_column='premise_upper2', num_jobs=1)"
    ]
   },
   {


### PR DESCRIPTION
Changes to `Dataset.map`:
- Adds `nest_under` to allows users to decide to put the output column under another column, allowing annotations like span highlighting from the UI.
- Renames `output_path` to `output_column` as a string to name the containing column for the map.
- Adds automatic inference for {__span__: {start: int, end: int}, 'metadata': ...} so that users dont have to define a schema for map and API calls to ll.lilac_span() will automatically create a span schema for highlighting.

Other *important* changes:
- When calling select_rows with combine_cols=False, we now flatten all columns to top-level. This is the same for the call to dataset.map().

[[Demo](https://lilacai-nikhil-staging.hf.space/datasets#local/glue_ax_map&showMetadataPanel=true&expandedStats=%7B%22premise.thes%22%3Atrue%7D&query=%7B%22filters%22%3A%5B%7B%22path%22%3A%5B%22premise%22%2C%22thes%22%5D%2C%22op%22%3A%22equals%22%2C%22value%22%3A%22the%22%7D%5D%7D)] [[Notebook](https://app.reviewnb.com/lilacai/lilac/pull/866/)]


Code that generates the UI below:
```py
import re
# Find instances of 'the'.
MATCH_REGEX = 'the'


def _find_the(row: dict, job_id: int) -> ll.Item:
  return [ll.lilac_span(m.start(), m.end()) for m in re.finditer(MATCH_REGEX, row['premise'])]

glue.map(
  _find_the, output_column='thes', nest_under='premise', overwrite=True, combine_columns=False
)

# Print the first three rows.
rows = glue.select_rows([ll.PATH_WILDCARD], combine_columns=False, limit=3)
for row in rows:
  print(row)
```

<img width="1265" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/ad693e93-fa72-4622-8bda-c3580c3deaff">

