### PR TITLE
Add support for input paths to dataset.map.

### DIFF
--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -581,6 +581,7 @@ class Dataset(abc.ABC):
   def map(
     self,
     map_fn: MapFn,
+    input_path: Optional[Path] = None,
     output_column: Optional[str] = None,
     nest_under: Optional[Path] = None,
     overwrite: bool = False,
@@ -593,6 +594,10 @@ class Dataset(abc.ABC):
     Args:
       map_fn: A callable that takes a full row item dictionary, and returns an Item for the
         result. The result Item can be a primitive, like a string.
+      input_path: The path to the input column to map over. If not specified, the map function will
+        be called with the full row item dictionary. If specified, the map function will be called
+        with the value at the given path, flattened. The output column will be written in the same
+        shape as the input column, paralleling its nestedness.
       output_column: The name of the output column to write to. When `nest_under` is False
         (the default), this will be the name of the top-level column. When `nest_under` is True,
         the output_column will be the name of the column under the path given by `nest_under`.

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -2457,6 +2457,8 @@ class DatasetDuckDB(Dataset):
 
     manifest = self.manifest()
 
+    input_path = normalize_path(input_path) if input_path else None
+
     # Validate output_column and nest_under.
     if nest_under is not None:
       nest_under = normalize_path(nest_under)
@@ -2535,7 +2537,7 @@ class DatasetDuckDB(Dataset):
         jsonl_cache_filepath,
         i,
         num_jobs,
-        normalize_path(input_path) if input_path else None,
+        input_path,
         overwrite,
         combine_columns,
         resolve_span,
@@ -2559,7 +2561,10 @@ class DatasetDuckDB(Dataset):
       map_field_root = map_schema.get_field(output_path)
 
       map_field_root.map = MapInfo(
-        fn_name=map_fn.__name__, fn_source=inspect.getsource(map_fn), date_created=datetime.now()
+        fn_name=map_fn.__name__,
+        input_path=input_path,
+        fn_source=inspect.getsource(map_fn),
+        date_created=datetime.now(),
       )
 
       parquet_dir = os.path.dirname(parquet_filepath)

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -783,8 +783,10 @@ class DatasetDuckDB(Dataset):
           flat_input, lambda x: signal.compute(cast(Iterable[RichData], x))
         )
       else:
-        raise ValueError(f'Unknown type of transform_fn: {type(transform_fn)}')
-
+        flat_input = cast(Iterator[Optional[RichData]], deep_flatten(input_values_0))
+        dense_out = sparse_to_dense_compute(
+          flat_input, lambda x: transform_fn(cast(Iterable[RichData], x))
+        )
       output_items = deep_unflatten(dense_out, input_values_1)
 
     else:
@@ -2443,6 +2445,7 @@ class DatasetDuckDB(Dataset):
   def map(
     self,
     map_fn: MapFn,
+    input_path: Optional[Path] = None,
     output_column: Optional[str] = None,
     nest_under: Optional[Path] = None,
     overwrite: bool = False,
@@ -2532,6 +2535,7 @@ class DatasetDuckDB(Dataset):
         jsonl_cache_filepath,
         i,
         num_jobs,
+        normalize_path(input_path) if input_path else None,
         overwrite,
         combine_columns,
         resolve_span,
@@ -2582,6 +2586,7 @@ class DatasetDuckDB(Dataset):
     jsonl_cache_filepath: str,
     job_id: int,
     job_count: int,
+    unnest_input_path: Optional[PathTuple] = None,
     overwrite: bool = False,
     combine_columns: bool = False,
     resolve_span: bool = False,
@@ -2595,6 +2600,7 @@ class DatasetDuckDB(Dataset):
       _map_iterable,
       output_path=output_path,
       jsonl_cache_filepath=jsonl_cache_filepath,
+      unnest_input_path=unnest_input_path,
       overwrite=overwrite,
       combine_columns=combine_columns,
       resolve_span=resolve_span,

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -783,9 +783,11 @@ class DatasetDuckDB(Dataset):
           flat_input, lambda x: signal.compute(cast(Iterable[RichData], x))
         )
       else:
+        map_fn = transform_fn
+        assert not isinstance(map_fn, Signal)
         flat_input = cast(Iterator[Optional[RichData]], deep_flatten(input_values_0))
         dense_out = sparse_to_dense_compute(
-          flat_input, lambda x: transform_fn(cast(Iterable[RichData], x))
+          flat_input, lambda x: map_fn(cast(Iterable[RichData], x))
         )
       output_items = deep_unflatten(dense_out, input_values_1)
 

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -2458,6 +2458,13 @@ class DatasetDuckDB(Dataset):
     manifest = self.manifest()
 
     input_path = normalize_path(input_path) if input_path else None
+    if input_path:
+      input_field = manifest.data_schema.get_field(input_path)
+      if not input_field.dtype:
+        raise ValueError(
+          f'Input path {input_path} is not a leaf path. This is currently unsupported. If you '
+          'require this, please file an issue and we will prioritize.'
+        )
 
     # Validate output_column and nest_under.
     if nest_under is not None:

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -291,6 +291,22 @@ def test_map_input_path_nested(
   ]
 
 
+def test_map_input_path_nonleaf_throws(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(
+    [
+      {'id': 0, 'text': ['a']},
+      {'id': 1, 'text': ['b']},
+      {'id': 2, 'text': ['c']},
+    ]
+  )
+
+  def _upper(row: Item, job_id: int) -> Item:
+    return str(row).upper()
+
+  with pytest.raises(Exception):
+    dataset.map(_upper, input_path='text', output_column='text_upper')
+
+
 @pytest.mark.parametrize('num_jobs', [1, 2])
 def test_map_continuation(
   num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMaker, test_dask_logger: TestDaskLogger

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -218,7 +218,10 @@ def test_map_input_path(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMak
         'text_upper': field(
           dtype='string',
           map=MapInfo(
-            fn_name='_upper', fn_source=inspect.getsource(_upper), date_created=TEST_TIME
+            fn_name='_upper',
+            input_path=('text',),
+            fn_source=inspect.getsource(_upper),
+            date_created=TEST_TIME,
           ),
         ),
       }
@@ -268,7 +271,10 @@ def test_map_input_path_nested(
         'texts_upper': field(
           fields=['string'],
           map=MapInfo(
-            fn_name='_upper', fn_source=inspect.getsource(_upper), date_created=TEST_TIME
+            fn_name='_upper',
+            input_path=('texts', PATH_WILDCARD, 'value'),
+            fn_source=inspect.getsource(_upper),
+            date_created=TEST_TIME,
           ),
         ),
       }

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -192,6 +192,100 @@ def test_map_job_id(make_test_data: TestDataMaker, test_dask_logger: TestDaskLog
 
 
 @pytest.mark.parametrize('num_jobs', [1, 2])
+def test_map_input_path(num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(
+    [
+      {'id': 0, 'text': 'a'},
+      {'id': 1, 'text': 'b'},
+      {'id': 2, 'text': 'c'},
+    ]
+  )
+
+  def _upper(row: Item, job_id: int) -> Item:
+    return str(row).upper()
+
+  # Write the output to a new column.
+  dataset.map(_upper, input_path='text', output_column='text_upper', num_jobs=num_jobs)
+
+  # The schema should not reflect the output of the map as it didn't finish.
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'text': 'string',
+        'id': 'int32',
+        'text_upper': field(
+          dtype='string',
+          map=MapInfo(
+            fn_name='_upper', fn_source=inspect.getsource(_upper), date_created=TEST_TIME
+          ),
+        ),
+      }
+    ),
+    num_items=3,
+    source=TestSource(),
+  )
+  # The rows should not reflect the output of the unfinished map.
+  rows = list(dataset.select_rows([PATH_WILDCARD]))
+  assert rows == [
+    {'text': 'a', 'id': 0, 'text_upper': 'A'},
+    {'text': 'b', 'id': 1, 'text_upper': 'B'},
+    {'text': 'c', 'id': 2, 'text_upper': 'C'},
+  ]
+
+
+@pytest.mark.parametrize('num_jobs', [1, 2])
+def test_map_input_path_nested(
+  num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMaker, test_dask_logger: TestDaskLogger
+) -> None:
+  dataset = make_test_data(
+    [
+      {'id': 0, 'texts': [{'value': 'a'}]},
+      {'id': 1, 'texts': [{'value': 'b'}, {'value': 'c'}]},
+      {'id': 2, 'texts': [{'value': 'd'}, {'value': 'e'}, {'value': 'f'}]},
+    ]
+  )
+
+  def _upper(row: Item, job_id: int) -> Item:
+    return str(row).upper()
+
+  dataset.map(
+    _upper,
+    input_path=('texts', PATH_WILDCARD, 'value'),
+    output_column='texts_upper',
+    num_jobs=num_jobs,
+  )
+
+  # The schema should not reflect the output of the map as it didn't finish.
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'texts': [{'value': 'string'}],
+        'id': 'int32',
+        'texts_upper': field(
+          fields=['string'],
+          map=MapInfo(
+            fn_name='_upper', fn_source=inspect.getsource(_upper), date_created=TEST_TIME
+          ),
+        ),
+      }
+    ),
+    num_items=3,
+    source=TestSource(),
+  )
+  # The rows should not reflect the output of the unfinished map.
+  rows = list(dataset.select_rows([PATH_WILDCARD]))
+  assert rows == [
+    {'id': 0, 'texts.*.value': ['a'], 'texts_upper.*': ['A']},
+    {'id': 1, 'texts.*.value': ['b', 'c'], 'texts_upper.*': ['B', 'C']},
+    {'id': 2, 'texts.*.value': ['d', 'e', 'f'], 'texts_upper.*': ['D', 'E', 'F']},
+  ]
+
+
+@pytest.mark.parametrize('num_jobs', [1, 2])
 def test_map_continuation(
   num_jobs: Literal[-1, 1, 2], make_test_data: TestDataMaker, test_dask_logger: TestDaskLogger
 ) -> None:

--- a/lilac/schema.py
+++ b/lilac/schema.py
@@ -220,6 +220,7 @@ class MapInfo(BaseModel):
   """Holds information about a map that was run on a dataset."""
 
   fn_name: str
+  input_path: Optional[PathTuple] = None
   fn_source: str
   date_created: datetime
 

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -29,7 +29,6 @@
   import type {SpanDetails} from './StringSpanDetails.svelte';
   import {LABELED_TEXT_COLOR, colorFromOpacity} from './colors';
   import {
-    SNIPPET_LEN_BUDGET,
     getRenderSpans,
     getSnippetSpans,
     type RenderSpan,
@@ -173,23 +172,11 @@
   };
 
   const notificationStore = getNotificationsContext();
-
-  let totalSnippetLength = 0;
-  $: {
-    totalSnippetLength = 0;
-    for (const snippetSpan of snippetSpans) {
-      if (!snippetSpan.isEllipsis) {
-        totalSnippetLength += snippetSpan.snippetText.length;
-      }
-    }
-  }
 </script>
 
 <div
   class="overflow-x-hidden text-ellipsis whitespace-break-spaces"
-  class:text-preview-overlay={textIsOverBudget &&
-    totalSnippetLength > SNIPPET_LEN_BUDGET &&
-    !isExpanded}
+  class:text-preview-overlay={textIsOverBudget && !isExpanded}
 >
   {#each snippetSpans as snippetSpan}
     {#if !snippetSpan.isEllipsis}

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -29,6 +29,7 @@
   import type {SpanDetails} from './StringSpanDetails.svelte';
   import {LABELED_TEXT_COLOR, colorFromOpacity} from './colors';
   import {
+    SNIPPET_LEN_BUDGET,
     getRenderSpans,
     getSnippetSpans,
     type RenderSpan,
@@ -172,11 +173,23 @@
   };
 
   const notificationStore = getNotificationsContext();
+
+  let totalSnippetLength = 0;
+  $: {
+    totalSnippetLength = 0;
+    for (const snippetSpan of snippetSpans) {
+      if (!snippetSpan.isEllipsis) {
+        totalSnippetLength += snippetSpan.snippetText.length;
+      }
+    }
+  }
 </script>
 
 <div
   class="overflow-x-hidden text-ellipsis whitespace-break-spaces"
-  class:text-preview-overlay={textIsOverBudget && !isExpanded}
+  class:text-preview-overlay={textIsOverBudget &&
+    totalSnippetLength > SNIPPET_LEN_BUDGET &&
+    !isExpanded}
 >
   {#each snippetSpans as snippetSpan}
     {#if !snippetSpan.isEllipsis}

--- a/web/lib/fastapi_client/models/MapInfo.ts
+++ b/web/lib/fastapi_client/models/MapInfo.ts
@@ -8,6 +8,7 @@
  */
 export type MapInfo = {
     fn_name: string;
+    input_path?: (Array<string> | null);
     fn_source: string;
     date_created: string;
 };


### PR DESCRIPTION
When passing an input path, the value will get flattened and passed one-by-one to dataset.map. The output structure will parallel the repeated structure of the input.

MapInfo now contains the input_path if passed, so the UI can automatically show lineage information.

Demo (the second copy is generated by a map): https://lilacai-nikhil-staging.hf.space/datasets#local/OpenHermes-2.5