### PR TITLE
Add rendering of string spans that were derived from a map with input path

### DIFF
--- a/web/blueprint/src/lib/components/datasetView/ItemMetadata.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMetadata.svelte
@@ -53,14 +53,12 @@
             if (node) {
               const text = L.value<'string'>(node);
               if (text) {
-                console.log('text', text);
                 stringValues.push(text.slice(span.start, span.end));
                 break;
               }
             }
           }
         }
-        console.log(field.path, stringValues);
         value = stringValues as unknown as DataTypeCasted;
       }
     }

--- a/web/blueprint/src/lib/components/datasetView/ItemMetadata.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMetadata.svelte
@@ -17,7 +17,8 @@
     type DataTypeCasted,
     type LilacField,
     type LilacSelectRowsSchema,
-    type LilacValueNode
+    type LilacValueNode,
+    type Path
   } from '$lilac';
   import ItemMetadataField, {type RenderNode} from './ItemMetadataField.svelte';
 
@@ -36,18 +37,30 @@
       // We default to __value__ for back compat.
       span = span || (value as {start: number; end: number});
       if (span != null) {
-        const stringValues = [];
+        const stringValues: string[] = [];
         // Get the parent that is dtype string to resolve the span.
         for (let i = path.length - 1; i >= 0; i--) {
           const parentPath = path.slice(0, i);
           const parent = getField(selectRowsSchema!.schema, parentPath)!;
-
-          if (parent.dtype?.type === 'string') {
-            const text = L.value<'string'>(valueAtPath(row, parentPath)!)!;
-            stringValues.push(text.slice(span.start, span.end));
-            break;
+          let stringPath: Path | null = null;
+          if (parent.map?.input_path != null) {
+            stringPath = parent.map.input_path;
+          } else if (parent.dtype?.type === 'string') {
+            stringPath = parentPath;
+          }
+          if (stringPath != null) {
+            const node = valueAtPath(row, stringPath);
+            if (node) {
+              const text = L.value<'string'>(node);
+              if (text) {
+                console.log('text', text);
+                stringValues.push(text.slice(span.start, span.end));
+                break;
+              }
+            }
           }
         }
+        console.log(field.path, stringValues);
         value = stringValues as unknown as DataTypeCasted;
       }
     }

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -13,6 +13,7 @@
     getValueNodes,
     pathIncludes,
     pathIsEqual,
+    pathMatchesPrefix,
     serializePath,
     type ConceptSignal,
     type LilacField,
@@ -66,10 +67,11 @@
   $: {
     pathToSpans = {};
     spanPaths.forEach(sp => {
-      const valueNodes = getValueNodes(row, sp);
-      pathToSpans[serializePath(sp)] = valueNodes.filter(
-        v => pathIncludes(L.path(v), path) || path == null
-      ) as LilacValueNodeCasted<'string_span'>[];
+      let valueNodes = getValueNodes(row, sp);
+      if (pathMatchesPrefix(path, sp)) {
+        valueNodes = valueNodes.filter(v => pathIncludes(L.path(v), path) || path == null);
+      }
+      pathToSpans[serializePath(sp)] = valueNodes as LilacValueNodeCasted<'string_span'>[];
     });
   }
 

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -68,7 +68,10 @@
     pathToSpans = {};
     spanPaths.forEach(sp => {
       let valueNodes = getValueNodes(row, sp);
-      if (pathMatchesPrefix(path, sp)) {
+      const isSpanNestedUnder = pathMatchesPrefix(path, sp);
+      if (isSpanNestedUnder) {
+        // Filter out any span values that do not share the same coordinates as the current path we
+        // are rendering.
         valueNodes = valueNodes.filter(v => pathIncludes(L.path(v), path) || path == null);
       }
       pathToSpans[serializePath(sp)] = valueNodes as LilacValueNodeCasted<'string_span'>[];

--- a/web/blueprint/src/lib/view_utils.ts
+++ b/web/blueprint/src/lib/view_utils.ts
@@ -335,7 +335,7 @@ export function conceptDisplayName(
 }
 
 /** Returns the input path used to compute this field, if it was computed via map, otherwise returns undefined. */
-function getInputPath(field: LilacField): Path | undefined {
+function getMapInputPath(field: LilacField): Path | undefined {
   let currentField: LilacField | undefined = field;
   while (currentField != null) {
     if (currentField.map?.input_path) {
@@ -373,7 +373,7 @@ export function getSpanValuePaths(
   // Find if any of the highlighted fields were derived from the current field and include any
   // spans from those fields as well.
   for (const highlightedField of highlightedFields || []) {
-    const inputPath = getInputPath(highlightedField);
+    const inputPath = getMapInputPath(highlightedField);
     const derivedFromCurrentField = inputPath && pathIsEqual(inputPath, field.path);
     if (derivedFromCurrentField) {
       const highlightedSpans = childFields(highlightedField).filter(

--- a/web/blueprint/src/lib/view_utils.ts
+++ b/web/blueprint/src/lib/view_utils.ts
@@ -334,6 +334,17 @@ export function conceptDisplayName(
   return `${conceptNamespace}/${conceptName}`;
 }
 
+/** Returns the input path used to compute this field, if it was computed via map, otherwise returns undefined. */
+function getInputPath(field: LilacField): Path | undefined {
+  let currentField: LilacField | undefined = field;
+  while (currentField != null) {
+    if (currentField.map?.input_path) {
+      return currentField.map.input_path;
+    }
+    currentField = field.parent != currentField ? field.parent : undefined;
+  }
+}
+
 export function getSpanValuePaths(
   field: LilacField,
   highlightedFields?: LilacField[]
@@ -357,6 +368,19 @@ export function getSpanValuePaths(
     spanFields = spanFields.filter(f =>
       childFields(f).some(c => highlightedFields.some(v => pathIncludes(c.path, v.path)))
     );
+  }
+
+  // Find if any of the highlighted fields were derived from the current field and include any
+  // spans from those fields as well.
+  for (const highlightedField of highlightedFields || []) {
+    const inputPath = getInputPath(highlightedField);
+    const derivedFromCurrentField = inputPath && pathIsEqual(inputPath, field.path);
+    if (derivedFromCurrentField) {
+      const highlightedSpans = childFields(highlightedField).filter(
+        f => f.dtype?.type === 'string_span'
+      );
+      spanFields = [...spanFields, ...highlightedSpans];
+    }
   }
 
   const spanPaths = spanFields.map(f => f.path);

--- a/web/lib/src/schema.ts
+++ b/web/lib/src/schema.ts
@@ -145,6 +145,17 @@ export function pathIncludes(
   return pathIsEqual(path.slice(0, prefix.length), prefix);
 }
 
+/** Return true if the path matches a prefix, with support for wildcards. */
+export function pathMatchesPrefix(path: Path | undefined, prefix: Path | undefined) {
+  if (!path || !prefix) return false;
+  if (path.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (prefix[i] === PATH_WILDCARD || path[i] == PATH_WILDCARD) continue;
+    if (prefix[i] !== path[i]) return false;
+  }
+  return true;
+}
+
 /**
  * Returns true if path2 matches the pattern of path1
  * @param path1 Path that may contain wildcard pattern


### PR DESCRIPTION
https://huggingface.co/spaces/lilacai/daniel_staging

Deeplink to a demo with 2 filters active: https://lilacai-daniel-staging.hf.space/datasets#local/glaive-coder&expandedStats=%7B%22question.spacy_ner%22%3Atrue%2C%22q_pii.credit_card%22%3Atrue%7D&query=%7B%22filters%22%3A%5B%7B%22path%22%3A%5B%22question%22%2C%22spacy_ner%22%5D%2C%22op%22%3A%22equals%22%2C%22value%22%3A%22Python%22%7D%2C%7B%22path%22%3A%5B%22q_pii%22%2C%22credit_card%22%5D%2C%22op%22%3A%22equals%22%2C%22value%22%3A%221111111111111000%22%7D%5D%7D&schemaCollapsed=false