### PR TITLE
Fix memory leak caused by Iterable/Iterator mixups

### DIFF
--- a/lilac/batch_utils.py
+++ b/lilac/batch_utils.py
@@ -8,7 +8,7 @@ from .utils import chunks, is_primitive
 
 def _deep_flatten(
   input: Union[Iterator, object], is_primitive_predicate: Callable[[object], bool]
-) -> Generator:
+) -> Iterator:
   """Flattens a nested iterable."""
   if is_primitive_predicate(input):
     yield input
@@ -97,7 +97,7 @@ def flat_batched_compute(
   input: Iterable[Iterable[TFlatBatchedInput]],
   f: Callable[[list[TFlatBatchedInput]], Iterable[TFlatBatchedOutput]],
   batch_size: int,
-) -> Iterable[Iterable[TFlatBatchedOutput]]:
+) -> Iterator[Iterable[TFlatBatchedOutput]]:
   """Flatten the input, batched call f, and return the output unflattened."""
   # Tee the input so we can use it twice for the input and output shapes.
   input_1, input_2 = itertools.tee(input, 2)

--- a/lilac/concepts/db_concept_test.py
+++ b/lilac/concepts/db_concept_test.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import ClassVar, Generator, Iterable, Type, cast
+from typing import ClassVar, Generator, Iterable, Iterator, Type, cast
 
 import numpy as np
 import pytest
@@ -59,7 +59,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Embed the examples, use a hashmap to the vector for simplicity."""
     for example in data:
       if example not in EMBEDDING_MAP:

--- a/lilac/data/dataset_compute_signal_chain_test.py
+++ b/lilac/data/dataset_compute_signal_chain_test.py
@@ -1,7 +1,7 @@
 """Tests for dataset.compute_signal() when signals are chained."""
 
 import re
-from typing import ClassVar, Iterable, List, Optional, cast
+from typing import ClassVar, Iterable, Iterator, List, Optional, cast
 
 import numpy as np
 import pytest
@@ -64,7 +64,7 @@ class TestSplitter(TextSignal):
     return field(fields=['string_span'])
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     for text in data:
       if not isinstance(text, str):
         raise ValueError(f'Expected text to be a string, got {type(text)} instead.')
@@ -80,7 +80,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
@@ -97,7 +97,7 @@ class TestEmbeddingSumSignal(VectorSignal):
     return field('float32')
 
   @override
-  def vector_compute(self, keys: Iterable[PathKey], vector_index: VectorDBIndex) -> Iterable[Item]:
+  def vector_compute(self, keys: Iterable[PathKey], vector_index: VectorDBIndex) -> Iterator[Item]:
     # The signal just sums the values of the embedding.
     all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
@@ -183,7 +183,7 @@ class NamedEntity(TextSignal):
     return field(fields=['string_span'])
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[List[Item]]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[List[Item]]]:
     for text in data:
       if not isinstance(text, str):
         yield None

--- a/lilac/data/dataset_config_test.py
+++ b/lilac/data/dataset_config_test.py
@@ -1,6 +1,6 @@
 """Tests for dataset.config()."""
 
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import numpy as np
 import pytest
@@ -27,8 +27,8 @@ class TestSignal(TextSignal):
     return field(fields={'len': 'int32'})
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
-    return [{'len': len(text_content)} for text_content in data]
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
+    return ({'len': len(text_content)} for text_content in data)
 
 
 class TestSignal2(TextSignal):
@@ -39,8 +39,8 @@ class TestSignal2(TextSignal):
     return field(fields={'len2': 'int32'})
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
-    return [{'len2': len(text_content)} for text_content in data]
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
+    return ({'len2': len(text_content)} for text_content in data)
 
 
 class TestEmbedding(TextEmbeddingSignal):
@@ -49,7 +49,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array([1.0]))]
@@ -61,7 +61,7 @@ class TestEmbedding2(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding2'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array([2.0]))]

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -848,7 +848,9 @@ class DatasetDuckDB(Dataset):
       elif isinstance(transform_fn, Signal):
         signal = transform_fn
         flat_input = cast(Iterator[Optional[RichData]], deep_flatten(input_values_0))
-        dense_out = sparse_to_dense_compute(flat_input, lambda x: signal.compute(x))
+        dense_out = sparse_to_dense_compute(
+          flat_input, lambda x: signal.compute(cast(Iterable[RichData], x))
+        )
       else:
         map_fn = transform_fn
         assert not isinstance(map_fn, Signal)

--- a/lilac/data/dataset_export_test.py
+++ b/lilac/data/dataset_export_test.py
@@ -4,7 +4,7 @@ import csv
 import json
 import pathlib
 from datetime import datetime
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import numpy as np
 import pandas as pd
@@ -26,8 +26,8 @@ class TestSignal(TextSignal):
     return field(fields={'len': 'int32', 'flen': 'float32'})
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
-    return [{'len': len(text_content), 'flen': float(len(text_content))} for text_content in data]
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
+    return ({'len': len(text_content), 'flen': float(len(text_content))} for text_content in data)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -2,7 +2,7 @@
 
 import inspect
 import re
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import pytest
 from typing_extensions import override
@@ -46,8 +46,8 @@ class TestFirstCharSignal(TextSignal):
     return field(fields={'len': 'int32', 'firstchar': 'string'})
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
-    return [{'len': len(text_content), 'firstchar': text_content[0]} for text_content in data]
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
+    return ({'len': len(text_content), 'firstchar': text_content[0]} for text_content in data)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/data/dataset_project_test.py
+++ b/lilac/data/dataset_project_test.py
@@ -1,7 +1,7 @@
 """Implementation-agnostic tests of the Dataset DB API working with projects."""
 
 from pathlib import Path
-from typing import ClassVar, Iterable, Optional, cast
+from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 import numpy as np
 import pytest
@@ -68,7 +68,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
@@ -82,7 +82,7 @@ class TestSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       self._call_count += 1
       yield len(text_content)

--- a/lilac/data/dataset_select_rows_filter_test.py
+++ b/lilac/data/dataset_select_rows_filter_test.py
@@ -1,6 +1,6 @@
 """Tests for dataset.select_rows(filters=[...])."""
 
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 from ..schema import ROWID, Field, Item, MapType, RichData, field, schema
 from ..signal import TextSignal
@@ -224,7 +224,7 @@ def test_filter_by_exists_on_enriched(make_test_data: TestDataMaker) -> None:
     def fields(self) -> Field:
       return field('int32')
 
-    def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+    def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
       for text_content in data:
         yield len(text_content)
 

--- a/lilac/data/dataset_select_rows_schema_test.py
+++ b/lilac/data/dataset_select_rows_schema_test.py
@@ -1,6 +1,6 @@
 """Tests for `db.select_rows_schema()`."""
 
-from typing import ClassVar, Iterable, Optional, cast
+from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 import numpy as np
 import pytest
@@ -79,7 +79,7 @@ class TestSplitter(TextSignal):
     return field(fields=['string_span'])
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     for text in data:
       if not isinstance(text, str):
         raise ValueError(f'Expected text to be a string, got {type(text)} instead.')
@@ -105,7 +105,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
@@ -124,7 +124,7 @@ class TestEmbeddingSumSignal(VectorSignal):
   @override
   def vector_compute(
     self, keys: Iterable[VectorKey], vector_index: VectorDBIndex
-  ) -> Iterable[Item]:
+  ) -> Iterator[Item]:
     # The signal just sums the values of the embedding.
     all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
@@ -153,7 +153,7 @@ class LengthSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield len(text_content)
 
@@ -164,7 +164,7 @@ class AddSpaceSignal(TextSignal):
   def fields(self) -> Field:
     return field('string')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield cast(str, text_content) + ' '
 

--- a/lilac/data/dataset_select_rows_search_test.py
+++ b/lilac/data/dataset_select_rows_search_test.py
@@ -1,6 +1,6 @@
 """Tests for dataset.select_rows(searches=[...])."""
 
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 import pytest
@@ -166,7 +166,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       embedding = np.array(STR_EMBEDDINGS[cast(str, example)])

--- a/lilac/data/dataset_select_rows_sort_test.py
+++ b/lilac/data/dataset_select_rows_sort_test.py
@@ -1,6 +1,6 @@
 """Tests for dataset.select_rows(sort_by=...)."""
 
-from typing import ClassVar, Iterable, Optional, Sequence, cast
+from typing import ClassVar, Iterable, Iterator, Optional, Sequence, cast
 
 import numpy as np
 import pytest
@@ -36,7 +36,7 @@ class TestSignal(TextSignal):
   def fields(self) -> Field:
     return field(fields={'len': 'int32', 'is_all_cap': 'boolean'})
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield {'len': len(text_content), 'is_all_cap': text_content.isupper()}
 
@@ -47,7 +47,7 @@ class TestPrimitiveSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield len(text_content) + 1
 
@@ -58,7 +58,7 @@ class NestedArraySignal(TextSignal):
   def fields(self) -> Field:
     return field(fields=[['int32']])
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield [[len(text_content) + 1], [len(text_content)]]
 
@@ -445,7 +445,7 @@ class TopKEmbedding(TextEmbeddingSignal):
 
   name: ClassVar[str] = 'topk_embedding'
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       example = cast(str, example)
@@ -471,7 +471,7 @@ class TopKSignal(VectorSignal):
   @override
   def vector_compute(
     self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
       embeddings = np.array([vector_span['vector'] for vector_span in vector_spans])

--- a/lilac/data/dataset_test.py
+++ b/lilac/data/dataset_test.py
@@ -1,6 +1,6 @@
 """Implementation-agnostic tests of the Dataset DB API."""
 
-from typing import ClassVar, Iterable, Optional, cast
+from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 import numpy as np
 import pytest
@@ -51,7 +51,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
@@ -65,7 +65,7 @@ class LengthSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       self._call_count += 1
       yield len(text_content)
@@ -79,8 +79,8 @@ class TestSignal(TextSignal):
     return field(fields={'len': 'int32', 'flen': 'float32'})
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
-    return [{'len': len(text_content), 'flen': float(len(text_content))} for text_content in data]
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
+    return ({'len': len(text_content), 'flen': float(len(text_content))} for text_content in data)
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -563,7 +563,7 @@ class SignalWithQuoteInIt(TextSignal):
     return field('boolean')
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for d in data:
       yield True
 
@@ -576,7 +576,7 @@ class SignalWithDoubleQuoteInIt(TextSignal):
     return field('boolean')
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for d in data:
       yield True
 

--- a/lilac/data/dataset_utils_test.py
+++ b/lilac/data/dataset_utils_test.py
@@ -37,7 +37,7 @@ def test_wrap_in_dicts_with_spec_of_double_repeated() -> None:
 def test_sparse_to_dense_compute() -> None:
   sparse_input = iter([None, 1, 7, None, None, 3, None, 5, None, None])
 
-  def func(xs: Iterable[int]) -> Iterable[int]:
+  def func(xs: Iterable[int]) -> Iterator[int]:
     for x in xs:
       yield x + 1
 
@@ -48,7 +48,7 @@ def test_sparse_to_dense_compute() -> None:
 def test_sparse_to_dense_compute_batching() -> None:
   sparse_input = iter([None, 1, 7, None, None, 3, None, 5, None, None])
 
-  def func(xs: Iterable[int]) -> Iterable[int]:
+  def func(xs: Iterable[int]) -> Iterator[int]:
     for batch in chunks(xs, 2):
       yield batch[0] + 1
       if len(batch) > 1:
@@ -61,7 +61,7 @@ def test_sparse_to_dense_compute_batching() -> None:
 def test_fully_dense() -> None:
   sparse_input = iter([1, 7, 3, 5])
 
-  def func(xs: Iterable[int]) -> Iterable[int]:
+  def func(xs: Iterable[int]) -> Iterator[int]:
     for x in xs:
       yield x + 1
 
@@ -72,7 +72,7 @@ def test_fully_dense() -> None:
 def test_sparse_to_dense_compute_fully_sparse() -> None:
   sparse_input = iter([None, None, None])
 
-  def func(xs: Iterable[int]) -> Iterable[int]:
+  def func(xs: Iterable[int]) -> Iterator[int]:
     for x in xs:
       yield x + 1
 
@@ -83,7 +83,7 @@ def test_sparse_to_dense_compute_fully_sparse() -> None:
 def test_sparse_to_dense_compute_empty() -> None:
   sparse_input: Iterator[int] = iter([])
 
-  def func(xs: Iterable[int]) -> Iterable[int]:
+  def func(xs: Iterable[int]) -> Iterator[int]:
     for x in xs:
       yield x + 1
 

--- a/lilac/embeddings/cohere.py
+++ b/lilac/embeddings/cohere.py
@@ -1,5 +1,5 @@
 """Cohere embeddings."""
-from typing import TYPE_CHECKING, ClassVar, Iterable, cast
+from typing import TYPE_CHECKING, ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 from typing_extensions import override
@@ -51,7 +51,7 @@ class Cohere(TextEmbeddingSignal):
       )
 
   @override
-  def compute(self, docs: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, docs: Iterable[RichData]) -> Iterator[Item]:
     """Compute embeddings for the given documents."""
 
     def embed_fn(texts: list[str]) -> list[np.ndarray]:

--- a/lilac/embeddings/gte.py
+++ b/lilac/embeddings/gte.py
@@ -1,5 +1,5 @@
 """Gegeral Text Embeddings (GTE) model. Open-source model, designed to run on device."""
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 from typing_extensions import override
 
@@ -28,7 +28,7 @@ class GTESmall(TextEmbeddingSignal):
   _model_name = GTE_SMALL
 
   @override
-  def compute(self, docs: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, docs: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     model = get_model(self._model_name)
     embed_fn = model.encode

--- a/lilac/embeddings/jina.py
+++ b/lilac/embeddings/jina.py
@@ -1,6 +1,6 @@
 """Jina embeddings. Open-source, designed to run on device, with 8K context."""
 import functools
-from typing import TYPE_CHECKING, ClassVar, Iterable, cast
+from typing import TYPE_CHECKING, ClassVar, Iterable, Iterator, cast
 
 from ..utils import chunks
 
@@ -52,7 +52,7 @@ class JinaV2Small(TextEmbeddingSignal):
   _size = 'small'
 
   @override
-  def compute(self, docs: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, docs: Iterable[RichData]) -> Iterator[Item]:
     model = _get_model(self._size)
     docs = cast(Iterable[str], docs)
 

--- a/lilac/embeddings/openai.py
+++ b/lilac/embeddings/openai.py
@@ -1,5 +1,5 @@
 """OpenAI embeddings."""
-from typing import Any, ClassVar, Iterable, cast
+from typing import Any, ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 from openai import OpenAI
@@ -64,7 +64,7 @@ class OpenAIEmbedding(TextEmbeddingSignal):
       )
 
   @override
-  def compute(self, docs: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, docs: Iterable[RichData]) -> Iterator[Item]:
     """Compute embeddings for the given documents."""
     client = OpenAI()
 

--- a/lilac/embeddings/palm.py
+++ b/lilac/embeddings/palm.py
@@ -1,5 +1,5 @@
 """PaLM embeddings."""
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random_exponential
@@ -68,7 +68,7 @@ class PaLM(TextEmbeddingSignal):
         )
 
   @override
-  def compute(self, docs: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, docs: Iterable[RichData]) -> Iterator[Item]:
     """Compute embeddings for the given documents."""
     if self._connector == 'api':
 

--- a/lilac/embeddings/sbert.py
+++ b/lilac/embeddings/sbert.py
@@ -1,5 +1,5 @@
 """Sentence-BERT embeddings. Open-source models, designed to run on device."""
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 from typing_extensions import override
 
@@ -21,7 +21,7 @@ class SBERT(TextEmbeddingSignal):
   display_name: ClassVar[str] = 'SBERT Embeddings'
 
   @override
-  def compute(self, docs: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, docs: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     model = get_model(MINI_LM_MODEL)
     embed_fn = model.encode

--- a/lilac/load_test.py
+++ b/lilac/load_test.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from typing import ClassVar, Iterable, Optional, cast
+from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 import numpy as np
 import pytest
@@ -64,7 +64,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
@@ -78,7 +78,7 @@ class TestSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       self._call_count += 1
       yield len(text_content)

--- a/lilac/server_concept_test.py
+++ b/lilac/server_concept_test.py
@@ -2,7 +2,7 @@
 import os
 import uuid
 from pathlib import Path
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 import pytest
@@ -52,7 +52,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]

--- a/lilac/server_dataset_signals_test.py
+++ b/lilac/server_dataset_signals_test.py
@@ -1,7 +1,7 @@
 """Test our public dataset/signals computation REST API."""
 
 import os
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
@@ -22,7 +22,7 @@ class LengthSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield len(text_content) if text_content is not None else None
 

--- a/lilac/server_dataset_test.py
+++ b/lilac/server_dataset_test.py
@@ -1,6 +1,6 @@
 """Test our public dataset REST API."""
 import os
-from typing import ClassVar, Iterable, Optional, Type
+from typing import ClassVar, Iterable, Iterator, Optional, Type
 
 import pytest
 from fastapi.testclient import TestClient
@@ -187,7 +187,7 @@ class LengthSignal(TextSignal):
   def fields(self) -> Field:
     return field('int32')
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text_content in data:
       yield len(text_content) if text_content is not None else None
 

--- a/lilac/server_signal_test.py
+++ b/lilac/server_signal_test.py
@@ -1,7 +1,7 @@
 """Test the public REST API for signals."""
 import os
 from pathlib import Path
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import pytest
 from fastapi.testclient import TestClient
@@ -44,8 +44,8 @@ class TestQueryAndLengthSignal(Signal):
     return field('int32')
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
-    return [f'{self.query}_{len(e)}' for e in data]
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
+    return (f'{self.query}_{len(e)}' for e in data)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -7,6 +7,7 @@ from typing import (
   Callable,
   ClassVar,
   Iterable,
+  Iterator,
   Optional,
   Sequence,
   Type,
@@ -78,7 +79,7 @@ class Signal(BaseModel):
     """
     return None
 
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     """Compute the signal for an iterable of documents or images.
 
     Args:
@@ -203,7 +204,7 @@ class VectorSignal(Signal, abc.ABC):
   @abc.abstractmethod
   def vector_compute(
     self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     """Compute the signal for an iterable of keys that point to documents or images.
 
     Args:

--- a/lilac/signal_test.py
+++ b/lilac/signal_test.py
@@ -1,5 +1,5 @@
 """Test signal base class."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import pytest
 from typing_extensions import override
@@ -31,9 +31,9 @@ class TestSignal(Signal):
     return field('float32')
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     del data
-    return []
+    yield from ()
 
 
 class TestTextEmbedding(TextEmbeddingSignal):
@@ -42,9 +42,9 @@ class TestTextEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     del data
-    return []
+    yield from ()
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/signals/cluster_dbscan.py
+++ b/lilac/signals/cluster_dbscan.py
@@ -1,5 +1,5 @@
 """Compute clusters for a dataset."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import numpy as np
 from pydantic import Field as PyField
@@ -46,7 +46,7 @@ class ClusterDBSCAN(VectorSignal):
     )
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     embed_fn = get_embed_fn(self.embedding, split=True)
     span_vectors = embed_fn(data)
     return self._cluster_span_vectors(span_vectors)
@@ -54,13 +54,13 @@ class ClusterDBSCAN(VectorSignal):
   @override
   def vector_compute(
     self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     span_vectors = vector_index.get(keys)
     return self._cluster_span_vectors(span_vectors)
 
   def _cluster_span_vectors(
     self, span_vectors: Iterable[list[SpanVector]]
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     all_spans: list[list[tuple[int, int]]] = []
     all_vectors: list[np.ndarray] = []
     with DebugTimer('DBSCAN: Reading from vector store'):

--- a/lilac/signals/cluster_dbscan_test.py
+++ b/lilac/signals/cluster_dbscan_test.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 import pytest
@@ -47,7 +47,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(EMBEDDINGS[cast(str, example)]))]

--- a/lilac/signals/cluster_hdbscan.py
+++ b/lilac/signals/cluster_hdbscan.py
@@ -1,5 +1,5 @@
 """Compute clusters for a dataset."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import numpy as np
 from pydantic import Field as PyField
@@ -50,7 +50,7 @@ class ClusterHDBScan(VectorSignal):
     )
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     embed_fn = get_embed_fn(self.embedding, split=True)
     span_vectors = embed_fn(data)
     return self._cluster_span_vectors(span_vectors)
@@ -58,13 +58,13 @@ class ClusterHDBScan(VectorSignal):
   @override
   def vector_compute(
     self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     span_vectors = vector_index.get(keys)
     return self._cluster_span_vectors(span_vectors)
 
   def _cluster_span_vectors(
     self, span_vectors: Iterable[list[SpanVector]]
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     # umap is expensive to import due to numba compilation; lazy import when needed.
     import umap
 

--- a/lilac/signals/cluster_hdbscan_test.py
+++ b/lilac/signals/cluster_hdbscan_test.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from typing import ClassVar, Iterable, cast
+from typing import ClassVar, Iterable, Iterator, cast
 
 import numpy as np
 import pytest
@@ -47,7 +47,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(EMBEDDINGS[cast(str, example)]))]

--- a/lilac/signals/concept_labels.py
+++ b/lilac/signals/concept_labels.py
@@ -1,5 +1,5 @@
 """A signal to compute span offsets of already labeled concept text."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 from typing_extensions import override
 
@@ -38,7 +38,7 @@ class ConceptLabelsSignal(TextSignal):
       self.version = concept.version
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     concept = self._concept_db.get(self.namespace, self.concept_name, self._user)
     if not concept:
       raise ValueError(f'Concept "{self.namespace}/{self.concept_name}" does not exist.')

--- a/lilac/signals/concept_scorer.py
+++ b/lilac/signals/concept_scorer.py
@@ -1,5 +1,5 @@
 """A signal to compute a score along a concept."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import numpy as np
 from typing_extensions import override
@@ -59,7 +59,7 @@ class ConceptSignal(VectorSignal):
 
   def _score_span_vectors(
     self, span_vectors: Iterable[Iterable[SpanVector]]
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     concept_model = self._get_concept_model()
 
     return flat_batched_compute(
@@ -82,7 +82,7 @@ class ConceptSignal(VectorSignal):
     self.version = concept_model.version
 
   @override
-  def compute(self, examples: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, examples: Iterable[RichData]) -> Iterator[Optional[Item]]:
     """Get the scores for the provided examples."""
     embed_fn = get_embed_fn(self.embedding, split=True)
     span_vectors = embed_fn(examples)
@@ -91,7 +91,7 @@ class ConceptSignal(VectorSignal):
   @override
   def vector_compute(
     self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     span_vectors = vector_index.get(keys)
     return self._score_span_vectors(span_vectors)
 

--- a/lilac/signals/concept_scorer_test.py
+++ b/lilac/signals/concept_scorer_test.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from typing import ClassVar, Generator, Iterable, Type, cast
+from typing import ClassVar, Generator, Iterable, Iterator, Type, cast
 
 import numpy as np
 import pytest
@@ -49,7 +49,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Embed the examples, use a hashmap to the vector for simplicity."""
     for example in data:
       if example not in EMBEDDING_MAP:

--- a/lilac/signals/filter_mask.py
+++ b/lilac/signals/filter_mask.py
@@ -1,5 +1,5 @@
 """Filters metadata based on an operatio. Internal use only for highlighting search results."""
-from typing import Any, ClassVar, Iterable, Optional, Union
+from typing import Any, ClassVar, Iterable, Iterator, Optional, Union
 
 from typing_extensions import override
 
@@ -23,7 +23,7 @@ class FilterMaskSignal(Signal):
     return field(dtype='boolean')
 
   @override
-  def compute(self, values: Iterable[Any]) -> Iterable[Optional[Item]]:
+  def compute(self, values: Iterable[Any]) -> Iterator[Optional[Item]]:
     for value in values:
       if self.op != 'equals':
         raise ValueError(f'Metadata search does not support "{self.op}" op yet.')

--- a/lilac/signals/lang_detection.py
+++ b/lilac/signals/lang_detection.py
@@ -1,6 +1,6 @@
 """Language detection of a document."""
 import re
-from typing import Any, ClassVar, Iterable, Optional, cast
+from typing import Any, ClassVar, Iterable, Iterator, Optional, cast
 
 from pydantic import Field as PydanticField
 from typing_extensions import override
@@ -57,7 +57,7 @@ class LangDetectionSignal(TextSignal):
     return field('string')
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     import langdetect
 
     data = cast(Iterable[str], data)

--- a/lilac/signals/near_dup.py
+++ b/lilac/signals/near_dup.py
@@ -1,5 +1,5 @@
 """Compute near duplicates for a dataset."""
-from typing import ClassVar, Iterable, Optional, cast
+from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 from pydantic import Field as PydanticField
 from typing_extensions import override
@@ -34,7 +34,7 @@ class NearDuplicateSignal(TextSignal):
     return field(fields={CLUSTER_KEY: field('uint32', categorical=True)})
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     cluster_ids = find_clusters(cast(Iterable[str], data), threshold=self.threshold)
     for cluster_id in cluster_ids:
       yield {CLUSTER_KEY: cluster_id}

--- a/lilac/signals/ner.py
+++ b/lilac/signals/ner.py
@@ -1,5 +1,5 @@
 """Compute named entity recognition with SpaCy."""
-from typing import TYPE_CHECKING, ClassVar, Iterable, Optional
+from typing import TYPE_CHECKING, ClassVar, Iterable, Iterator, Optional
 
 from pydantic import Field as PydanticField
 from typing_extensions import override
@@ -49,7 +49,7 @@ class SpacyNER(TextSignal):
     return field(fields=[field('string_span', fields={'label': 'string'})])
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     if not self._nlp:
       raise RuntimeError('SpaCy model is not initialized.')
 

--- a/lilac/signals/pii.py
+++ b/lilac/signals/pii.py
@@ -1,5 +1,5 @@
 """Compute text statistics for a document."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 from typing_extensions import override
 
@@ -39,7 +39,7 @@ class PIISignal(TextSignal):
     )
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     try:
       from .pii_presidio import find_pii
       from .pii_secrets import find_secrets

--- a/lilac/signals/semantic_similarity.py
+++ b/lilac/signals/semantic_similarity.py
@@ -1,6 +1,6 @@
 """A signal to compute semantic search for a document."""
 from functools import cached_property
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 import numpy as np
 from pydantic import Field as PydanticField
@@ -70,7 +70,7 @@ class SemanticSimilaritySignal(VectorSignal):
 
   def _score_span_vectors(
     self, span_vectors: Iterable[Iterable[SpanVector]]
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     return flat_batched_compute(
       span_vectors, f=self._compute_span_vector_batch, batch_size=_BATCH_SIZE
     )
@@ -82,14 +82,14 @@ class SemanticSimilaritySignal(VectorSignal):
     return [span(start, end, {'score': score}) for score, (start, end) in zip(scores, spans)]
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     span_vectors = self._document_embed_fn(data)
     return self._score_span_vectors(span_vectors)
 
   @override
   def vector_compute(
     self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterable[Optional[Item]]:
+  ) -> Iterator[Optional[Item]]:
     span_vectors = vector_index.get(keys)
     return self._score_span_vectors(span_vectors)
 

--- a/lilac/signals/semantic_similarity_test.py
+++ b/lilac/signals/semantic_similarity_test.py
@@ -1,6 +1,6 @@
 """Test the semantic search signal."""
 
-from typing import ClassVar, Iterable, Optional, cast
+from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 import numpy as np
 import pytest
@@ -60,7 +60,7 @@ class TestEmbedding(TextEmbeddingSignal):
   name: ClassVar[str] = 'test_embedding'
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Item]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Embed the examples, use a hashmap to the vector for simplicity."""
     for example in data:
       yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]

--- a/lilac/signals/substring_search.py
+++ b/lilac/signals/substring_search.py
@@ -1,5 +1,5 @@
 """A signal to search for a substring in a document."""
-from typing import ClassVar, Iterable, Optional
+from typing import ClassVar, Iterable, Iterator, Optional
 
 from typing_extensions import override
 
@@ -35,7 +35,7 @@ class SubstringSignal(Signal):
     return field(fields=['string_span'])
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     for text in data:
       if not isinstance(text, str):
         yield None

--- a/lilac/signals/text_statistics.py
+++ b/lilac/signals/text_statistics.py
@@ -1,5 +1,5 @@
 """Compute text statistics for a document."""
-from typing import TYPE_CHECKING, ClassVar, Iterable, Optional, cast
+from typing import TYPE_CHECKING, ClassVar, Iterable, Iterator, Optional, cast
 
 from typing_extensions import override
 
@@ -72,7 +72,7 @@ class TextStatisticsSignal(TextSignal):
     self._lang.max_length = SPACY_MAX_LENGTH
 
   @override
-  def compute(self, data: Iterable[RichData]) -> Iterable[Optional[Item]]:
+  def compute(self, data: Iterable[RichData]) -> Iterator[Optional[Item]]:
     try:
       import textacy.corpus
       from textacy import text_stats

--- a/lilac/sources/duckdb_utils.py
+++ b/lilac/sources/duckdb_utils.py
@@ -11,7 +11,6 @@ def duckdb_setup(con: duckdb.DuckDBPyConnection) -> None:
   """Setup DuckDB. This includes setting up performance optimizations."""
   con.execute(
     """
-    SET memory_limit='1GB';
     SET enable_http_metadata_cache=true;
     SET enable_object_cache=true;
   """

--- a/lilac/sources/duckdb_utils.py
+++ b/lilac/sources/duckdb_utils.py
@@ -11,6 +11,7 @@ def duckdb_setup(con: duckdb.DuckDBPyConnection) -> None:
   """Setup DuckDB. This includes setting up performance optimizations."""
   con.execute(
     """
+    SET memory_limit='1GB';
     SET enable_http_metadata_cache=true;
     SET enable_object_cache=true;
   """

--- a/lilac/tasks.py
+++ b/lilac/tasks.py
@@ -382,7 +382,6 @@ def show_progress_and_block(task_id: TaskId, description: Optional[str] = None) 
       if task_info.total_progress:
         pbar.update(task_info.total_progress - pbar.n)
       if task_info.status == TaskStatus.COMPLETED:
-        pbar.update(pbar.total - pbar.n)
         break
       if task_info.status == TaskStatus.ERROR:
         break

--- a/lilac/utils.py
+++ b/lilac/utils.py
@@ -14,7 +14,18 @@ from asyncio import AbstractEventLoop
 from concurrent.futures import Executor, ThreadPoolExecutor
 from datetime import timedelta
 from functools import partial, wraps
-from typing import IO, TYPE_CHECKING, Any, Awaitable, Callable, Iterable, Optional, TypeVar, Union
+from typing import (
+  IO,
+  TYPE_CHECKING,
+  Any,
+  Awaitable,
+  Callable,
+  Iterable,
+  Iterator,
+  Optional,
+  TypeVar,
+  Union,
+)
 
 import numpy as np
 import requests
@@ -187,7 +198,7 @@ def copy_files(copy_requests: Iterable[CopyRequest], input_gcs: bool, output_gcs
 Tchunk = TypeVar('Tchunk')
 
 
-def chunks(iterable: Iterable[Tchunk], size: int) -> Iterable[list[Tchunk]]:
+def chunks(iterable: Iterable[Tchunk], size: int) -> Iterator[list[Tchunk]]:
   """Split a list of items into equal-sized chunks. The last chunk might be smaller."""
   it = iter(iterable)
   chunk = list(itertools.islice(it, size))


### PR DESCRIPTION
Major change here is to strictly enforce that compute(), map(), and related functionality returns an Iterator, not an Iterable, since the former is more likely to be O(1) memory (misuses of tee aside...), whereas the latter is more likely to be O(N) memory.

Still haven't figured out the duckdb memory leak; seems like something in our mess of join views and nested views is causing duckdb to pull the entire parquet file into memory, even if the final query is only requesting row_id and one other column. The ORDER BY ROWID is likely contributing to the issue, but removing the ORDER BY does not fully fix the "pull it all into memory" issue.