### PR TITLE
Fix UI bugs with span rendering of maps.

### DIFF
--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -2808,9 +2808,16 @@ def _select_sql(
 
 def read_source_manifest(dataset_path: str) -> SourceManifest:
   """Read the manifest file."""
+  manifest_filepath = os.path.join(dataset_path, MANIFEST_FILENAME)
+  if not os.path.exists(manifest_filepath):
+    raise ValueError(
+      f'Dataset manifest does not exist at path: {manifest_filepath}. '
+      'Please check that the dataset name is correct and that you set the lilac project dir '
+      'correctly. To set the project dir call: `ll.set_project_dir("path/to/project")`.'
+    )
   # TODO(nsthorat): Overwrite the source manifest with a "source" added if the source is not defined
   # by reading the config yml.
-  with open_file(os.path.join(dataset_path, MANIFEST_FILENAME), 'r') as f:
+  with open_file(manifest_filepath, 'r') as f:
     source_manifest = SourceManifest.model_validate_json(f.read())
 
   # For backwards compatibility, check if the config has the source and write it back to the

--- a/web/blueprint/src/lib/components/ButtonDropdown.svelte
+++ b/web/blueprint/src/lib/components/ButtonDropdown.svelte
@@ -73,7 +73,8 @@
   </div>
   {#if dropdownOpen}
     <div
-      class="absolute z-50 w-60"
+      class="z-50 w-60"
+      class:absolute={hoist}
       class:hidden={!dropdownOpen}
       use:clickOutside={() => (dropdownOpen = false)}
       use:hoistElement={{disable: !hoist}}

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -68,7 +68,7 @@
     pathToSpans = {};
     spanPaths.forEach(sp => {
       let valueNodes = getValueNodes(row, sp);
-      const isSpanNestedUnder = pathMatchesPrefix(path, sp);
+      const isSpanNestedUnder = pathMatchesPrefix(sp, path);
       if (isSpanNestedUnder) {
         // Filter out any span values that do not share the same coordinates as the current path we
         // are rendering.


### PR DESCRIPTION
- Fix UI bug with add labels UI glitching
- The call to pathMatchesPrefix has the wrong order, swapped and now it works.
- Add better error messages when dataset is not found in py.

Hermes repeated string search:
https://lilacai-nikhil-staging.hf.space/datasets#local/OpenHermes-2.5&query=%7B%22searches%22%3A%5B%7B%22path%22%3A%5B%22conversations%22%2C%22*%22%2C%22value%22%5D%2C%22type%22%3A%22keyword%22%2C%22query%22%3A%22PLAINFORMAT%22%7D%5D%7D

Map spans (this is just a dumb constant span(5, 10)):

https://lilacai-nikhil-staging.hf.space/datasets#local/glue_ax_map&expandedStats=%7B%22premise_span%22%3Atrue%7D&query=%7B%22filters%22%3A%5B%7B%22path%22%3A%5B%22premise_span%22%5D%2C%22op%22%3A%22equals%22%2C%22value%22%3A%22ermor%22%7D%5D%7D