### PR TITLE
Make schema in signals optional

### DIFF
--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -718,3 +718,21 @@ def test_concept_signal_with_select_groups(make_test_data: TestDataMaker) -> Non
     f'text.{concept_key}.*.score', sort_by=GroupsSortBy.COUNT, sort_order=SortOrder.ASC
   )
   assert result.counts == [('In concept', 1), ('Not in concept', 2)]
+
+
+def test_optional_schema(make_test_data: TestDataMaker) -> None:
+  class TestSignal(TextSignal):
+    name: ClassVar[str] = 'len_of_text'
+
+    @override
+    def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+      for text in data:
+        yield len(text)
+
+  dataset = make_test_data([{'text': 'hello'}, {'text': 'hello world'}])
+  dataset.compute_signal(TestSignal(), 'text')
+  result = dataset.select_rows(['text'], combine_columns=True)
+  assert list(result) == [
+    {'text': enriched_item('hello', {'len_of_text': 5})},
+    {'text': enriched_item('hello world', {'len_of_text': 11})},
+  ]

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1929,7 +1929,7 @@ class DatasetDuckDB(Dataset):
       if col.signal_udf:
         udfs.append(SelectRowsSchemaUDF(path=dest_path, alias=col.alias))
         field = col.signal_udf.fields()
-        assert field, f'Expected signal {col.signal_udf.name} to have a schema defined.'
+        assert field, f'Signal {col.signal_udf.name} needs `Signal.fields` defined when run as UDF.'
         field.signal = col.signal_udf.model_dump()
       elif manifest.data_schema.has_field(dest_path):
         field = manifest.data_schema.get_field(dest_path)

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -111,7 +111,9 @@ def schema_contains_path(schema: Schema, path: PathTuple) -> bool:
   return True
 
 
-def create_signal_schema(signal: Signal, source_path: PathTuple, current_schema: Schema) -> Schema:
+def create_signal_schema(
+  signal: Signal, source_path: PathTuple, current_schema: Schema
+) -> Optional[Schema]:
   """Create a schema describing the enriched fields added an enrichment."""
   leafs = current_schema.leafs
   # Validate that the enrich fields are actually a valid leaf path.
@@ -119,6 +121,9 @@ def create_signal_schema(signal: Signal, source_path: PathTuple, current_schema:
     raise ValueError(f'"{source_path}" is not a valid leaf path. Leaf paths: {leafs.keys()}')
 
   signal_schema = signal.fields()
+  if not signal_schema:
+    return None
+
   signal_schema.signal = signal.model_dump()
 
   enriched_schema = field(fields={signal.key(is_computed_signal=True): signal_schema})

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -114,7 +114,10 @@ def schema_contains_path(schema: Schema, path: PathTuple) -> bool:
 def create_signal_schema(
   signal: Signal, source_path: PathTuple, current_schema: Schema
 ) -> Optional[Schema]:
-  """Create a schema describing the enriched fields added an enrichment."""
+  """Create a signal schema describing the enriched fields.
+
+  Returns None if the signal has no predefined schema.
+  """
   leafs = current_schema.leafs
   # Validate that the enrich fields are actually a valid leaf path.
   if source_path not in leafs:

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -70,13 +70,13 @@ class Signal(BaseModel):
 
   model_config = ConfigDict(extra='ignore', json_schema_extra=_signal_schema_extra)
 
-  def fields(self) -> Field:
-    """Return the fields schema for this signal.
+  def fields(self) -> Optional[Field]:
+    """Return the schema for the signal output. If None, the schema will be automatically inferred.
 
     Returns:
       A Field object that describes the schema of the signal.
     """
-    raise NotImplementedError
+    return None
 
   def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
     """Compute the signal for an iterable of documents or images.


### PR DESCRIPTION
Signal authors can now omit providing schema. In that case the schema will be auto-inferred from the emitted items.