### PR TITLE
Eliminate setup count call from parquet_source.

### DIFF
--- a/lilac/source.py
+++ b/lilac/source.py
@@ -119,6 +119,12 @@ class Source(BaseModel):
     The output parquet files should have a {schema.ROWID} column defined. This ROWID should not be
     part of source_schema, however.
 
+    Finally, self.source_schema().num_items is usually computed in setup(), but can be left as None
+    for sources implementing load_to_parquet, since this count is only used to display a progress
+    bar. load_to_parquet doesn't have progress bar support so the count is unnecessary. However, you
+    must still keep track of how many items were processed in total, because fields like
+    self.sample_size should reflect the actual size of the dataset if len(dataset) < sample_size.
+
     Args:
       output_dir: The directory to write the parquet files to.
       task_step_id: The TaskManager `task_step_id` for this process run. This is used to update the

--- a/lilac/sources/parquet_source.py
+++ b/lilac/sources/parquet_source.py
@@ -145,7 +145,7 @@ class ParquetSource(Source):
 
     # Ensure that self.sample_size reflects the actual number of rows processed.
     processed_count = self._con.execute(
-      f"SELECT COUNT(*) FROM read_parquet('{filepath}')"
+      f'SELECT COUNT(*) FROM read_parquet({filepath!r})'
     ).fetchone()
     num_items = cast(tuple[int], processed_count)[0]
     if self.sample_size:

--- a/lilac/sources/parquet_source.py
+++ b/lilac/sources/parquet_source.py
@@ -115,17 +115,12 @@ class ParquetSource(Source):
 
     # DuckDB expects s3 protocol: https://duckdb.org/docs/guides/import/s3_import.html.
     duckdb_paths = [convert_path_to_duckdb(path) for path in filepaths]
-    res = self._con.execute(f'SELECT COUNT(*) FROM read_parquet({duckdb_paths})').fetchone()
-    num_items = cast(tuple[int], res)[0]
-    if self.sample_size:
-      self.sample_size = min(self.sample_size, num_items)
-      num_items = self.sample_size
     schema = arrow_schema_to_schema(
       self._con.execute(f"""SELECT * FROM read_parquet('{duckdb_paths[0]}')""")
       .fetch_record_batch(1)
       .schema
     )
-    self._source_schema = SourceSchema(fields=schema.fields, num_items=num_items)
+    self._source_schema = SourceSchema(fields=schema.fields, num_items=None)
     self._setup_sampling(duckdb_paths)
 
   @override
@@ -147,5 +142,14 @@ class ParquetSource(Source):
     os.makedirs(output_dir, exist_ok=True)
 
     self._con.sql(self._process_query).write_parquet(filepath, compression='zstd')
+
+    # Ensure that self.sample_size reflects the actual number of rows processed.
+    processed_count = self._con.execute(
+      f"SELECT COUNT(*) FROM read_parquet('{filepath}')"
+    ).fetchone()
+    num_items = cast(tuple[int], processed_count)[0]
+    if self.sample_size:
+      self.sample_size = min(self.sample_size, num_items)
+
     schema = Schema(fields=self.source_schema().fields.copy())
     return SourceManifest(files=[out_filename], data_schema=schema, source=self)

--- a/lilac/sources/parquet_source_test.py
+++ b/lilac/sources/parquet_source_test.py
@@ -32,7 +32,7 @@ def test_simple_rows(tmp_path: pathlib.Path) -> None:
   source.setup()
   source_schema = source.source_schema()
   assert source_schema == SourceSchema(
-    fields=schema({'name': 'string', 'age': 'int64'}).fields, num_items=3
+    fields=schema({'name': 'string', 'age': 'int64'}).fields, num_items=None
   )
   manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
   items = retrieve_parquet_rows(tmp_path, manifest)
@@ -59,7 +59,7 @@ def test_map_dtype(tmp_path: pathlib.Path) -> None:
   source_schema = source.source_schema()
   assert source_schema == SourceSchema(
     fields=schema({'column': field(MapType(key_type=STRING, value_field=field('float32')))}).fields,
-    num_items=3,
+    num_items=None,
   )
   manifest = source.load_to_parquet(str(tmp_path), task_step_id=None)
   items = retrieve_parquet_rows(tmp_path, manifest)


### PR DESCRIPTION
The count() call would access all N shards even if pseudosampling was on. I defer the count so that it only accesses the final written file.