### PR TITLE
Prefer existing embedding in embedding retrieval function

### DIFF
--- a/web/blueprint/src/lib/view_utils.ts
+++ b/web/blueprint/src/lib/view_utils.ts
@@ -116,32 +116,33 @@ export function getSearchEmbedding(
   searchPath: Path | undefined,
   embeddings: string[]
 ): string | null {
+  const existingEmbeddings = getComputedEmbeddings(schema, searchPath);
+  if (existingEmbeddings != null && existingEmbeddings.length > 0) {
+    // Sort embeddings by what have already been precomputed first.
+    const sortedEmbeddings =
+      existingEmbeddings != null
+        ? [...(embeddings || [])].sort((a, b) => {
+            const hasA = existingEmbeddings.includes(a);
+            const hasB = existingEmbeddings.includes(b);
+            if (hasA && hasB) {
+              return 0;
+            } else if (hasA) {
+              return -1;
+            } else if (hasB) {
+              return 1;
+            }
+            return 0;
+          })
+        : [];
+    return sortedEmbeddings[0];
+  }
   if (datasetSettings != null && datasetSettings.preferred_embedding != null) {
     return datasetSettings.preferred_embedding;
   }
   if (appSettings.embedding != null) {
     return appSettings.embedding;
   }
-  if (searchPath == null) return null;
-
-  const existingEmbeddings = getComputedEmbeddings(schema, searchPath);
-  // Sort embeddings by what have already been precomputed first.
-  const sortedEmbeddings =
-    existingEmbeddings != null
-      ? [...(embeddings || [])].sort((a, b) => {
-          const hasA = existingEmbeddings.includes(a);
-          const hasB = existingEmbeddings.includes(b);
-          if (hasA && hasB) {
-            return 0;
-          } else if (hasA) {
-            return -1;
-          } else if (hasB) {
-            return 1;
-          }
-          return 0;
-        })
-      : [];
-  return sortedEmbeddings[0];
+  return null;
 }
 
 /** Get the computed embeddings for a path. */


### PR DESCRIPTION
Before, I had computed "gte-base" but searchbox still suggests "Compute Embedding":

![Screenshot 2023-11-27 at 11 30 59 AM](https://github.com/lilacai/lilac/assets/1320214/631e7c27-a15f-4331-9069-5611783c39aa)

After:

![Screenshot 2023-11-27 at 11 31 09 AM](https://github.com/lilacai/lilac/assets/1320214/c8cd1057-5849-41b8-aece-08418a593363)

Not sure what else might be affected by changing this function, though...