### PR TITLE
Simplify monaco viewer. Add support for deep linking.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,6 +855,11 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fontsource-variable/inconsolata": {
+      "version": "5.0.16",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.0.16.tgz",
+      "integrity": "sha512-cBORoFvgCEoWB8i65+AFScraU1Tygus5fAXiAtCqNhhbQwII9zUTnL6kyju3MhQzeDyn9mGIbU6UOODL3S64mw=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -7746,6 +7751,7 @@
       "name": "websvelte",
       "version": "0.0.1",
       "dependencies": {
+        "@fontsource-variable/inconsolata": "~5.0.16",
         "@monaco-editor/loader": "~1.4.0",
         "@tanstack/svelte-query": "^4.36.1",
         "@yornaath/batshit": "^0.8.0",

--- a/web/blueprint/package.json
+++ b/web/blueprint/package.json
@@ -43,6 +43,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@fontsource-variable/inconsolata": "~5.0.16",
     "@monaco-editor/loader": "~1.4.0",
     "@tanstack/svelte-query": "^4.36.1",
     "@yornaath/batshit": "^0.8.0",

--- a/web/blueprint/src/app.html
+++ b/web/blueprint/src/app.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
-    <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet" />
 
     <meta name="viewport" content="width=device-width" />
     %sveltekit.head%

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -198,6 +198,8 @@
   }
   $: datasetSettingsMarkdown =
     $settings.data?.ui?.markdown_paths?.find(p => pathIsEqual(p, mediaPath)) != null;
+  $: viewType = $settings.data?.ui?.view_type || 'single_item';
+
   $: markdown = userPreview !== undefined ? userPreview : datasetSettingsMarkdown;
 </script>
 
@@ -283,10 +285,11 @@
               spanValueInfos={spanValuePaths.spanValueInfos}
               {datasetViewStore}
               embeddings={computedEmbeddings}
+              {viewType}
               bind:textIsOverBudget
             />
             <div class="markdown w-full" class:hidden={!markdown}>
-              <div class="markdown w-fit">
+              <div class="markdown -ml-0.5 w-fit pl-14">
                 <SvelteMarkdown source={formatValue(value)} />
               </div>
             </div>

--- a/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
@@ -9,11 +9,8 @@
   import {
     MAX_MONACO_HEIGHT_COLLAPSED,
     MAX_MONACO_HEIGHT_EXPANDED,
-    MONACO_LANGUAGE,
     MONACO_OPTIONS,
-    getMonaco,
-    registerHoverProvider,
-    removeHoverProvider
+    getMonaco
   } from '$lib/monaco';
   import {editConceptMutation} from '$lib/queries/conceptQueries';
   import type {DatasetViewStore} from '$lib/stores/datasetViewStore';
@@ -23,9 +20,11 @@
     L,
     getValueNodes,
     pathIncludes,
+    pathIsEqual,
     pathMatchesPrefix,
     serializePath,
     type ConceptSignal,
+    type DatasetUISettings,
     type LilacField,
     type LilacValueNode,
     type LilacValueNodeCasted,
@@ -33,6 +32,7 @@
     type SemanticSimilaritySignal,
     type SubstringSignal
   } from '$lilac';
+  import {derived} from 'svelte/store';
   import {getMonacoRenderSpans, type MonacoRenderSpan, type SpanValueInfo} from './spanHighlight';
   export let text: string;
   // The full row item.
@@ -52,6 +52,7 @@
   export let isExpanded = false;
   // Passed back up to the parent.
   export let textIsOverBudget = false;
+  export let viewType: DatasetUISettings['view_type'] | undefined = undefined;
 
   // Map paths from the searches to the spans that they refer to.
   let pathToSpans: {
@@ -70,6 +71,10 @@
       pathToSpans[serializePath(sp)] = valueNodes as LilacValueNodeCasted<'string_span'>[];
     });
   }
+
+  // True after the editor has remeasured fonts and ready to render. When false, the monaco element
+  // is visibility: hidden.
+  let editorReady = false;
 
   // Map each of the span paths from the search (generic) to the concrete value infos for the row.
   let spanPathToValueInfos: Record<string, SpanValueInfo[]> = {};
@@ -99,7 +104,7 @@
   let editorContainer: HTMLElement;
 
   let monaco: typeof Monaco;
-  let editor: Monaco.editor.IStandaloneCodeEditor;
+  let editor: Monaco.editor.IStandaloneCodeEditor | null = null;
   let model: Monaco.editor.ITextModel | null = null;
 
   $: {
@@ -120,7 +125,6 @@
       }
 
       editor.layout();
-      monaco.editor.remeasureFonts();
     }
   }
 
@@ -129,16 +133,60 @@
 
     editor = monaco.editor.create(editorContainer, {
       ...MONACO_OPTIONS,
-      lineNumbers: 'off',
+      lineNumbers: 'on',
+      glyphMargin: true,
+      lineNumbersMinChars: 3,
       minimap: {
         enabled: true,
         side: 'right',
         scale: 2
       }
     });
+    model = monaco.editor.createModel('', 'text/plain');
+    editor.setModel(model);
+
+    // When the fonts are ready, measure the fonts and display the editor after the font measurement
+    // is complete. This is very important, otherwise the cursor will get shifted slightly,
+    // breaking all user selection.
+    document.fonts.ready.then(() => {
+      monaco.editor.remeasureFonts();
+      editorReady = true;
+    });
   });
 
+  // When text changes, set the value on the global model and relayout.
+  $: {
+    if (model != null && text != null) {
+      model.setValue(text);
+      relayout();
+    }
+  }
+
   $: monacoSpans = getMonacoRenderSpans(text, pathToSpans, spanPathToValueInfos);
+
+  // Reveal the first span so that it is near the top of the view.
+  $: {
+    if (model != null && editor != null) {
+      let minPosition: Monaco.Position | null = null;
+      for (const renderSpan of monacoSpans) {
+        if (!renderSpan.isHighlighted) continue;
+
+        const span = L.span(renderSpan.span)!;
+        const position = model.getPositionAt(span.start);
+
+        if (minPosition == null) {
+          minPosition = position;
+        } else {
+          if (position.lineNumber < minPosition.lineNumber) {
+            minPosition = position;
+          }
+        }
+      }
+      if (minPosition != null) {
+        editor.revealPositionNearTop(minPosition);
+      }
+    }
+  }
 
   // Returns a preview of the query for the hover card.
   function queryPreview(query: string) {
@@ -148,104 +196,69 @@
 
   // Returns the hover content for the given position in the editor by searching through the render
   // spans for the relevant span.
-  function getHoverCard(
-    model: Monaco.editor.ITextModel,
-    position: Monaco.Position
-  ): Monaco.languages.ProviderResult<Monaco.languages.Hover> {
-    const charOffset = model.getOffsetAt(position);
-
-    // Matched spans are spans that are within the hover position.
-    const matchedSpans: MonacoRenderSpan[] = [];
-    for (const renderSpan of monacoSpans) {
-      const span = L.span(renderSpan.span)!;
-      // Ignore non-highlighted spans.
-      if (span == null || !renderSpan.isHighlighted) continue;
-
-      // Only show the hover if the mouse is over the span.
-      if (span.start <= charOffset && charOffset <= span.end) {
-        matchedSpans.push(renderSpan);
-      }
-    }
-
-    // Don't show a hover card when no spans are matched.
-    if (matchedSpans.length === 0) return null;
-
-    // Map the render spans to their hover card components.
-    const hoverContents: Monaco.IMarkdownString[] = matchedSpans.flatMap(renderSpan => {
-      const namedValue = renderSpan.namedValue;
-      const title = namedValue.info.name;
-
-      if (renderSpan.isConceptSearch) {
-        const signal = namedValue.info.signal as ConceptSignal;
-        const link = window.location.origin + conceptLink(signal.namespace, signal.concept_name);
-        const value = (namedValue.value as number).toFixed(2);
-        return [
-          {
-            value: `**concept** <a href="${link}">${title}</a> (${value})`,
-            supportHtml: true,
-            isTrusted: true
-          },
-          {
-            value: `<span>${renderSpan.text}</span>`,
-            supportHtml: true,
-            isTrusted: true
-          }
-        ];
-      } else if (renderSpan.isSemanticSearch) {
-        const signal = namedValue.info.signal as SemanticSimilaritySignal;
-        const value = (namedValue.value as number).toFixed(2);
-        const query = queryPreview(signal.query);
-        return [
-          {
-            value: `**more like this** *${query}* (${value})`,
-            supportHtml: true,
-            isTrusted: true
-          },
-          {
-            value: `<span>${renderSpan.text}</span>`,
-            supportHtml: true,
-            isTrusted: true
-          }
-        ];
-      } else if (renderSpan.isKeywordSearch) {
-        const signal = namedValue.info.signal as SubstringSignal;
-        const query = queryPreview(signal.query);
-        return [
-          {
-            value: `**keyword search** *${query}*`,
-            supportHtml: true,
-            isTrusted: true
-          },
-          {
-            value: `<span>${renderSpan.text}</span>`,
-            supportHtml: true,
-            isTrusted: true
-          }
-        ];
-      }
+  function getHoverCard(renderSpan: MonacoRenderSpan): Monaco.IMarkdownString[] {
+    if (!renderSpan.isHighlighted || model == null) {
       return [];
-    });
-
-    return {
-      contents: hoverContents
-    };
-  }
-
-  $: {
-    if (editor != null && text != null) {
-      model = monaco.editor.createModel(text, MONACO_LANGUAGE);
-      editor.setModel(model);
-
-      // Register the hover provider. We will get called back when the user hovers over a span.
-      registerHoverProvider(model, (model, position) => getHoverCard(model, position));
-
-      relayout();
-
-      editor.onDidChangeModel(() => {
-        relayout();
-      });
     }
+    const namedValue = renderSpan.namedValue;
+    const title = namedValue.info.name;
+
+    if (renderSpan.isConceptSearch) {
+      const signal = namedValue.info.signal as ConceptSignal;
+      const link = window.location.origin + conceptLink(signal.namespace, signal.concept_name);
+      const value = (namedValue.value as number).toFixed(2);
+      return [
+        {
+          value: `**concept** <a href="${link}">${title}</a> (${value})`,
+          supportHtml: true,
+          isTrusted: true
+        },
+        {
+          value: `<span>${renderSpan.text}</span>`,
+          supportHtml: true,
+          isTrusted: false
+        }
+      ];
+    } else if (renderSpan.isSemanticSearch) {
+      const signal = namedValue.info.signal as SemanticSimilaritySignal;
+      const value = (namedValue.value as number).toFixed(2);
+      const query = queryPreview(signal.query);
+      return [
+        {
+          value: `**more like this** *${query}*`,
+          supportHtml: true,
+          isTrusted: true
+        },
+        {
+          value: `similarity: ${value}`,
+          supportHtml: true,
+          isTrusted: true
+        },
+        {
+          value: `<span>${renderSpan.text}</span>`,
+          supportHtml: false,
+          isTrusted: true
+        }
+      ];
+    } else if (renderSpan.isKeywordSearch) {
+      const signal = namedValue.info.signal as SubstringSignal;
+      const query = queryPreview(signal.query);
+      return [
+        {
+          value: `**keyword search** *${query}*`,
+          supportHtml: true,
+          isTrusted: true
+        },
+        {
+          value: `<span>${renderSpan.text}</span>`,
+          supportHtml: false,
+          isTrusted: true
+        }
+      ];
+    }
+    return [];
   }
+
   $: searches = $datasetViewStore != null ? getSearches($datasetViewStore, null) : null;
 
   // Gets the current editors highlighted text a string.
@@ -253,8 +266,38 @@
     if (editor == null) return null;
     const selection = editor.getSelection();
     if (selection == null) return null;
-    const value = model!.getValueInRange(selection);
-    return value;
+    return model!.getValueInRange(selection);
+  }
+
+  function conceptActionKeyId(conceptNamespace: string, conceptName: string) {
+    return `add-to-concept-${conceptNamespace}-${conceptName}`;
+  }
+
+  let contextKeys: Monaco.editor.IContextKey[] = [];
+
+  // Create conditions for concepts from searches. Always set all the values to false. They will get
+  // reset below when searches are defined so we don't keep growing the actions.
+  $: {
+    if (editor != null && searches != null) {
+      // Reset all context keys.
+      for (const contextKey of contextKeys) {
+        contextKey.set(false);
+      }
+    }
+  }
+
+  // Set the conditions for each concept to true if they exist in the searches.
+  $: {
+    if (editor != null && searches != null) {
+      for (const search of searches) {
+        if (search.type != 'concept') continue;
+        const contextKey = editor.createContextKey(
+          conceptActionKeyId(search.concept_namespace, search.concept_name),
+          true
+        );
+        contextKeys.push(contextKey);
+      }
+    }
   }
 
   // Add the concept actions to the right-click menu.
@@ -268,6 +311,7 @@
             id: idAdd,
             label: `👍 add as positive to concept "${search.concept_name}"`,
             contextMenuGroupId: 'navigation_concepts',
+            precondition: conceptActionKeyId(search.concept_namespace, search.concept_name),
             run: () => {
               const selection = getEditorSelection();
               if (selection == null) return;
@@ -280,6 +324,7 @@
             id: 'add-negative-to-concept',
             label: `👎 add as negative to concept "${search.concept_name}"`,
             contextMenuGroupId: 'navigation_concepts',
+            precondition: conceptActionKeyId(search.concept_namespace, search.concept_name),
             run: () => {
               const selection = getEditorSelection();
               if (selection == null) return;
@@ -340,71 +385,250 @@
     }
   }
 
+  // Get position information from the URL for deep-linking. The derived store will only retrieve
+  // line numbers and column selections for this path and row id.
+  const urlSelection =
+    datasetViewStore != null
+      ? derived(datasetViewStore, $datasetViewStore => {
+          if ($datasetViewStore.selection == null) return null;
+          const [selectionPath, selection] = $datasetViewStore.selection;
+          if (!pathIsEqual(selectionPath, path)) return null;
+
+          return selection;
+        })
+      : null;
+
+  let spanDecorations: Monaco.editor.IModelDeltaDecoration[] = [];
+
   // Add highlighting to the editor based on searches.
   $: {
     if (editor != null && model != null) {
-      editor.createDecorationsCollection(
-        monacoSpans.flatMap(renderSpan => {
-          if (!renderSpan.isHighlighted || model == null) {
-            return [];
-          }
-          const span = L.span(renderSpan.span)!;
-          const startPosition = model.getPositionAt(span.start);
-          const endPosition = model.getPositionAt(span.end);
-          if (startPosition == null || endPosition == null) {
-            return [];
-          }
+      spanDecorations = monacoSpans.flatMap(renderSpan => {
+        if (!renderSpan.isHighlighted || model == null) {
+          return [];
+        }
+        const span = L.span(renderSpan.span)!;
+        const startPosition = model.getPositionAt(span.start);
+        const endPosition = model.getPositionAt(span.end);
+        if (startPosition == null || endPosition == null) {
+          return [];
+        }
 
-          const classNames: string[] = [];
-          if (renderSpan.isKeywordSearch) {
-            classNames.push('keyword-search-decoration');
-          }
-          if (renderSpan.isConceptSearch) {
-            classNames.push('concept-search-decoration');
-          }
-          if (renderSpan.isSemanticSearch) {
-            classNames.push('semantic-search-decoration');
-          }
+        const spanDecorations: Monaco.editor.IModelDeltaDecoration[] = [];
 
-          return [
-            {
-              range: new monaco.Range(
-                startPosition.lineNumber,
-                startPosition.column,
-                endPosition.lineNumber,
-                endPosition.column
-              ),
-              options: {inlineClassName: classNames.join(' ')}
+        const hoverCard = getHoverCard(renderSpan);
+
+        const range = new monaco.Range(
+          startPosition.lineNumber,
+          startPosition.column,
+          endPosition.lineNumber,
+          endPosition.column
+        );
+
+        if (renderSpan.isKeywordSearch) {
+          spanDecorations.push({
+            range,
+            options: {
+              className: 'keyword-search-bg',
+              inlineClassName: 'keyword-search-text',
+              hoverMessage: hoverCard,
+              glyphMarginClassName: 'keyword-search-glyph',
+              glyphMarginHoverMessage: hoverCard,
+              isWholeLine: false,
+              minimap: {
+                position: monaco.editor.MinimapPosition.Inline,
+                color: '#888888'
+              }
             }
-          ];
-        })
-      );
+          });
+        } else if (renderSpan.isConceptSearch) {
+          spanDecorations.push({
+            range,
+            options: {
+              className: 'concept-search-bg',
+              inlineClassName: 'concept-search-text',
+              hoverMessage: hoverCard,
+              glyphMarginClassName: 'concept-search-bg',
+              glyphMarginHoverMessage: hoverCard,
+              isWholeLine: false,
+              minimap: {
+                position: monaco.editor.MinimapPosition.Inline,
+                color: '#dbeafe' // bg-blue-200 from tailwind
+              }
+            }
+          });
+        } else if (renderSpan.isSemanticSearch) {
+          spanDecorations.push({
+            range,
+            options: {
+              className: 'semantic-search-bg',
+              inlineClassName: 'semantic-search-text',
+              hoverMessage: hoverCard,
+              glyphMarginClassName: 'semantic-search-bg',
+              glyphMarginHoverMessage: hoverCard,
+              isWholeLine: false,
+              minimap: {
+                position: monaco.editor.MinimapPosition.Inline,
+                color: '#dbeafe' // bg-blue-200 from tailwind
+              }
+            }
+          });
+        }
+        return spanDecorations;
+      });
     }
   }
 
-  onDestroy(() => {
-    if (model != null) {
-      // Clean up the hover provider to avoid memory leaks.
-      removeHoverProvider(model);
-      model.dispose();
-    }
+  /**
+   * Deep linking.
+   */
+  // Add highlighting to the editor based on URL deep-link selections.
+  let deepLinkLineDecorations: Monaco.editor.IModelDeltaDecoration[] = [];
+  $: {
+    if (editor != null && model != null && urlSelection != null && $urlSelection != null) {
+      // The background color of the full line is always present.
+      deepLinkLineDecorations = [];
+      if (
+        $urlSelection.startLine == $urlSelection.endLine &&
+        $urlSelection.startCol == $urlSelection.endCol
+      ) {
+        deepLinkLineDecorations.push({
+          range: new monaco.Range(
+            $urlSelection.startLine,
+            $urlSelection.startCol,
+            $urlSelection.endLine,
+            $urlSelection.endCol || model.getLineMaxColumn($urlSelection.startLine)
+          ),
+          options: {
+            isWholeLine: true,
+            className: 'line-selection-bg',
+            glyphMarginClassName: 'line-selection-glyph',
+            glyphMarginHoverMessage: {value: '🔗 From the URL'}
+          }
+        });
+      } else {
+        // The specific selection highlighting is a darker color.
+        deepLinkLineDecorations.push({
+          range: new monaco.Range(
+            $urlSelection.startLine,
+            $urlSelection.startCol,
+            $urlSelection.endLine,
+            $urlSelection.endCol
+          ),
+          options: {
+            className: 'line-col-selection-bg',
+            hoverMessage: [{value: '🔗 From the URL'}],
+            glyphMarginClassName: 'line-selection-glyph',
+            glyphMarginHoverMessage: {value: '🔗 From the URL'},
+            minimap: {
+              position: monaco.editor.MinimapPosition.Inline,
+              color: '#cccccc'
+            }
+          }
+        });
+      }
 
+      editor.revealLineInCenter($urlSelection.startLine);
+    }
+  }
+
+  // Add right-click menus for deep-linking.
+  $: {
+    if (model != null && editor != null && viewType != null && path != null) {
+      const idLinkSelection = 'link-selection';
+      if (editor.getAction(idLinkSelection) == null) {
+        editor.addAction({
+          id: idLinkSelection,
+          label: '🔗 Link to selection',
+          contextMenuGroupId: 'navigation_links',
+          // We use ctrl/cmd + K to create a link, which is standard for hyperlinks.
+          keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK],
+          run: () => {
+            if (datasetViewStore == null || path == null || field == null || editor == null) return;
+
+            const selection = editor.getSelection();
+            if (selection == null) return;
+
+            datasetViewStore.setTextSelection(path, {
+              startLine: selection.startLineNumber,
+              endLine: selection.endLineNumber,
+              startCol: selection.startColumn,
+              endCol: selection.endColumn
+            });
+            editor.setSelection(selection);
+          }
+        });
+      }
+    }
+  }
+
+  $: {
+    if ($urlSelection == null) {
+      deepLinkLineDecorations = [];
+    }
+  }
+
+  let decorationIds: string[] = [];
+  $: {
+    if (editor != null) {
+      // deltaDecorations is deprecated, but it's currently the only API that supports resetting old
+      // decorations. This is important for settings that can change from state from stores.
+      decorationIds = editor.deltaDecorations(decorationIds, [
+        ...spanDecorations,
+        ...deepLinkLineDecorations
+      ]);
+      [decorationIds];
+    }
+  }
+  onDestroy(() => {
+    model?.dispose();
     editor?.dispose();
   });
 </script>
 
 <!-- For reasons unknown to me, the -ml-6 is required to make the autolayout of monaco react. -->
 <div class="relative -ml-6 flex h-fit w-full flex-col gap-x-4">
-  <div class="ml-6 h-64" class:hidden bind:this={editorContainer} />
+  <div
+    class="editor-container ml-6 h-64"
+    class:hidden
+    bind:this={editorContainer}
+    class:invisible={!editorReady}
+  />
 </div>
 
 <style lang="postcss">
-  :global(.keyword-search-decoration) {
-    cursor: pointer;
-    @apply py-0.5 font-extrabold !text-violet-500 underline;
+  /** Keyword search */
+  :global(.keyword-search-bg) {
+    @apply bg-amber-900 opacity-20;
   }
-  :global(.concept-search-decoration, .semantic-search-decoration) {
-    cursor: pointer;
-    @apply bg-blue-50 py-0.5 !text-black;
+  :global(.keyword-search-glyph) {
+    @apply border-r-8 border-amber-900 opacity-20;
+  }
+  :global(.keyword-search-text) {
+    @apply font-extrabold text-violet-500 underline;
+  }
+
+  /** Concept and semantic search */
+  :global(.concept-search-bg, .semantic-search-bg) {
+    @apply bg-blue-400 bg-opacity-20;
+  }
+  :global(.concept-search-text, .semantic-search-text) {
+    @apply text-black;
+  }
+
+  /** Deep-linked selection */
+  :global(.line-selection-bg) {
+    @apply bg-gray-500 bg-opacity-20;
+  }
+  :global(.line-col-selection-bg) {
+    @apply bg-gray-500 bg-opacity-20;
+  }
+
+  :global(.line-selection-glyph) {
+    @apply border-r-8 border-gray-500 opacity-50;
+  }
+
+  :global(.editor-container .monaco-editor .lines-content.monaco-editor-background) {
+    margin-left: 10px;
   }
 </style>

--- a/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
@@ -169,8 +169,6 @@
     if (model != null && editor != null) {
       let minPosition: Monaco.Position | null = null;
       for (const renderSpan of monacoSpans) {
-        if (!renderSpan.isHighlighted) continue;
-
         const span = L.span(renderSpan.span)!;
         const position = model.getPositionAt(span.start);
 
@@ -197,7 +195,7 @@
   // Returns the hover content for the given position in the editor by searching through the render
   // spans for the relevant span.
   function getHoverCard(renderSpan: MonacoRenderSpan): Monaco.IMarkdownString[] {
-    if (!renderSpan.isHighlighted || model == null) {
+    if (model == null) {
       return [];
     }
     const namedValue = renderSpan.namedValue;
@@ -404,7 +402,7 @@
   $: {
     if (editor != null && model != null) {
       spanDecorations = monacoSpans.flatMap(renderSpan => {
-        if (!renderSpan.isHighlighted || model == null) {
+        if (model == null) {
           return [];
         }
         const span = L.span(renderSpan.span)!;

--- a/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
+++ b/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
@@ -57,9 +57,6 @@ export interface MonacoRenderSpan {
   isConceptSearch: boolean;
   isSemanticSearch: boolean;
 
-  isBlackBolded: boolean;
-  isHighlightBolded: boolean;
-
   // Whether this span is highlighted and needs to always be shown.
   isHighlighted: boolean;
   // The text for this render span.
@@ -99,11 +96,8 @@ export function getMonacoRenderSpans(
 
         const namedValue = {value, info: valueInfo, specificPath: L.path(valueNode)!};
 
-        const isLabeled = namedValue.info.type === 'label';
-        const isLeafSpan = namedValue.info.type === 'leaf_span';
         const isKeywordSearch = namedValue.info.type === 'keyword';
-        const hasNonNumericMetadata =
-          namedValue.info.type === 'metadata' && !isNumeric(namedValue.info.dtype);
+
         let isHighlighted = false;
         if (valueInfo.type === 'concept_score' || valueInfo.type === 'semantic_similarity') {
           if ((value as number) > 0.5) {
@@ -112,7 +106,7 @@ export function getMonacoRenderSpans(
         } else {
           isHighlighted = true;
         }
-        // TODO: filter by isHighlighted.
+        if (!isHighlighted) continue;
 
         const text = textChars.slice(span.start, span.end).join('');
 
@@ -121,9 +115,6 @@ export function getMonacoRenderSpans(
           isKeywordSearch,
           isConceptSearch: valueInfo.type === 'concept_score',
           isSemanticSearch: valueInfo.type === 'semantic_similarity',
-          // TODO: delete
-          isBlackBolded: isKeywordSearch || hasNonNumericMetadata || isLeafSpan,
-          isHighlightBolded: isLabeled,
           isHighlighted,
           namedValue,
           path,

--- a/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
+++ b/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
@@ -112,6 +112,7 @@ export function getMonacoRenderSpans(
         } else {
           isHighlighted = true;
         }
+        // TODO: filter by isHighlighted.
 
         const text = textChars.slice(span.start, span.end).join('');
 
@@ -120,6 +121,7 @@ export function getMonacoRenderSpans(
           isKeywordSearch,
           isConceptSearch: valueInfo.type === 'concept_score',
           isSemanticSearch: valueInfo.type === 'semantic_similarity',
+          // TODO: delete
           isBlackBolded: isKeywordSearch || hasNonNumericMetadata || isLeafSpan,
           isHighlightBolded: isLabeled,
           isHighlighted,

--- a/web/blueprint/src/lib/monaco.ts
+++ b/web/blueprint/src/lib/monaco.ts
@@ -1,13 +1,14 @@
 import loader from '@monaco-editor/loader';
 import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-export const MONACO_LANGUAGE = 'lilac_text';
 export const MAX_MONACO_HEIGHT_COLLAPSED = 360;
 export const MAX_MONACO_HEIGHT_EXPANDED = 720;
 let monacoInstance: Promise<typeof Monaco>;
 
 export const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions = {
-  fontFamily: 'Inconsolata',
+  // Inconsolata variable comes from the @fontsource-variable/inconsolata NPM package so we don't
+  // hit google fonts on every page load.
+  fontFamily: 'inconsolata variable',
   fontSize: 14,
   readOnly: true,
   lineNumbers: 'off',
@@ -26,7 +27,7 @@ export const MONACO_OPTIONS: Monaco.editor.IStandaloneEditorConstructionOptions 
   },
   // Allows the hovers to be hoisted out of the editor and not get cut off.
   fixedOverflowWidgets: true,
-  language: MONACO_LANGUAGE,
+  language: 'text/plain',
   automaticLayout: true
 };
 
@@ -36,58 +37,7 @@ export async function getMonaco(): Promise<typeof Monaco> {
   }
   monacoInstance = import('monaco-editor').then(async monacoEditor => {
     loader.config({monaco: monacoEditor.default});
-    const monaco = await loader.init();
-
-    setupHovers(monaco);
-    // This is required to make sure that the fonts are loaded before the editor measures its size.
-    // If not set, hovers will be misaligned.
-    document.fonts.ready.then(() => {
-      monaco.editor.remeasureFonts();
-    });
-
-    return monaco;
+    return loader.init();
   });
   return monacoInstance;
-}
-
-/**
- * Register the single global hover provider for all monaco instances with the lilac language.
- * @param monaco
- */
-function setupHovers(monaco: typeof Monaco) {
-  monaco.languages.register({id: MONACO_LANGUAGE});
-
-  monaco.languages.registerHoverProvider(MONACO_LANGUAGE, {
-    provideHover: function (model, position, token) {
-      const callback = MONACO_HOVER_CALLBACKS.get(model.id);
-      if (callback != null) {
-        return callback(model, position, token);
-      }
-    }
-  });
-}
-
-// Maps a model id to its hover callback.
-const MONACO_HOVER_CALLBACKS = new Map<
-  string,
-  (
-    model: Monaco.editor.ITextModel,
-    position: Monaco.Position,
-    token: Monaco.CancellationToken
-  ) => Monaco.languages.ProviderResult<Monaco.languages.Hover>
->();
-
-export function registerHoverProvider(
-  model: Monaco.editor.ITextModel,
-  callback: (
-    model: Monaco.editor.ITextModel,
-    position: Monaco.Position,
-    token: Monaco.CancellationToken
-  ) => Monaco.languages.ProviderResult<Monaco.languages.Hover>
-) {
-  MONACO_HOVER_CALLBACKS.set(model.id, callback);
-}
-
-export function removeHoverProvider(model: Monaco.editor.ITextModel) {
-  MONACO_HOVER_CALLBACKS.delete(model.id);
 }

--- a/web/blueprint/src/routes/+layout.svelte
+++ b/web/blueprint/src/routes/+layout.svelte
@@ -16,6 +16,7 @@
   import {createNavigationStore, setNavigationContext} from '$lib/stores/navigationStore';
   import {createNotificationsStore, setNotificationsContext} from '$lib/stores/notificationsStore';
   import {createSettingsStore, setSettingsContext} from '$lib/stores/settingsStore';
+  import '@fontsource-variable/inconsolata';
   import 'carbon-components-svelte/css/all.css';
   import {slide} from 'svelte/transition';
 


### PR DESCRIPTION
https://github.com/lilacai/lilac/assets/1100749/a8d0a85f-7c3e-48ac-81d8-4ebcec1d5572

Details:
- Add deep linking support with right click => link. You can link both a full line, or a selection. CMD+K is the shortcut for this.
- Package inconsolata with our build by npm installing it.
- Fix issue with cursor offset by recomputing the fonts.
- Add support for minimap previews
- Remove the hover provider. Monaco has an explicit API for this.
- Add conditions for the right click menu.

https://lilacai-nikhil-staging.hf.space/datasets#local/OpenOrca-10k
https://lilacai-nikhil-staging.hf.space/datasets#local/OpenHermes-2.5-100k