### PR TITLE
Fix css style for markdown tables

### DIFF
--- a/web/blueprint/src/app.css
+++ b/web/blueprint/src/app.css
@@ -285,3 +285,54 @@ audio,
 video {
   border-style: solid;
 }
+
+/** Global styles for markdown rendering */
+
+.markdown pre {
+  @apply overflow-x-auto bg-slate-200 p-2 text-sm;
+}
+.markdown pre {
+  @apply my-3;
+}
+.markdown p,
+.markdown h1 {
+  background-color: inherit;
+}
+.markdown p {
+  @apply mt-3 text-sm;
+  font-weight: inherit;
+}
+.markdown ul {
+  @apply mt-3 list-inside list-disc;
+}
+/** Inline the last paragraph that preceeds the highlight. */
+.markdown:has(+ .highlighted) p:last-child {
+  @apply !inline;
+}
+/** Inline the first paragraph that succeeds the highlight. */
+:global(.highlighted + .markdown p:first-child) {
+  @apply !inline;
+}
+:global(.highlighted p) {
+  @apply !inline;
+}
+
+/** Table styles for markdown inspired by https://flowbite.com/docs/components/tables/*/
+.markdown table {
+  @apply text-left text-sm text-gray-500 rtl:text-right;
+}
+.markdown table thead {
+  @apply bg-gray-50 text-xs font-bold uppercase text-gray-700;
+}
+.markdown table thead th {
+  @apply px-6 py-3;
+}
+.markdown table tbody tr {
+  @apply border-b border-gray-200 bg-white;
+}
+.markdown table tbody th {
+  @apply whitespace-nowrap px-6 py-4 font-medium text-gray-900;
+}
+.markdown table tbody td {
+  @apply px-6 py-4;
+}

--- a/web/blueprint/src/lib/components/JSONSchema/JSONSchemaInput.svelte
+++ b/web/blueprint/src/lib/components/JSONSchema/JSONSchemaInput.svelte
@@ -63,7 +63,7 @@
 {#if !hiddenProperties?.includes(path)}
   {#if propertyType === 'object'}
     {#if property.description && showDescription}
-      <div class="description mb-4">
+      <div class="markdown description mb-4">
         <SvelteMarkdown source={property.description} />
       </div>
     {/if}

--- a/web/blueprint/src/lib/components/commands/CommandConcepts.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandConcepts.svelte
@@ -105,7 +105,7 @@
               </button>
             </div>
             {#if selectedConceptInfo.metadata.description}
-              <div>
+              <div class="markdown">
                 <SvelteMarkdown source={selectedConceptInfo.metadata.description} />
               </div>
             {/if}

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -172,7 +172,7 @@
       <div class="flex w-full flex-col gap-y-6 rounded border border-gray-300 bg-white p-4">
         {#if signalInfo}
           {#key signalInfo}
-            <div>
+            <div class="markdown">
               <SvelteMarkdown source={signalInfo.json_schema.description} />
             </div>
 

--- a/web/blueprint/src/lib/components/datasetView/DatasetSettingsFields.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetSettingsFields.svelte
@@ -93,7 +93,7 @@
   }
   // Markdown.
   function isMarkdownRendered(field: LilacField) {
-    return newSettings.ui?.markdown_paths?.includes(field.path);
+    return newSettings.ui?.markdown_paths?.find(p => pathIsEqual(p, field.path)) != null;
   }
   function markdownToggle(e: CustomEvent<{toggled: boolean}>, field: LilacField) {
     if (e.detail.toggled) {

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -231,7 +231,9 @@
         on:mouseleave={() => spanMouseLeave(renderSpan)}
       >
         {#if markdown}
-          <SvelteMarkdown source={snippetSpan.snippetText} />
+          <div class="markdown">
+            <SvelteMarkdown source={snippetSpan.snippetText} />
+          </div>
         {:else}{snippetSpan.snippetText}{/if}</span
       >
     {:else}
@@ -281,5 +283,25 @@
   }
   :global(.highlighted p) {
     @apply !inline;
+  }
+
+  /** Table styles for markdown inspired by https://flowbite.com/docs/components/tables/*/
+  :global(.markdown table) {
+    @apply w-full text-left text-sm text-gray-500 rtl:text-right;
+  }
+  :global(.markdown table thead) {
+    @apply bg-gray-50 text-xs font-bold uppercase text-gray-700;
+  }
+  :global(.markdown table thead th) {
+    @apply px-6 py-3;
+  }
+  :global(.markdown table tbody tr) {
+    @apply border-b border-gray-200 bg-white;
+  }
+  :global(.markdown table tbody th) {
+    @apply whitespace-nowrap px-6 py-4 font-medium text-gray-900;
+  }
+  :global(.markdown table tbody td) {
+    @apply px-6 py-4;
   }
 </style>

--- a/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
+++ b/web/blueprint/src/lib/components/datasetView/StringSpanHighlight.svelte
@@ -241,8 +241,10 @@
         use:hoverTooltip={{
           text: 'Some text was hidden to improve readability. \nClick "Show all" to show the entire document.'
         }}
-        class="highlight-span text-sm leading-5">...</span
+        class="highlight-span text-sm leading-5"
       >
+        ...
+      </span>
     {/if}
   {/each}
 </div>
@@ -255,53 +257,5 @@
     /** Add a tiny bit of padding so that the hover doesn't flicker between rows. */
     padding-top: 1.5px;
     padding-bottom: 1.5px;
-  }
-  :global(.highlight-span pre) {
-    @apply overflow-x-auto bg-slate-200 p-2 text-sm;
-  }
-  :global(.highlight-span pre) {
-    @apply my-3;
-  }
-  :global(.highlight-span p),
-  :global(.highlight-span h1) {
-    background-color: inherit;
-  }
-  :global(.highlight-span p) {
-    @apply mt-3 text-sm;
-    font-weight: inherit;
-  }
-  :global(.highlight-span ul) {
-    @apply mt-3 list-inside list-disc;
-  }
-  /** Inline the last paragraph that preceeds the highlight. */
-  :global(.highlight-span:has(+ .highlighted) p:last-child) {
-    @apply !inline;
-  }
-  /** Inline the first paragraph that succeeds the highlight. */
-  :global(.highlighted + .highlight-span p:first-child) {
-    @apply !inline;
-  }
-  :global(.highlighted p) {
-    @apply !inline;
-  }
-
-  /** Table styles for markdown inspired by https://flowbite.com/docs/components/tables/*/
-  :global(.markdown table) {
-    @apply w-full text-left text-sm text-gray-500 rtl:text-right;
-  }
-  :global(.markdown table thead) {
-    @apply bg-gray-50 text-xs font-bold uppercase text-gray-700;
-  }
-  :global(.markdown table thead th) {
-    @apply px-6 py-3;
-  }
-  :global(.markdown table tbody tr) {
-    @apply border-b border-gray-200 bg-white;
-  }
-  :global(.markdown table tbody th) {
-    @apply whitespace-nowrap px-6 py-4 font-medium text-gray-900;
-  }
-  :global(.markdown table tbody td) {
-    @apply px-6 py-4;
   }
 </style>

--- a/web/blueprint/src/lib/components/signals/SignalView.svelte
+++ b/web/blueprint/src/lib/components/signals/SignalView.svelte
@@ -123,7 +123,7 @@
       {signalInfo.json_schema.title}
     </div>
     {#if signalInfo.json_schema.description}
-      <div class="text text-base text-gray-600">
+      <div class="markdown text text-base text-gray-600">
         <SvelteMarkdown source={signalInfo.json_schema.description} />
       </div>
     {/if}

--- a/web/blueprint/src/routes/rag/+page.svelte
+++ b/web/blueprint/src/routes/rag/+page.svelte
@@ -275,32 +275,4 @@
     padding-top: 1.5px;
     padding-bottom: 1.5px;
   }
-  :global(.markdown pre) {
-    @apply overflow-x-auto bg-slate-200 p-2 text-sm;
-  }
-  :global(.markdown pre) {
-    @apply my-3;
-  }
-  :global(.markdown p),
-  :global(.markdown h1) {
-    background-color: inherit;
-  }
-  :global(.markdown p) {
-    @apply mt-3 text-sm;
-    font-weight: inherit;
-  }
-  :global(.markdown ul) {
-    @apply mt-3 list-inside list-disc;
-  }
-  /** Inline the last paragraph that preceeds the highlight. */
-  :global(.markdown:has(+ .highlighted) p:last-child) {
-    @apply !inline;
-  }
-  /** Inline the first paragraph that succeeds the highlight. */
-  :global(.highlighted + .markdown p:first-child) {
-    @apply !inline;
-  }
-  :global(.highlighted p) {
-    @apply !inline;
-  }
 </style>


### PR DESCRIPTION
Before:
<img width="292" alt="CleanShot 2023-12-06 at 09 17 21@2x" src="https://github.com/lilacai/lilac/assets/2294279/890090b5-ad4d-410c-9462-eed8e2242b71">

After:
<img width="707" alt="CleanShot 2023-12-06 at 09 18 13@2x" src="https://github.com/lilacai/lilac/assets/2294279/bb32a64e-7f2e-42d6-8ad4-7649db3f5a61">
