### PR TITLE
Improve the row header to give us space for deleting.

### DIFF
--- a/web/blueprint/src/lib/components/ButtonDropdown.svelte
+++ b/web/blueprint/src/lib/components/ButtonDropdown.svelte
@@ -61,7 +61,7 @@
       use:hoverTooltip={{text: helperText}}
       class:border={buttonOutline}
       class:border-gray-300={buttonOutline}
-      class="flex items-center gap-x-2"
+      class="flex items-center gap-x-2 bg-white"
       class:hidden={dropdownOpen}
     >
       {#if isLoading}

--- a/web/blueprint/src/lib/components/commands/CommandFilter.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandFilter.svelte
@@ -47,9 +47,10 @@
         })
       : [];
 
-  $: defaultField = $selectRowsSchema?.isSuccess
-    ? getField($selectRowsSchema.data.schema, command.path)
-    : undefined;
+  $: defaultField =
+    $selectRowsSchema?.isSuccess && command.path
+      ? getField($selectRowsSchema.data.schema, command.path)
+      : undefined;
 
   // Copy filters from query options
   let stagedFilters: Filter[] = [];

--- a/web/blueprint/src/lib/components/commands/Commands.svelte
+++ b/web/blueprint/src/lib/components/commands/Commands.svelte
@@ -61,7 +61,7 @@
     command: Command.EditFilter;
     namespace: string;
     datasetName: string;
-    path: Path;
+    path?: Path;
   };
 
   export type CreateConceptCommand = {

--- a/web/blueprint/src/lib/components/common/DropdownPill.svelte
+++ b/web/blueprint/src/lib/components/common/DropdownPill.svelte
@@ -12,6 +12,8 @@
   export let selectedId: string | null | undefined = null;
   export let items: DropdownItem[] | null | undefined = null;
   export let tooltip: string | null | undefined = undefined;
+  // The direction to open the dropdown.
+  export let direction: 'left' | 'right' = 'right';
 
   const dispatch = createEventDispatcher();
   export let open = false;
@@ -32,6 +34,7 @@
 
 <div
   class="drop-pill flex items-center px-2"
+  class:drop-pill-left={direction === 'left'}
   class:active={selectedId != null}
   use:hoverTooltip={!open && tooltip ? {text: tooltip} : {text: ''}}
 >
@@ -64,7 +67,14 @@
   :global(.drop-pill .bx--list-box__menu) {
     max-height: 26rem !important;
     width: unset;
-    right: unset;
+  }
+  :global(.drop-pill.drop-pill-left .bx--list-box__menu) {
+    /** These two lines move the drop pill from the right-hand side. */
+    transform: translateX(-100%);
+    margin-left: 100%;
+  }
+  :global(.drop-pill bx--list-box--expanded) {
+    @apply flex flex-col;
   }
   :global(.drop-pill .bx--dropdown) {
     @apply !max-w-xs;

--- a/web/blueprint/src/lib/components/datasetView/Dataset.svelte
+++ b/web/blueprint/src/lib/components/datasetView/Dataset.svelte
@@ -152,7 +152,7 @@
     >
       <SchemaView />
     </div>
-    <div class="h-full w-2/3 flex-grow">
+    <div class="h-full w-2/3 flex-grow py-1">
       {#if viewType == 'scroll'}
         <ScrollView />
       {:else if viewType == 'single_item'}

--- a/web/blueprint/src/lib/components/datasetView/EditLabel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/EditLabel.svelte
@@ -24,6 +24,7 @@
   export let disabled = false;
   export let disabledMessage = 'User does not have access to add labels.';
   export let icon: typeof CarbonIcon;
+  // True when we are removing a particular label.
   export let remove = false;
   export let totalNumRows: number | undefined = undefined;
   const dispatch = createEventDispatcher();

--- a/web/blueprint/src/lib/components/datasetView/FilterPanel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/FilterPanel.svelte
@@ -8,6 +8,7 @@
   import {formatValue, type Search, type SearchType, type WebManifest} from '$lilac';
   import {Button, Modal, SkeletonText} from 'carbon-components-svelte';
   import {ArrowUpRight, Filter, TagGroup, TagNone} from 'carbon-icons-svelte';
+  import {Command, triggerCommand} from '../commands/Commands.svelte';
   import ConceptView from '../concepts/ConceptView.svelte';
   import EditLabel from './EditLabel.svelte';
   import FilterPill from './FilterPill.svelte';
@@ -67,7 +68,7 @@
   <div class="flex w-full justify-between gap-x-6 gap-y-2">
     <div class="flex w-full flex-row gap-x-4">
       <!-- Number of results. -->
-      <div class="flex rounded border border-neutral-200 bg-neutral-50 p-2">
+      <div class="flex items-center rounded border border-neutral-200 bg-neutral-50 p-2">
         {#if totalNumRows && manifest}
           {#if totalNumRows == manifest.dataset_manifest.num_items}
             {formatValue(totalNumRows)} rows
@@ -98,14 +99,14 @@
     </div>
     <div class="flex grow flex-row gap-x-4">
       <!-- Filters -->
-      <div class="mx-6 flex items-center gap-x-1">
+      <div class="flex items-center gap-x-1 rounded border border-neutral-300 px-2">
         <div><Filter /></div>
         {#if searches.length > 0 || (filters && filters.length > 0)}
           <div class="flex flex-grow flex-row gap-x-4">
             <!-- Search groups -->
             {#each searchTypeOrder as searchType}
               {#if searchesByType[searchType]}
-                <div class="filter-group rounded bg-slate-50 px-2 py-1 shadow-sm">
+                <div class="filter-group rounded bg-slate-50 px-2 shadow-sm">
                   <div class="text-xs font-light">{searchTypeDisplay[searchType]}</div>
                   <div class="flex flex-row gap-x-1">
                     {#each searchesByType[searchType] as search}
@@ -117,7 +118,7 @@
             {/each}
             <!-- Filters group -->
             {#if filters != null && filters.length > 0}
-              <div class="filter-group rounded bg-slate-50 px-2 py-1 shadow-sm">
+              <div class="filter-group rounded bg-slate-50 px-2 shadow-sm">
                 <div class="text-xs font-light">Filters</div>
                 <div class="flex flex-row gap-x-1">
                   {#if $schema.data}
@@ -132,12 +133,23 @@
             {/if}
           </div>
         {:else}
-          Filters
+          <button
+            on:click={() =>
+              triggerCommand({
+                command: Command.EditFilter,
+                namespace: $datasetViewStore.namespace,
+                datasetName: $datasetViewStore.datasetName
+              })}>Filters</button
+          >
         {/if}
       </div>
 
-      <GroupByPill />
-      <SortPill />
+      <div class="rounded border border-neutral-300">
+        <GroupByPill />
+      </div>
+      <div class="rounded border border-neutral-300">
+        <SortPill />
+      </div>
     </div>
   </div>
 </div>
@@ -171,6 +183,6 @@
 <style lang="postcss">
   .filter-group {
     min-width: 6rem;
-    @apply flex flex-row items-center gap-x-2 border border-gray-200 px-2 py-1 shadow-sm;
+    @apply flex flex-row items-center gap-x-2  px-2 shadow-sm;
   }
 </style>

--- a/web/blueprint/src/lib/components/datasetView/FilterPanel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/FilterPanel.svelte
@@ -183,6 +183,6 @@
 <style lang="postcss">
   .filter-group {
     min-width: 6rem;
-    @apply flex flex-row items-center gap-x-2  px-2 shadow-sm;
+    @apply flex flex-row items-center gap-x-2 px-2 shadow-sm;
   }
 </style>

--- a/web/blueprint/src/lib/components/datasetView/FilterPanel.svelte
+++ b/web/blueprint/src/lib/components/datasetView/FilterPanel.svelte
@@ -64,77 +64,81 @@
 </script>
 
 <div class="relative mx-5 my-2 flex items-center justify-between">
-  <div class="flex items-center gap-x-6 gap-y-2">
-    <div class="flex items-center gap-x-2">
-      <EditLabel
-        {totalNumRows}
-        icon={TagGroup}
-        disabled={!canLabelAll}
-        disabledMessage={!canLabelAll ? 'User does not have access to label all.' : ''}
-        labelsQuery={{searches, filters}}
-        helperText={'Label all items in the current filter'}
-      />
-      <EditLabel
-        {totalNumRows}
-        remove
-        icon={TagNone}
-        disabled={!canLabelAll}
-        disabledMessage={!canLabelAll ? 'User does not have access to label all.' : ''}
-        labelsQuery={{searches, filters}}
-        helperText={'Remove label from all items in the current filter'}
-      />
+  <div class="flex w-full justify-between gap-x-6 gap-y-2">
+    <div class="flex w-full flex-row gap-x-4">
+      <!-- Number of results. -->
+      <div class="flex rounded border border-neutral-200 bg-neutral-50 p-2">
+        {#if totalNumRows && manifest}
+          {#if totalNumRows == manifest.dataset_manifest.num_items}
+            {formatValue(totalNumRows)} rows
+          {:else}
+            {formatValue(totalNumRows)} of {formatValue(manifest.dataset_manifest.num_items)} rows
+          {/if}
+        {/if}
+      </div>
+      <div class="flex items-center gap-x-2">
+        <EditLabel
+          {totalNumRows}
+          icon={TagGroup}
+          disabled={!canLabelAll}
+          disabledMessage={!canLabelAll ? 'User does not have access to label all.' : ''}
+          labelsQuery={{searches, filters}}
+          helperText={'Label all items in the current filter'}
+        />
+        <EditLabel
+          {totalNumRows}
+          remove
+          icon={TagNone}
+          disabled={!canLabelAll}
+          disabledMessage={!canLabelAll ? 'User does not have access to label all.' : ''}
+          labelsQuery={{searches, filters}}
+          helperText={'Remove label from all items in the current filter'}
+        />
+      </div>
     </div>
-    <!-- Filters -->
-    <div class="flex items-center gap-x-1">
-      <div><Filter /></div>
-      {#if searches.length > 0 || (filters && filters.length > 0)}
-        <div class="flex flex-grow flex-row gap-x-4">
-          <!-- Search groups -->
-          {#each searchTypeOrder as searchType}
-            {#if searchesByType[searchType]}
+    <div class="flex grow flex-row gap-x-4">
+      <!-- Filters -->
+      <div class="mx-6 flex items-center gap-x-1">
+        <div><Filter /></div>
+        {#if searches.length > 0 || (filters && filters.length > 0)}
+          <div class="flex flex-grow flex-row gap-x-4">
+            <!-- Search groups -->
+            {#each searchTypeOrder as searchType}
+              {#if searchesByType[searchType]}
+                <div class="filter-group rounded bg-slate-50 px-2 py-1 shadow-sm">
+                  <div class="text-xs font-light">{searchTypeDisplay[searchType]}</div>
+                  <div class="flex flex-row gap-x-1">
+                    {#each searchesByType[searchType] as search}
+                      <SearchPill {search} on:click={() => openSearchPill(search)} />
+                    {/each}
+                  </div>
+                </div>
+              {/if}
+            {/each}
+            <!-- Filters group -->
+            {#if filters != null && filters.length > 0}
               <div class="filter-group rounded bg-slate-50 px-2 py-1 shadow-sm">
-                <div class="text-xs font-light">{searchTypeDisplay[searchType]}</div>
+                <div class="text-xs font-light">Filters</div>
                 <div class="flex flex-row gap-x-1">
-                  {#each searchesByType[searchType] as search}
-                    <SearchPill {search} on:click={() => openSearchPill(search)} />
-                  {/each}
+                  {#if $schema.data}
+                    {#each filters as filter}
+                      <FilterPill schema={$schema.data} {filter} />
+                    {/each}
+                  {:else}
+                    <SkeletonText />
+                  {/if}
                 </div>
               </div>
             {/if}
-          {/each}
-          <!-- Filters group -->
-          {#if filters != null && filters.length > 0}
-            <div class="filter-group rounded bg-slate-50 px-2 py-1 shadow-sm">
-              <div class="text-xs font-light">Filters</div>
-              <div class="flex flex-row gap-x-1">
-                {#if $schema.data}
-                  {#each filters as filter}
-                    <FilterPill schema={$schema.data} {filter} />
-                  {/each}
-                {:else}
-                  <SkeletonText />
-                {/if}
-              </div>
-            </div>
-          {/if}
-        </div>
-      {:else}
-        Filters
-      {/if}
-    </div>
+          </div>
+        {:else}
+          Filters
+        {/if}
+      </div>
 
-    <GroupByPill />
-    <SortPill />
-  </div>
-  <!-- Number of results. -->
-  <div class="flex py-2">
-    {#if totalNumRows && manifest}
-      {#if totalNumRows == manifest.dataset_manifest.num_items}
-        {formatValue(totalNumRows)} rows
-      {:else}
-        {formatValue(totalNumRows)} of {formatValue(manifest.dataset_manifest.num_items)} rows
-      {/if}
-    {/if}
+      <GroupByPill />
+      <SortPill />
+    </div>
   </div>
 </div>
 

--- a/web/blueprint/src/lib/components/datasetView/GroupByPill.svelte
+++ b/web/blueprint/src/lib/components/datasetView/GroupByPill.svelte
@@ -62,6 +62,7 @@
   title="Group by"
   {items}
   bind:open
+  direction="left"
   on:select={selectItem}
   {selectedId}
   tooltip={selectedPath ? `Grouping by ${getDisplayPath(selectedPath)}` : null}

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -207,10 +207,8 @@
 
 <div class="flex w-full flex-row gap-x-4 p-2">
   {#if isLeaf}
-    <div
-      class="relative mr-4 flex w-28 shrink-0 flex-row font-mono font-medium text-neutral-500 md:w-36"
-    >
-      <div class="sticky top-0 flex w-full flex-col gap-y-2 self-start">
+    <div class="relative mr-4 flex w-28 flex-row font-mono font-medium text-neutral-500 md:w-36">
+      <div class="z-100 sticky top-16 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}
           <div title={displayPath} class="mx-2 mt-2 w-full flex-initial truncate">
             {displayPath}

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -31,6 +31,8 @@
     CatalogPublish,
     ChevronDown,
     ChevronUp,
+    DataBackup,
+    DataView,
     DataViewAlt,
     DirectionFork,
     Search,
@@ -206,7 +208,7 @@
 <div class="flex w-full flex-row gap-x-4 p-2">
   {#if isLeaf}
     <div
-      class="relative mr-4 flex w-32 shrink-0 flex-row font-mono font-medium text-neutral-500 md:w-44"
+      class="relative mr-4 flex w-28 shrink-0 flex-row font-mono font-medium text-neutral-500 md:w-36"
     >
       <div class="sticky top-0 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}
@@ -253,6 +255,18 @@
           {/if}
 
           <button
+            on:click={() =>
+              ($datasetViewStore.showMetadataPanel = !$datasetViewStore.showMetadataPanel)}
+            use:hoverTooltip={{
+              text: $datasetViewStore.showMetadataPanel
+                ? 'Collapse metadata panel'
+                : 'Expand metadata panel'
+            }}
+            >{#if $datasetViewStore.showMetadataPanel}<DataBackup size={16} />{:else}<DataView
+                size={16}
+              />{/if}
+          </button>
+          <button
             disabled={!textIsOverBudget}
             class:opacity-50={!textIsOverBudget}
             on:click={() => (userExpanded = !userExpanded)}
@@ -265,7 +279,7 @@
     <div class="flex grow flex-col font-normal">
       {#if titleValue != null}
         <div
-          class="-m-2 mb-1 rounded bg-gray-100 p-1 px-2 text-xs font-bold uppercase text-gray-700"
+          class="mb-1 ml-11 rounded bg-gray-100 p-1 px-2 text-xs font-bold uppercase text-gray-700"
         >
           {titleValue}
         </div>

--- a/web/blueprint/src/lib/components/datasetView/LabelPill.svelte
+++ b/web/blueprint/src/lib/components/datasetView/LabelPill.svelte
@@ -10,6 +10,7 @@
   {disabled}
   class="rounded-lg border border-gray-300 hover:border-gray-500"
   class:bg-slate-500={active}
+  class:bg-white={!active}
   class:hover:bg-slate-500={active}
   class:hover:bg-transparent={!active}
   class:text-white={active}

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -131,8 +131,10 @@
 
 <div class="relative flex w-full flex-col rounded md:flex-col">
   <!-- Header -->
-  <div style="z-index: 500;" class="sticky top-0 flex w-full flex-row justify-between rounded-t">
-    <div class="mx-4 flex w-full border border-neutral-300 bg-violet-100 py-2">
+  <div style="z-index: 500;" class="sticky top-0 flex w-full flex-row justify-between">
+    <div
+      class="mx-4 flex w-full rounded-t border border-neutral-300 bg-violet-200 bg-opacity-70 py-2"
+    >
       <!-- Left arrow -->
       <div class="flex w-1/3 flex-row">
         <!-- Right 1/3 -->
@@ -167,7 +169,7 @@
             {@const leftArrowEnabled = index != null && index > 0}
             <div class="flex-0 my-0.5">
               <button
-                class:opacity-20={!leftArrowEnabled}
+                class:opacity-30={!leftArrowEnabled}
                 disabled={!leftArrowEnabled}
                 on:click={() =>
                   updateSequentialRowId != null ? updateSequentialRowId('previous') : null}
@@ -184,9 +186,9 @@
                 <SkeletonText lines={1} class="!w-10" />
               {/if}
             </span>
-            <span class="inline-flex text-gray-500 opacity-90">of</span>
+            <span class="inline-flex text-gray-500 opacity-80">of</span>
 
-            <span class="inline-flex text-gray-500 opacity-90">
+            <span class="inline-flex text-gray-500 opacity-80">
               {#if totalNumRows != null}
                 {formatValue(totalNumRows)}
               {:else}
@@ -199,7 +201,7 @@
 
             <div class="flex-0">
               <button
-                class:opacity-20={!rightArrowEnabled}
+                class:opacity-30={!rightArrowEnabled}
                 disabled={!rightArrowEnabled}
                 on:click={() =>
                   updateSequentialRowId != null ? updateSequentialRowId('next') : null}

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -4,7 +4,6 @@
     queryDatasetSchema,
     queryRowMetadata,
     querySelectRowsSchema,
-    querySettings,
     removeLabelsMutation
   } from '$lib/queries/datasetQueries';
   import {queryAuthInfo} from '$lib/queries/serverQueries';
@@ -36,8 +35,8 @@
   export let mediaFields: LilacField[];
   export let highlightedFields: LilacField[];
   // The counting index of this row item.
-  export let index: number | undefined;
-  export let totalNumRows: number | undefined;
+  export let index: number | undefined = undefined;
+  export let totalNumRows: number | undefined = undefined;
   export let updateSequentialRowId: ((direction: 'previous' | 'next') => void) | undefined =
     undefined;
 
@@ -87,9 +86,6 @@
     }
   }
 
-  $: settings = querySettings($datasetViewStore.namespace, $datasetViewStore.datasetName);
-  $: viewType = $settings.data?.ui?.view_type || 'single_item';
-
   function addLabel(label: string) {
     const addLabelsOptions: AddLabelsOptions = {
       row_ids: [rowId],
@@ -133,55 +129,15 @@
   }
 </script>
 
-<div class="flex w-full flex-col rounded border border-neutral-300 md:flex-row">
-  <div
-    class={`flex flex-col  ${!$datasetViewStore.showMetadataPanel ? 'grow ' : 'w-2/3'}`}
-    bind:clientHeight={mediaHeight}
-  >
-    <div
-      class="flex flex-row justify-between rounded-t border-b border-neutral-300 bg-violet-100 py-2"
-    >
+<div class="relative flex w-full flex-col rounded md:flex-col">
+  <!-- Header -->
+  <div style="z-index: 500;" class="sticky top-0 flex w-full flex-row justify-between rounded-t">
+    <div class="mx-4 flex w-full border border-neutral-300 bg-violet-100 py-2">
       <!-- Left arrow -->
-      <div class="w-1/3">
-        <!-- left 1/3 container. -->
-        {#if updateSequentialRowId != null}
-          <div class="flex-0">
-            {#if rowId != null && index != null}
-              <button
-                class:invisible={index === 0}
-                on:click={() =>
-                  updateSequentialRowId != null ? updateSequentialRowId('previous') : null}
-              >
-                <ChevronLeft title="Previous item" size={24} />
-              </button>
-            {/if}
-          </div>
-        {/if}
-      </div>
-      <div class="w-1/3 flex-col items-center justify-items-center self-center justify-self-center">
-        <div class="items-center justify-items-center truncate text-center text-lg">
-          <span class="inline-flex">
-            {#if index != null && index >= 0}
-              {index + 1}
-            {:else}
-              <SkeletonText lines={1} class="!w-10" />
-            {/if}
-          </span>
-
-          <span class="inline-flex text-gray-500 opacity-90">
-            of
-            {#if totalNumRows != null}
-              {formatValue(totalNumRows)}
-            {:else}
-              <SkeletonText lines={1} class="!w-20" />
-            {/if}
-          </span>
-        </div>
-      </div>
       <div class="flex w-1/3 flex-row">
         <!-- Right 1/3 -->
         <div
-          class="flex w-full flex-row items-center justify-end gap-x-2 gap-y-2 pr-2"
+          class="flex w-full flex-row items-center gap-x-2 gap-y-2 pl-2"
           class:opacity-50={disableLabels}
         >
           {#each schemaLabels || [] as label}
@@ -203,62 +159,95 @@
           <div class="relative mr-8 h-8">
             <EditLabel icon={Tag} labelsQuery={{row_ids: [rowId]}} hideLabels={rowLabels} />
           </div>
-          {#if updateSequentialRowId != null && totalNumRows != null}
-            <div class="flex-0">
-              {#if index != null && index < totalNumRows - 1}
-                <button
-                  on:click={() =>
-                    updateSequentialRowId != null ? updateSequentialRowId('next') : null}
-                >
-                  <ChevronRight title="Next item" size={24} />
-                </button>
+        </div>
+      </div>
+      <div class="w-1/3 items-center justify-items-center self-center justify-self-center">
+        <div class="flex w-full flex-row items-center justify-center truncate text-center text-lg">
+          {#if updateSequentialRowId != null}
+            {@const leftArrowEnabled = index != null && index > 0}
+            <div class="flex-0 my-0.5">
+              <button
+                class:opacity-20={!leftArrowEnabled}
+                disabled={!leftArrowEnabled}
+                on:click={() =>
+                  updateSequentialRowId != null ? updateSequentialRowId('previous') : null}
+              >
+                <ChevronLeft title="Previous item" size={24} />
+              </button>
+            </div>
+          {/if}
+          <div class="flex w-32 flex-row justify-center gap-x-1.5">
+            <span class="inline-flex">
+              {#if index != null && index >= 0}
+                {index + 1}
+              {:else}
+                <SkeletonText lines={1} class="!w-10" />
               {/if}
+            </span>
+            <span class="inline-flex text-gray-500 opacity-90">of</span>
+
+            <span class="inline-flex text-gray-500 opacity-90">
+              {#if totalNumRows != null}
+                {formatValue(totalNumRows)}
+              {:else}
+                <SkeletonText lines={1} class="!w-20" />
+              {/if}
+            </span>
+          </div>
+          {#if updateSequentialRowId != null && totalNumRows != null}
+            {@const rightArrowEnabled = index != null && index < totalNumRows - 1}
+
+            <div class="flex-0">
+              <button
+                class:opacity-20={!rightArrowEnabled}
+                disabled={!rightArrowEnabled}
+                on:click={() =>
+                  updateSequentialRowId != null ? updateSequentialRowId('next') : null}
+              >
+                <ChevronRight title="Next item" size={24} />
+              </button>
             </div>
           {/if}
         </div>
       </div>
-    </div>
-    {#if mediaFields.length > 0}
-      {#each mediaFields as mediaField, i (serializePath(mediaField.path))}
-        <div
-          class:border-b={i < mediaFields.length - 1}
-          class:pb-2={i < mediaFields.length - 1}
-          class="flex h-full w-full flex-col border-neutral-200"
-        >
-          <ItemMedia mediaPath={mediaField.path} {row} field={mediaField} {highlightedFields} />
-        </div>
-      {/each}
-    {/if}
-    <!-- <div class="absolute right-0 top-0">
-      <button
-        class="mr-1 mt-1 opacity-60 hover:bg-gray-200"
-        use:hoverTooltip={{
-          text: $datasetViewStore.showMetadataPanel ? 'Close metadata' : 'Open metadata'
-        }}
-        on:click={() =>
-          ($datasetViewStore.showMetadataPanel = !$datasetViewStore.showMetadataPanel)}
-      >
-        {#if $datasetViewStore.showMetadataPanel}
-          <SidePanelOpen />
-        {:else}
-          <SidePanelClose />
-        {/if}</button
-      >
-    </div> -->
-  </div>
-  {#if $datasetViewStore.showMetadataPanel}
-    <div
-      class="flex h-full bg-neutral-100 md:w-1/3"
-      transition:slide={{axis: 'x', duration: SIDEBAR_TRANSITION_TIME_MS}}
-    >
-      <div class="sticky top-0 w-full self-start">
-        <div
-          style={`max-height: ${Math.max(MIN_METADATA_HEIGHT_PX, mediaHeight)}px`}
-          class="overflow-y-auto"
-        >
-          <ItemMetadata {row} selectRowsSchema={$selectRowsSchema.data} {highlightedFields} />
-        </div>
+      <div class="flex w-1/3 flex-row">
+        <!-- Right 1/3 -->
       </div>
     </div>
-  {/if}
+  </div>
+  <div class="px-4">
+    <div
+      class={`flex flex-col ${!$datasetViewStore.showMetadataPanel ? 'grow ' : 'w-2/3'}`}
+      bind:clientHeight={mediaHeight}
+    >
+      <div class="rounded-b border-b border-l border-r border-neutral-300">
+        {#if mediaFields.length > 0}
+          {#each mediaFields as mediaField, i (serializePath(mediaField.path))}
+            <div
+              class:border-b={i < mediaFields.length - 1}
+              class:pb-2={i < mediaFields.length - 1}
+              class="flex h-full w-full flex-col border-neutral-200"
+            >
+              <ItemMedia mediaPath={mediaField.path} {row} field={mediaField} {highlightedFields} />
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </div>
+    {#if $datasetViewStore.showMetadataPanel}
+      <div
+        class="flex h-full bg-neutral-100 md:w-1/3"
+        transition:slide={{axis: 'x', duration: SIDEBAR_TRANSITION_TIME_MS}}
+      >
+        <div class="sticky top-0 w-full self-start">
+          <div
+            style={`max-height: ${Math.max(MIN_METADATA_HEIGHT_PX, mediaHeight)}px`}
+            class="overflow-y-auto"
+          >
+            <ItemMetadata {row} selectRowsSchema={$selectRowsSchema.data} {highlightedFields} />
+          </div>
+        </div>
+      </div>
+    {/if}
+  </div>
 </div>

--- a/web/blueprint/src/lib/components/datasetView/ScrollView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ScrollView.svelte
@@ -85,7 +85,7 @@
 
 {#if rowIds && $schema.isSuccess && mediaFields != null}
   <div
-    class="flex h-full w-full flex-col gap-y-10 overflow-y-scroll px-5 pb-32"
+    class="flex h-full w-full flex-col gap-y-10 overflow-y-scroll pb-32"
     bind:this={itemScrollContainer}
   >
     {#each rowIds as rowId, i}

--- a/web/blueprint/src/lib/components/datasetView/ScrollView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ScrollView.svelte
@@ -88,8 +88,8 @@
     class="flex h-full w-full flex-col gap-y-10 overflow-y-scroll px-5 pb-32"
     bind:this={itemScrollContainer}
   >
-    {#each rowIds as rowId}
-      <RowItem {rowId} {mediaFields} {highlightedFields} />
+    {#each rowIds as rowId, i}
+      <RowItem {rowId} index={i} {totalNumRows} {mediaFields} {highlightedFields} />
     {/each}
     {#if rowIds.length > 0}
       <InfiniteScroll threshold={100} on:loadMore={() => $rows?.fetchNextPage()} />

--- a/web/blueprint/src/lib/components/datasetView/SingleItemView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/SingleItemView.svelte
@@ -82,7 +82,7 @@
 {/each}
 
 {#if rowId != null}
-  <div class="flex h-full w-full flex-col overflow-y-scroll px-5 pb-32 pt-1">
+  <div class="flex h-full w-full flex-col overflow-y-scroll pb-32">
     <RowItem
       {index}
       totalNumRows={rowsResponse?.total_num_rows}

--- a/web/blueprint/src/lib/components/datasetView/SingleItemView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/SingleItemView.svelte
@@ -6,9 +6,7 @@
   } from '$lib/queries/datasetQueries';
   import {getDatasetViewContext, getSelectRowsSchemaOptions} from '$lib/stores/datasetViewStore';
   import {getHighlightedFields, getMediaFields} from '$lib/view_utils';
-  import {L, ROWID, formatValue, type SelectRowsResponse} from '$lilac';
-  import {SkeletonText} from 'carbon-components-svelte';
-  import {ChevronLeft, ChevronRight} from 'carbon-icons-svelte';
+  import {L, ROWID, type SelectRowsResponse} from '$lilac';
   import FilterPanel from './FilterPanel.svelte';
   import PrefetchRowItem from './PrefetchRowItem.svelte';
   import RowItem from './RowItem.svelte';
@@ -52,11 +50,11 @@
     : [];
   $: highlightedFields = getHighlightedFields($store.query, $selectRowsSchema?.data);
 
-  function updateRowId(next: boolean) {
+  function updateSequentialRowId(direction: 'previous' | 'next') {
     if (index == null) {
       return;
     }
-    const newIndex = next ? index + 1 : Math.max(index - 1, 0);
+    const newIndex = direction === 'next' ? index + 1 : Math.max(index - 1, 0);
     const newRowId = L.value(nextRowsResponse?.rows[newIndex][ROWID], 'string');
     if (newRowId != null) {
       store.setRowId(newRowId);
@@ -66,57 +64,14 @@
 
   function onKeyDown(key: KeyboardEvent) {
     if (key.code === 'ArrowLeft') {
-      updateRowId(false);
+      updateSequentialRowId('previous');
     } else if (key.code === 'ArrowRight') {
-      updateRowId(true);
+      updateSequentialRowId('next');
     }
   }
 </script>
 
 <FilterPanel totalNumRows={rowsResponse?.total_num_rows} manifest={$manifest.data} />
-
-<div
-  class="mx-5 my-2 flex items-center justify-between rounded-lg border border-neutral-300 bg-neutral-100 py-2"
->
-  {#if rows?.length === 0}
-    <div class="w-full text-center">No results found</div>
-  {:else}
-    <div class="flex-0">
-      {#if rowId != null && index != null && index > 0}
-        <button on:click={() => updateRowId(false)}>
-          <ChevronLeft title="Previous item" size={24} />
-        </button>
-      {/if}
-    </div>
-
-    <div class="flex-col items-center justify-items-center">
-      <div class="min-w-0 max-w-lg truncate text-center text-lg">
-        <span class="inline-flex">
-          {#if index != null && index >= 0}
-            {index + 1}
-          {:else}
-            <SkeletonText lines={1} class="!w-10" />
-          {/if}
-        </span>
-        of
-        <span class="inline-flex">
-          {#if rowsResponse?.total_num_rows != null}
-            {formatValue(rowsResponse?.total_num_rows)}
-          {:else}
-            <SkeletonText lines={1} class="!w-20" />
-          {/if}
-        </span>
-      </div>
-    </div>
-    <div class="flex-0">
-      {#if index != null && index < (rowsResponse?.total_num_rows || 0) - 1}
-        <button on:click={() => updateRowId(true)}>
-          <ChevronRight title="Next item" size={24} />
-        </button>
-      {/if}
-    </div>
-  {/if}
-</div>
 
 <SingleItemSelectRows {limit} bind:rowsResponse />
 <SingleItemSelectRows limit={limit * 2} bind:rowsResponse={nextRowsResponse} />
@@ -127,8 +82,15 @@
 {/each}
 
 {#if rowId != null}
-  <div class="flex h-full w-full flex-col overflow-y-scroll pb-32 pl-5 pr-2">
-    <RowItem {rowId} {mediaFields} {highlightedFields} />
+  <div class="flex h-full w-full flex-col overflow-y-scroll px-5 pb-32 pt-1">
+    <RowItem
+      {index}
+      totalNumRows={rowsResponse?.total_num_rows}
+      {rowId}
+      {mediaFields}
+      {highlightedFields}
+      {updateSequentialRowId}
+    />
   </div>
 {/if}
 

--- a/web/blueprint/src/lib/components/datasetView/SortPill.svelte
+++ b/web/blueprint/src/lib/components/datasetView/SortPill.svelte
@@ -106,7 +106,15 @@
 </script>
 
 <div class="sort-container flex flex-row items-center gap-x-1 md:w-fit">
-  <DropdownPill bind:open title="Sort" on:select={selectSort} {selectedId} {items} let:item>
+  <DropdownPill
+    bind:open
+    direction="left"
+    title="Sort"
+    on:select={selectSort}
+    {selectedId}
+    {items}
+    let:item
+  >
     <div slot="icon">
       <button
         use:hoverTooltip={{

--- a/web/blueprint/src/routes/+layout.svelte
+++ b/web/blueprint/src/routes/+layout.svelte
@@ -115,7 +115,7 @@
     </div>
   </main>
 
-  <div class="absolute right-2 top-0 z-10 w-96">
+  <div class="absolute right-2 top-0 w-96" style="z-index: 1000">
     {#each notifications as notification}
       <ToastNotification
         lowContrast
@@ -131,7 +131,7 @@
       />
     {/each}
   </div>
-  <div class="absolute bottom-4 right-4">
+  <div class="absolute bottom-4 right-4" style="z-index: 1000">
     {#each $apiErrors as error}
       <ToastNotification
         lowContrast


### PR DESCRIPTION
Save a bunch of room, and add a little color pizzaz (I worked with Caroline on the colors).

- Add a header for each row regardless of the view type.
- We now put the labels in there. We'll put delete there too.
- Move the arrow buttons into the RowItem
- Move the filters, sort by, group by to the top-right.
- Move the show metadata to the buttons on the LHS.
- Make filters clicakble.
- The header is now sticky.

TODO(Fix the RowItem usages outside of the dataset view, e.g. loading).

Demo:
(single item) https://lilacai-nikhil-staging.hf.space/datasets#local/OpenHermes-2.5-100k
(scroll) https://lilacai-nikhil-staging.hf.space/datasets#local/OpenOrca-10k

https://github.com/lilacai/lilac/assets/1100749/2e262f1a-331a-4e71-b506-7b43fa2b4b5d
