### PR TITLE
Fix a bug with previewing and comparing on repeated values.

### DIFF
--- a/web/blueprint/src/lib/components/ButtonDropdown.svelte
+++ b/web/blueprint/src/lib/components/ButtonDropdown.svelte
@@ -3,7 +3,7 @@
   import type {ComboBoxItem} from 'carbon-components-svelte/types/ComboBox/ComboBox.svelte';
   import type {CarbonIcon} from 'carbon-icons-svelte';
   import {createEventDispatcher} from 'svelte';
-  import {hoist} from './common/Hoist';
+  import {hoistElement} from './common/Hoist';
   import {hoverTooltip} from './common/HoverTooltip';
   import {clickOutside} from './common/clickOutside';
 
@@ -20,6 +20,7 @@
   export let disabled = false;
   export let disabledMessage = '';
   export let redText = false;
+  export let hoist = false;
 
   const dispatch = createEventDispatcher();
 
@@ -75,7 +76,7 @@
       class="absolute z-50 w-60"
       class:hidden={!dropdownOpen}
       use:clickOutside={() => (dropdownOpen = false)}
-      use:hoist
+      use:hoistElement={{disable: !hoist}}
     >
       <ComboBox
         size="sm"

--- a/web/blueprint/src/lib/components/common/Hoist.ts
+++ b/web/blueprint/src/lib/components/common/Hoist.ts
@@ -1,10 +1,28 @@
+export interface HoistOptions {
+  // If true, the element will not be hoisted out of the DOM.
+  disable?: boolean;
+}
 /**
  * Hoists an element out of the DOM and positions it absolutely where it was.
  */
-export function hoist(element: HTMLElement) {
-  const boundingRect = element.getBoundingClientRect();
-  document.body.append(element);
-  element.style.position = 'absolute';
-  element.style.top = `${boundingRect.top}px`;
-  element.style.left = `${boundingRect.left}px`;
+export function hoistElement(element: HTMLElement, {disable}: HoistOptions) {
+  disable = disable ?? false;
+  const originalParent = element.parentElement;
+  if (!disable) {
+    const boundingRect = element.getBoundingClientRect();
+    document.body.append(element);
+    element.style.position = 'absolute';
+    element.style.top = `${boundingRect.top}px`;
+    element.style.left = `${boundingRect.left}px`;
+  }
+  return {
+    destroy() {
+      if (!disable) {
+        originalParent?.append(element);
+        element.style.position = '';
+        element.style.top = '';
+        element.style.left = '';
+      }
+    }
+  };
 }

--- a/web/blueprint/src/lib/components/datasetView/DatasetSettingsFields.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetSettingsFields.svelte
@@ -30,10 +30,8 @@
   $: settingsQuery = querySettings(namespace, datasetName);
 
   $: {
-    if (settings == null && !$settingsQuery.isFetching) {
+    if (!$settingsQuery.isFetching) {
       settings = JSON.parse(JSON.stringify($settingsQuery.data));
-      selectedMediaFields = null;
-      markdownMediaFields = null;
     }
   }
 
@@ -148,14 +146,19 @@
     if (
       markdownMediaFields == null &&
       mediaFieldOptions != null &&
-      $settingsQuery.data?.ui?.markdown_paths != null
+      $settingsQuery.data?.ui?.markdown_paths != null &&
+      !$settingsQuery.isFetching
     ) {
       const mardownPathsFromSettings = $settingsQuery.data.ui.markdown_paths.map(p =>
         Array.isArray(p) ? p : [p]
       );
-      markdownMediaFields = mediaFieldOptions.filter(f =>
-        mardownPathsFromSettings.some(path => pathIsEqual(f.path, path))
-      );
+      markdownMediaFields = mardownPathsFromSettings.flatMap(path => {
+        const field = mediaFieldOptions!.find(f => pathIsEqual(f.path, path));
+        if (field == null) {
+          return [];
+        }
+        return [field];
+      });
     }
   }
 
@@ -288,6 +291,7 @@
               items={mediaFieldOptionsItems}
               buttonText="Add media field"
               comboBoxPlaceholder="Add media field"
+              hoist={false}
               on:select={selectMediaField}
             />
           {/if}

--- a/web/blueprint/src/lib/components/datasetView/EditLabel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/EditLabel.svelte
@@ -123,6 +123,7 @@
     : disabled
     ? disabledMessage
     : ''}
+  hoist={false}
   buttonOutline
   buttonIcon={icon}
   bind:comboBoxText

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -93,19 +93,11 @@
   }
   // Returns the second path of a diff, if a given path is being diffed.
   let colCompareState: ColumnComparisonState | null = null;
-  let leftComparePath: Path | null = null;
-  let rightComparePath: Path | null = null;
   $: {
     colCompareState = null;
     for (const compareCols of $datasetViewStore.compareColumns) {
       if (pathIsEqual(compareCols.column, path)) {
         colCompareState = compareCols;
-        leftComparePath = colCompareState.swapDirection
-          ? colCompareState.compareToColumn
-          : colCompareState.column;
-        rightComparePath = colCompareState.swapDirection
-          ? colCompareState.column
-          : colCompareState.compareToColumn;
         break;
       }
     }

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -18,14 +18,7 @@
     type LilacValueNode,
     type Path
   } from '$lilac';
-  import {
-    ChevronDown,
-    ChevronUp,
-    DirectionFork,
-    PropertyRelationship,
-    Search,
-    Undo
-  } from 'carbon-icons-svelte';
+  import {ChevronDown, ChevronUp, DirectionFork, Search, Undo} from 'carbon-icons-svelte';
   import ButtonDropdown from '../ButtonDropdown.svelte';
   import {hoverTooltip} from '../common/HoverTooltip';
   import ItemMediaDiff from './ItemMediaDiff.svelte';
@@ -128,17 +121,7 @@
     <div class="relative flex w-28 flex-none font-mono font-medium text-neutral-500 md:w-44">
       <div class="sticky top-0 mt-2 flex w-full flex-col gap-y-2 self-start">
         <div title={displayPath(path)} class="w-full flex-initial truncate">
-          {#if colCompareState == null}
-            {displayPath(path)}
-          {:else if leftComparePath != null && rightComparePath != null}
-            <div class="mt-1 flex flex-col gap-y-2">
-              <div class="flex flex-row">
-                {displayPath(leftComparePath)}
-                <div class="ml-4"><PropertyRelationship /></div>
-              </div>
-              <div>{displayPath(rightComparePath)}</div>
-            </div>
-          {/if}
+          {displayPath(path)}
         </div>
         <div class="flex flex-row">
           <div
@@ -160,6 +143,7 @@
               items={compareItems}
               buttonIcon={DirectionFork}
               on:select={selectCompareColumn}
+              hoist={true}
             />
           {:else}
             <button

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -56,7 +56,7 @@
         .map(v => L.path(v))
         .filter(p => !pathIsEqual(p, path));
       return paths;
-    });
+    }) as Path[];
 
   $: compareItems = compareMediaPaths.map(p => ({
     id: p,

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -43,11 +43,22 @@
   const datasetViewStore = getDatasetViewContext();
   const appSettings = getSettingsContext();
 
+  $: valueNode = getValueNodes(row, path)[0];
+  $: value = L.value(valueNode);
+
   $: datasetSettings = querySettings($datasetViewStore.namespace, $datasetViewStore.datasetName);
-  $: mediaPaths = ($datasetSettings.data?.ui?.media_paths || [])
+  // Compare media paths should contain media paths with resolved path wildcards as sometimes the
+  // user wants to compare items in an array.
+  $: compareMediaPaths = ($datasetSettings.data?.ui?.media_paths || [])
     .map(p => (Array.isArray(p) ? p : [p]))
-    .filter(p => !pathIsEqual(p, path));
-  $: compareItems = mediaPaths.map(p => ({
+    .flatMap(p => {
+      const paths = getValueNodes(row, p)
+        .map(v => L.path(v))
+        .filter(p => !pathIsEqual(p, path));
+      return paths;
+    });
+
+  $: compareItems = compareMediaPaths.map(p => ({
     id: p,
     text: displayPath(p)
   }));
@@ -58,12 +69,11 @@
   $: schema = queryDatasetSchema($datasetViewStore.namespace, $datasetViewStore.datasetName);
 
   $: computedEmbeddings = getComputedEmbeddings($schema.data, path);
+  $: noEmbeddings = computedEmbeddings.length === 0;
 
   $: spanValuePaths = getSpanValuePaths(field, highlightedFields);
 
   $: settings = querySettings($datasetViewStore.namespace, $datasetViewStore.datasetName);
-
-  $: valueNodes = getValueNodes(row, path);
 
   function findSimilar(searchText: DataTypeCasted) {
     let embedding = computedEmbeddings[0];
@@ -112,86 +122,81 @@
   }
 </script>
 
-{#each valueNodes as valueNode}
-  {@const value = L.value(valueNode)}
-  {@const noEmbeddings = computedEmbeddings.length === 0}
-  {#if notEmpty(value)}
-    {@const path = L.path(valueNode) || []}
-    {@const markdown = $settings.data?.ui?.markdown_paths?.find(p => pathIsEqual(p, path)) != null}
-    <div class="flex w-full gap-x-4">
-      <div class="relative flex w-28 flex-none font-mono font-medium text-neutral-500 md:w-44">
-        <div class="sticky top-0 mt-2 flex w-full flex-col gap-y-2 self-start">
-          <div title={displayPath(path)} class="w-full flex-initial truncate">
-            {#if colCompareState == null}
-              {displayPath(path)}
-            {:else if leftComparePath != null && rightComparePath != null}
-              <div class="mt-1 flex flex-col gap-y-2">
-                <div class="flex flex-row">
-                  {displayPath(leftComparePath)}
-                  <div class="ml-4"><PropertyRelationship /></div>
-                </div>
-                <div>{displayPath(rightComparePath)}</div>
+{#if notEmpty(valueNode)}
+  {@const markdown = $settings.data?.ui?.markdown_paths?.find(p => pathIsEqual(p, path)) != null}
+  <div class="flex w-full gap-x-4">
+    <div class="relative flex w-28 flex-none font-mono font-medium text-neutral-500 md:w-44">
+      <div class="sticky top-0 mt-2 flex w-full flex-col gap-y-2 self-start">
+        <div title={displayPath(path)} class="w-full flex-initial truncate">
+          {#if colCompareState == null}
+            {displayPath(path)}
+          {:else if leftComparePath != null && rightComparePath != null}
+            <div class="mt-1 flex flex-col gap-y-2">
+              <div class="flex flex-row">
+                {displayPath(leftComparePath)}
+                <div class="ml-4"><PropertyRelationship /></div>
               </div>
-            {/if}
-          </div>
-          <div class="flex flex-row">
-            <div
-              use:hoverTooltip={{
-                text: noEmbeddings ? '"More like this" requires an embedding index' : undefined
-              }}
-              class:opacity-50={noEmbeddings}
-            >
-              <button
-                disabled={noEmbeddings}
-                on:click={() => findSimilar(value)}
-                use:hoverTooltip={{text: 'More like this'}}
-                ><Search size={16} />
-              </button>
+              <div>{displayPath(rightComparePath)}</div>
             </div>
-            {#if !colCompareState}
-              <ButtonDropdown
-                helperText={'Compare to'}
-                items={compareItems}
-                buttonIcon={DirectionFork}
-                on:select={selectCompareColumn}
-              />
-            {:else}
-              <button
-                on:click={() => removeComparison()}
-                use:hoverTooltip={{text: 'Remove comparison'}}
-                ><Undo size={16} />
-              </button>
-            {/if}
+          {/if}
+        </div>
+        <div class="flex flex-row">
+          <div
+            use:hoverTooltip={{
+              text: noEmbeddings ? '"More like this" requires an embedding index' : undefined
+            }}
+            class:opacity-50={noEmbeddings}
+          >
             <button
-              disabled={!textIsOverBudget}
-              class:opacity-50={!textIsOverBudget}
-              on:click={() => (userExpanded = !userExpanded)}
-              use:hoverTooltip={{text: userExpanded ? 'Collapse text' : 'Expand text'}}
-              >{#if userExpanded}<ChevronUp size={16} />{:else}<ChevronDown size={16} />{/if}
+              disabled={noEmbeddings}
+              on:click={() => findSimilar(value)}
+              use:hoverTooltip={{text: 'More like this'}}
+              ><Search size={16} />
             </button>
           </div>
+          {#if !colCompareState}
+            <ButtonDropdown
+              helperText={'Compare to'}
+              items={compareItems}
+              buttonIcon={DirectionFork}
+              on:select={selectCompareColumn}
+            />
+          {:else}
+            <button
+              on:click={() => removeComparison()}
+              use:hoverTooltip={{text: 'Remove comparison'}}
+              ><Undo size={16} />
+            </button>
+          {/if}
+          <button
+            disabled={!textIsOverBudget}
+            class:opacity-50={!textIsOverBudget}
+            on:click={() => (userExpanded = !userExpanded)}
+            use:hoverTooltip={{text: userExpanded ? 'Collapse text' : 'Expand text'}}
+            >{#if userExpanded}<ChevronUp size={16} />{:else}<ChevronDown size={16} />{/if}
+          </button>
         </div>
       </div>
-
-      <div class="w-full grow-0 overflow-x-auto pt-1 font-normal">
-        {#if colCompareState == null}
-          <StringSpanHighlight
-            text={formatValue(value)}
-            {row}
-            {path}
-            {field}
-            {markdown}
-            isExpanded={userExpanded}
-            spanPaths={spanValuePaths.spanPaths}
-            valuePaths={spanValuePaths.valuePaths}
-            {datasetViewStore}
-            embeddings={computedEmbeddings}
-            bind:textIsOverBudget
-          />
-        {:else}
-          <ItemMediaDiff {row} {colCompareState} bind:textIsOverBudget isExpanded={userExpanded} />
-        {/if}
-      </div>
     </div>
-  {/if}
-{/each}
+
+    <div class="w-full grow-0 overflow-x-auto pt-1 font-normal">
+      {#if colCompareState == null}
+        <StringSpanHighlight
+          text={formatValue(value)}
+          {row}
+          {path}
+          {field}
+          {markdown}
+          isExpanded={userExpanded}
+          spanPaths={spanValuePaths.spanPaths}
+          valuePaths={spanValuePaths.valuePaths}
+          {datasetViewStore}
+          embeddings={computedEmbeddings}
+          bind:textIsOverBudget
+        />
+      {:else}
+        <ItemMediaDiff {row} {colCompareState} bind:textIsOverBudget isExpanded={userExpanded} />
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -15,8 +15,10 @@
   import {getNotificationsContext} from '$lib/stores/notificationsStore';
   import {SIDEBAR_TRANSITION_TIME_MS} from '$lib/view_utils';
   import {
+    L,
     getRowLabels,
     getSchemaLabels,
+    getValueNodes,
     serializePath,
     type AddLabelsOptions,
     type LilacField,
@@ -157,13 +159,17 @@
       </div>
       {#if mediaFields.length > 0}
         {#each mediaFields as mediaField, i (serializePath(mediaField.path))}
-          <div
-            class:border-b={i < mediaFields.length - 1}
-            class:pb-2={i < mediaFields.length - 1}
-            class="flex h-full w-full flex-col border-neutral-200"
-          >
-            <ItemMedia {row} path={mediaField.path} field={mediaField} {highlightedFields} />
-          </div>
+          {@const valueNodes = getValueNodes(row, mediaField.path)}
+          {#each valueNodes as valueNode}
+            {@const path = L.path(valueNode) || []}
+            <div
+              class:border-b={i < mediaFields.length - 1}
+              class:pb-2={i < mediaFields.length - 1}
+              class="flex h-full w-full flex-col border-neutral-200"
+            >
+              <ItemMedia {row} {path} field={mediaField} {highlightedFields} />
+            </div>
+          {/each}
         {/each}
       {/if}
       <div class="absolute right-0 top-0">

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -20,7 +20,7 @@
     type LilacValueNodeCasted,
     type Path
   } from '$lilac';
-  import {getContext} from 'svelte';
+  import {createEventDispatcher, getContext} from 'svelte';
   import SvelteMarkdown from 'svelte-markdown';
   import type {Writable} from 'svelte/store';
   import {hoverTooltip} from '../common/HoverTooltip';
@@ -54,6 +54,8 @@
   export let isExpanded = false;
   // Passed back up to the parent.
   export let textIsOverBudget = false;
+
+  const dispatch = createEventDispatcher();
 
   const urlHashContext = getUrlHashContext();
 

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -20,7 +20,7 @@
     type LilacValueNodeCasted,
     type Path
   } from '$lilac';
-  import {createEventDispatcher, getContext} from 'svelte';
+  import {getContext} from 'svelte';
   import SvelteMarkdown from 'svelte-markdown';
   import type {Writable} from 'svelte/store';
   import {hoverTooltip} from '../common/HoverTooltip';
@@ -54,8 +54,6 @@
   export let isExpanded = false;
   // Passed back up to the parent.
   export let textIsOverBudget = false;
-
-  const dispatch = createEventDispatcher();
 
   const urlHashContext = getUrlHashContext();
 


### PR DESCRIPTION
- Make ItemMedia work on a single leaf path instead of an array, allowing us to bind overflow properly.
- Allow comparison across resolved path-wildcards for repeated (e.g. compare x[0] with x[1])

https://lilacai-nikhil-staging.hf.space/datasets#local/OpenHermes-2.5&compareColumns=%5B%7B%22column%22%3A%5B%22conversations%22%2C%221%22%2C%22value%22%5D%2C%22compareToColumn%22%3A%5B%22conversations%22%2C%220%22%2C%22value%22%5D%2C%22swapDirection%22%3Afalse%7D%5D&rowId=%22ffff3c3c-eaee-4847-8599-90eae0164d7c%22

<img width="936" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/f99c7208-28db-457b-8956-d91b34cfe965">
