### PR TITLE
Refactor dataset/signal endpoints into separate module

### DIFF
--- a/lilac/router_dataset.py
+++ b/lilac/router_dataset.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Literal, Optional, Sequence, Union, cast
 from fastapi import APIRouter, HTTPException, Response
 from fastapi.params import Depends
 from fastapi.responses import FileResponse, ORJSONResponse
-from pydantic import BaseModel, Field, SerializeAsAny, field_validator
+from pydantic import BaseModel, Field
 
 from .auth import UserInfo, get_session_user, get_user_access
 from .config import DatasetSettings
@@ -31,12 +31,11 @@ from .db_manager import DatasetInfo, get_dataset, list_datasets
 from .env import get_project_dir
 from .router_utils import RouteErrorHandler
 from .schema import Bin, Path, normalize_path
-from .signal import Signal, TextEmbeddingSignal, TextSignal, resolve_signal
+from .signal import Signal, TextEmbeddingSignal, TextSignal
 from .signals.concept_labels import ConceptLabelsSignal
 from .signals.concept_scorer import ConceptSignal
 from .signals.semantic_similarity import SemanticSimilaritySignal
 from .signals.substring_search import SubstringSignal
-from .tasks import TaskId, get_task_manager
 from .utils import to_yaml
 
 router = APIRouter(route_class=RouteErrorHandler)
@@ -63,21 +62,6 @@ def get_manifest(namespace: str, dataset_name: str) -> WebManifest:
   return cast(WebManifest, ORJSONResponse(res.model_dump(exclude_none=True)))
 
 
-class ComputeSignalOptions(BaseModel):
-  """The request for the compute signal endpoint."""
-
-  signal: SerializeAsAny[Signal]
-
-  # The leaf path to compute the signal on.
-  leaf_path: Path
-
-  @field_validator('signal', mode='before')
-  @classmethod
-  def parse_signal(cls, signal: dict) -> Signal:
-    """Parse a signal to its specific subclass instance."""
-    return resolve_signal(signal)
-
-
 @router.delete('/{namespace}/{dataset_name}')
 def delete_dataset(
   namespace: str, dataset_name: str, user: Annotated[Optional[UserInfo], Depends(get_session_user)]
@@ -88,80 +72,6 @@ def delete_dataset(
 
   dataset = get_dataset(namespace, dataset_name)
   dataset.delete()
-
-
-class ComputeSignalResponse(BaseModel):
-  """Response of the compute signal column endpoint."""
-
-  task_id: TaskId
-
-
-@router.post('/{namespace}/{dataset_name}/compute_signal')
-def compute_signal(
-  namespace: str,
-  dataset_name: str,
-  options: ComputeSignalOptions,
-  user: Annotated[Optional[UserInfo], Depends(get_session_user)],
-) -> ComputeSignalResponse:
-  """Compute a signal for a dataset."""
-  if not get_user_access(user).dataset.compute_signals:
-    raise HTTPException(401, 'User does not have access to compute signals over this dataset.')
-
-  # Resolve the signal outside the task so we don't look up the signal in the registry. This gets
-  # implicitly pickled by the dask serializer when _task_compute_signal is pickled.
-  # NOTE: This unfortunately does not work in Jupyter because a module is not picklable. In this
-  # case, we recommend defining and registering the signal outside a Jupyter notebook.
-  signal = options.signal
-
-  def _task_compute_signal(namespace: str, dataset_name: str, task_id: TaskId) -> None:
-    # NOTE: We manually call .model_dump() to avoid the dask serializer, which doesn't call the
-    # underlying pydantic serializer.
-    dataset = get_dataset(namespace, dataset_name)
-    dataset.compute_signal(
-      signal,
-      options.leaf_path,
-      # Overwrite for text embeddings since we don't have UI to control deleting embeddings.
-      overwrite=isinstance(options.signal, TextEmbeddingSignal),
-      task_step_id=(task_id, 0),
-    )
-
-  path_str = '.'.join(map(str, options.leaf_path))
-  task_id = get_task_manager().task_id(
-    name=f'[{namespace}/{dataset_name}] Compute signal "{options.signal.name}" on "{path_str}"',
-    description=f'Config: {options.signal}',
-  )
-  get_task_manager().execute(task_id, _task_compute_signal, namespace, dataset_name, task_id)
-
-  return ComputeSignalResponse(task_id=task_id)
-
-
-class DeleteSignalOptions(BaseModel):
-  """The request for the delete signal endpoint."""
-
-  # The signal path holding the data from the signal.
-  signal_path: Path
-
-
-class DeleteSignalResponse(BaseModel):
-  """Response of the compute signal column endpoint."""
-
-  completed: bool
-
-
-@router.delete('/{namespace}/{dataset_name}/delete_signal')
-def delete_signal(
-  namespace: str,
-  dataset_name: str,
-  options: DeleteSignalOptions,
-  user: Annotated[Optional[UserInfo], Depends(get_session_user)],
-) -> DeleteSignalResponse:
-  """Delete a signal from a dataset."""
-  if not get_user_access(user).dataset.delete_signals:
-    raise HTTPException(401, 'User does not have access to delete this signal.')
-
-  dataset = get_dataset(namespace, dataset_name)
-  dataset.delete_signal(options.signal_path)
-  return DeleteSignalResponse(completed=True)
 
 
 class GetStatsOptions(BaseModel):

--- a/lilac/router_dataset_signals.py
+++ b/lilac/router_dataset_signals.py
@@ -1,0 +1,101 @@
+from typing import Annotated, Optional
+
+from fastapi import HTTPException
+from fastapi.params import Depends
+from pydantic import BaseModel, SerializeAsAny, field_validator
+
+from lilac.auth import UserInfo, get_session_user, get_user_access
+from lilac.db_manager import get_dataset
+from lilac.router_dataset import router
+from lilac.schema import Path
+from lilac.signal import Signal, TextEmbeddingSignal, resolve_signal
+from lilac.tasks import TaskId, get_task_manager
+
+
+class ComputeSignalOptions(BaseModel):
+  """The request for the compute signal endpoint."""
+
+  signal: SerializeAsAny[Signal]
+
+  # The leaf path to compute the signal on.
+  leaf_path: Path
+
+  @field_validator('signal', mode='before')
+  @classmethod
+  def parse_signal(cls, signal: dict) -> Signal:
+    """Parse a signal to its specific subclass instance."""
+    return resolve_signal(signal)
+
+
+class ComputeSignalResponse(BaseModel):
+  """Response of the compute signal column endpoint."""
+
+  task_id: TaskId
+
+
+@router.post('/{namespace}/{dataset_name}/compute_signal')
+def compute_signal(
+  namespace: str,
+  dataset_name: str,
+  options: ComputeSignalOptions,
+  user: Annotated[Optional[UserInfo], Depends(get_session_user)],
+) -> ComputeSignalResponse:
+  """Compute a signal for a dataset."""
+  if not get_user_access(user).dataset.compute_signals:
+    raise HTTPException(401, 'User does not have access to compute signals over this dataset.')
+
+  # Resolve the signal outside the task so we don't look up the signal in the registry. This gets
+  # implicitly pickled by the dask serializer when _task_compute_signal is pickled.
+  # NOTE: This unfortunately does not work in Jupyter because a module is not picklable. In this
+  # case, we recommend defining and registering the signal outside a Jupyter notebook.
+  signal = options.signal
+
+  def _task_compute_signal(namespace: str, dataset_name: str, task_id: TaskId) -> None:
+    # NOTE: We manually call .model_dump() to avoid the dask serializer, which doesn't call the
+    # underlying pydantic serializer.
+    dataset = get_dataset(namespace, dataset_name)
+    dataset.compute_signal(
+      signal,
+      options.leaf_path,
+      # Overwrite for text embeddings since we don't have UI to control deleting embeddings.
+      overwrite=isinstance(options.signal, TextEmbeddingSignal),
+      task_step_id=(task_id, 0),
+    )
+
+  path_str = '.'.join(map(str, options.leaf_path))
+  task_id = get_task_manager().task_id(
+    name=f'[{namespace}/{dataset_name}] Compute signal "{options.signal.name}" on "{path_str}"',
+    description=f'Config: {options.signal}',
+  )
+  get_task_manager().execute(task_id, _task_compute_signal, namespace, dataset_name, task_id)
+
+  return ComputeSignalResponse(task_id=task_id)
+
+
+class DeleteSignalOptions(BaseModel):
+  """The request for the delete signal endpoint."""
+
+  # The signal path holding the data from the signal.
+  signal_path: Path
+
+
+class DeleteSignalResponse(BaseModel):
+  """Response of the compute signal column endpoint."""
+
+  completed: bool
+
+
+@router.delete('/{namespace}/{dataset_name}/delete_signal')
+def delete_signal(
+  namespace: str,
+  dataset_name: str,
+  options: DeleteSignalOptions,
+  user: Annotated[Optional[UserInfo], Depends(get_session_user)],
+) -> DeleteSignalResponse:
+  """Delete a signal from a dataset."""
+  if not get_user_access(user).dataset.delete_signals:
+    raise HTTPException(401, 'User does not have access to delete this signal.')
+
+  dataset = get_dataset(namespace, dataset_name)
+  dataset.delete_signal(options.signal_path)
+  return DeleteSignalResponse(completed=True)

--- a/lilac/router_dataset_signals.py
+++ b/lilac/router_dataset_signals.py
@@ -1,3 +1,4 @@
+"""Routing endpoints for running signals on datasets."""
 from typing import Annotated, Optional
 
 from fastapi import HTTPException

--- a/lilac/router_dataset_signals.py
+++ b/lilac/router_dataset_signals.py
@@ -1,16 +1,19 @@
 """Routing endpoints for running signals on datasets."""
 from typing import Annotated, Optional
 
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from fastapi.params import Depends
 from pydantic import BaseModel, SerializeAsAny, field_validator
 
 from lilac.auth import UserInfo, get_session_user, get_user_access
 from lilac.db_manager import get_dataset
-from lilac.router_dataset import router
 from lilac.schema import Path
 from lilac.signal import Signal, TextEmbeddingSignal, resolve_signal
 from lilac.tasks import TaskId, get_task_manager
+
+from .router_utils import RouteErrorHandler
+
+router = APIRouter(route_class=RouteErrorHandler)
 
 
 class ComputeSignalOptions(BaseModel):

--- a/lilac/router_dataset_signals.py
+++ b/lilac/router_dataset_signals.py
@@ -5,13 +5,12 @@ from fastapi import APIRouter, HTTPException
 from fastapi.params import Depends
 from pydantic import BaseModel, SerializeAsAny, field_validator
 
-from lilac.auth import UserInfo, get_session_user, get_user_access
-from lilac.db_manager import get_dataset
-from lilac.schema import Path
-from lilac.signal import Signal, TextEmbeddingSignal, resolve_signal
-from lilac.tasks import TaskId, get_task_manager
-
+from .auth import UserInfo, get_session_user, get_user_access
+from .db_manager import get_dataset
 from .router_utils import RouteErrorHandler
+from .schema import Path
+from .signal import Signal, TextEmbeddingSignal, resolve_signal
+from .tasks import TaskId, get_task_manager
 
 router = APIRouter(route_class=RouteErrorHandler)
 

--- a/lilac/server.py
+++ b/lilac/server.py
@@ -22,6 +22,7 @@ from . import (
   router_concept,
   router_data_loader,
   router_dataset,
+  router_dataset_signals,
   router_google_login,
   router_rag,
   router_signal,
@@ -113,6 +114,7 @@ app.include_router(router_google_login.router, prefix='/google', tags=['google_l
 
 v1_router = APIRouter(route_class=RouteErrorHandler)
 v1_router.include_router(router_dataset.router, prefix='/datasets', tags=['datasets'])
+v1_router.include_router(router_dataset_signals.router, prefix='/datasets', tags=['datasets'])
 v1_router.include_router(router_concept.router, prefix='/concepts', tags=['concepts'])
 v1_router.include_router(router_data_loader.router, prefix='/data_loaders', tags=['data_loaders'])
 v1_router.include_router(router_signal.router, prefix='/signals', tags=['signals'])

--- a/lilac/server_dataset_signals_test.py
+++ b/lilac/server_dataset_signals_test.py
@@ -1,0 +1,51 @@
+"""Test our public dataset/signals computation REST API."""
+
+import os
+from typing import ClassVar, Iterable, Optional
+
+from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
+
+from lilac.data.dataset_test_utils import TEST_DATASET_NAME, TEST_NAMESPACE
+from lilac.router_dataset_signals import ComputeSignalOptions, DeleteSignalOptions
+
+from .schema import Field, Item, RichData, field
+from .server import app
+from .signal import TextSignal
+
+client = TestClient(app)
+
+
+class LengthSignal(TextSignal):
+  name: ClassVar[str] = 'length_signal'
+
+  def fields(self) -> Field:
+    return field('int32')
+
+  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+    for text_content in data:
+      yield len(text_content) if text_content is not None else None
+
+
+def test_compute_signal_auth(mocker: MockerFixture) -> None:
+  mocker.patch.dict(os.environ, {'LILAC_AUTH_ENABLED': 'True'})
+
+  url = f'/api/v1/datasets/{TEST_NAMESPACE}/{TEST_DATASET_NAME}/compute_signal'
+  response = client.post(
+    url, json=ComputeSignalOptions(signal=LengthSignal(), leaf_path=('people', 'name')).model_dump()
+  )
+  assert response.status_code == 401
+  assert response.is_error is True
+  assert 'User does not have access to compute signals over this dataset.' in response.text
+
+
+def test_delete_signal_auth(mocker: MockerFixture) -> None:
+  mocker.patch.dict(os.environ, {'LILAC_AUTH_ENABLED': 'True'})
+
+  url = f'/api/v1/datasets/{TEST_NAMESPACE}/{TEST_DATASET_NAME}/delete_signal'
+  response = client.request(
+    'DELETE', url, json=DeleteSignalOptions(signal_path=('doesnt', 'matter')).model_dump()
+  )
+  assert response.status_code == 401
+  assert response.is_error is True
+  assert 'User does not have access to delete this signal.' in response.text

--- a/lilac/server_dataset_test.py
+++ b/lilac/server_dataset_test.py
@@ -20,8 +20,6 @@ from .data.dataset_test_utils import (
 from .router_dataset import (
   AddLabelsOptions,
   Column,
-  ComputeSignalOptions,
-  DeleteSignalOptions,
   SelectRowsOptions,
   SelectRowsResponse,
   SelectRowsSchemaOptions,
@@ -286,30 +284,6 @@ def test_select_rows_schema_no_cols() -> None:
       }
     )
   )
-
-
-def test_compute_signal_auth(mocker: MockerFixture) -> None:
-  mocker.patch.dict(os.environ, {'LILAC_AUTH_ENABLED': 'True'})
-
-  url = f'/api/v1/datasets/{TEST_NAMESPACE}/{TEST_DATASET_NAME}/compute_signal'
-  response = client.post(
-    url, json=ComputeSignalOptions(signal=LengthSignal(), leaf_path=('people', 'name')).model_dump()
-  )
-  assert response.status_code == 401
-  assert response.is_error is True
-  assert 'User does not have access to compute signals over this dataset.' in response.text
-
-
-def test_delete_signal_auth(mocker: MockerFixture) -> None:
-  mocker.patch.dict(os.environ, {'LILAC_AUTH_ENABLED': 'True'})
-
-  url = f'/api/v1/datasets/{TEST_NAMESPACE}/{TEST_DATASET_NAME}/delete_signal'
-  response = client.request(
-    'DELETE', url, json=DeleteSignalOptions(signal_path=('doesnt', 'matter')).model_dump()
-  )
-  assert response.status_code == 401
-  assert response.is_error is True
-  assert 'User does not have access to delete this signal.' in response.text
 
 
 def test_update_settings_auth(mocker: MockerFixture) -> None:

--- a/web/lib/fastapi_client/services/DatasetsService.ts
+++ b/web/lib/fastapi_client/services/DatasetsService.ts
@@ -91,64 +91,6 @@ export class DatasetsService {
     }
 
     /**
-     * Compute Signal
-     * Compute a signal for a dataset.
-     * @param namespace
-     * @param datasetName
-     * @param requestBody
-     * @returns ComputeSignalResponse Successful Response
-     * @throws ApiError
-     */
-    public static computeSignal(
-        namespace: string,
-        datasetName: string,
-        requestBody: ComputeSignalOptions,
-    ): CancelablePromise<ComputeSignalResponse> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/api/v1/datasets/{namespace}/{dataset_name}/compute_signal',
-            path: {
-                'namespace': namespace,
-                'dataset_name': datasetName,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-
-    /**
-     * Delete Signal
-     * Delete a signal from a dataset.
-     * @param namespace
-     * @param datasetName
-     * @param requestBody
-     * @returns DeleteSignalResponse Successful Response
-     * @throws ApiError
-     */
-    public static deleteSignal(
-        namespace: string,
-        datasetName: string,
-        requestBody: DeleteSignalOptions,
-    ): CancelablePromise<DeleteSignalResponse> {
-        return __request(OpenAPI, {
-            method: 'DELETE',
-            url: '/api/v1/datasets/{namespace}/{dataset_name}/delete_signal',
-            path: {
-                'namespace': namespace,
-                'dataset_name': datasetName,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-
-    /**
      * Get Stats
      * Get the stats for the dataset.
      * @param namespace
@@ -478,6 +420,64 @@ export class DatasetsService {
         return __request(OpenAPI, {
             method: 'DELETE',
             url: '/api/v1/datasets/{namespace}/{dataset_name}/labels',
+            path: {
+                'namespace': namespace,
+                'dataset_name': datasetName,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Compute Signal
+     * Compute a signal for a dataset.
+     * @param namespace
+     * @param datasetName
+     * @param requestBody
+     * @returns ComputeSignalResponse Successful Response
+     * @throws ApiError
+     */
+    public static computeSignal(
+        namespace: string,
+        datasetName: string,
+        requestBody: ComputeSignalOptions,
+    ): CancelablePromise<ComputeSignalResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/datasets/{namespace}/{dataset_name}/compute_signal',
+            path: {
+                'namespace': namespace,
+                'dataset_name': datasetName,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Delete Signal
+     * Delete a signal from a dataset.
+     * @param namespace
+     * @param datasetName
+     * @param requestBody
+     * @returns DeleteSignalResponse Successful Response
+     * @throws ApiError
+     */
+    public static deleteSignal(
+        namespace: string,
+        datasetName: string,
+        requestBody: DeleteSignalOptions,
+    ): CancelablePromise<DeleteSignalResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/datasets/{namespace}/{dataset_name}/delete_signal',
             path: {
                 'namespace': namespace,
                 'dataset_name': datasetName,


### PR DESCRIPTION
Just reducing the volume of code in the router_dataset.py module in anticipation of adding a bunch more dataset editing (column rename, dataset rename) endpoints.