### PR TITLE
Add color scales for semantic / concept search. Add openchat format.

### DIFF
--- a/lilac/data/dataset_format.py
+++ b/lilac/data/dataset_format.py
@@ -33,6 +33,21 @@ SHARE_GPT_FORMAT = DatasetFormat(
   ),
 )
 
+SHARE_GPT_ROLE_CONTENT_FORMAT = DatasetFormat(
+  name='sharegpt_role_content',
+  title_slots=[(('items', PATH_WILDCARD, 'content'), ('items', PATH_WILDCARD, 'role'))],
+  data_schema=schema(
+    {
+      'conversations': [
+        {
+          'role': 'string',
+          'content': 'string',
+        }
+      ]
+    }
+  ),
+)
+
 # Formats are taken from axlotl: https://github.com/OpenAccess-AI-Collective/axolotl#dataset
 DATASET_FORMATS: list[DatasetFormat] = [SHARE_GPT_FORMAT]
 

--- a/lilac/data/dataset_format.py
+++ b/lilac/data/dataset_format.py
@@ -56,11 +56,8 @@ DATASET_FORMATS: list[DatasetFormat] = [SHARE_GPT_FORMAT, OPEN_CHAT_FORMAT]
 
 def schema_is_compatible_with(dataset_schema: Schema, format_schema: Schema) -> bool:
   """Returns true if all fields of the format schema are in the dataset schema."""
-  print('checking', dataset_schema, format_schema, format_schema)
-
   for path, field in format_schema.all_fields:
     if not dataset_schema.has_field(path):
-      print('dataset doesnt have', path)
       return False
 
     field = dataset_schema.get_field(path)

--- a/lilac/data/dataset_format.py
+++ b/lilac/data/dataset_format.py
@@ -33,29 +33,34 @@ SHARE_GPT_FORMAT = DatasetFormat(
   ),
 )
 
-SHARE_GPT_ROLE_CONTENT_FORMAT = DatasetFormat(
-  name='sharegpt_role_content',
+# https://github.com/imoneoi/openchat
+OPEN_CHAT_FORMAT = DatasetFormat(
+  name='openchat_format',
   title_slots=[(('items', PATH_WILDCARD, 'content'), ('items', PATH_WILDCARD, 'role'))],
   data_schema=schema(
     {
-      'conversations': [
+      'items': [
         {
           'role': 'string',
           'content': 'string',
         }
-      ]
-    }
+      ],
+      'system': 'string',
+    },
   ),
 )
 
 # Formats are taken from axlotl: https://github.com/OpenAccess-AI-Collective/axolotl#dataset
-DATASET_FORMATS: list[DatasetFormat] = [SHARE_GPT_FORMAT]
+DATASET_FORMATS: list[DatasetFormat] = [SHARE_GPT_FORMAT, OPEN_CHAT_FORMAT]
 
 
 def schema_is_compatible_with(dataset_schema: Schema, format_schema: Schema) -> bool:
   """Returns true if all fields of the format schema are in the dataset schema."""
+  print('checking', dataset_schema, format_schema, format_schema)
+
   for path, field in format_schema.all_fields:
     if not dataset_schema.has_field(path):
+      print('dataset doesnt have', path)
       return False
 
     field = dataset_schema.get_field(path)

--- a/lilac/data/dataset_format_test.py
+++ b/lilac/data/dataset_format_test.py
@@ -1,7 +1,7 @@
 """Tests for the dataset_format module."""
 
 
-from .dataset_format import SHARE_GPT_FORMAT
+from .dataset_format import OPEN_CHAT_FORMAT, SHARE_GPT_FORMAT
 from .dataset_test_utils import TestDataMaker
 
 
@@ -36,6 +36,31 @@ def test_infer_sharegpt_extra(make_test_data: TestDataMaker) -> None:
   )
 
   assert dataset.manifest().dataset_format == SHARE_GPT_FORMAT
+
+
+def test_infer_open_chat(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(
+    [
+      {
+        'items': [
+          {'role': 'user', 'content': 'Hello', 'weight': 0.0},
+          {'role': 'assistant', 'content': 'Hi', 'weight': 1.0},
+          {'role': 'user', 'content': 'How are you today?', 'weight': 0.0},
+          {'role': 'assistant', 'content': "I'm fine.", 'weight': 1.0},
+        ],
+        'system': '',
+      },
+      {
+        'items': [
+          {'role': 'user', 'content': 'Who are you?', 'weight': 0.0},
+          {'role': 'assistant', 'content': "I'm OpenChat.", 'weight': 1.0},
+        ],
+        'system': 'You are a helpful assistant named OpenChat.',
+      },
+    ]
+  )
+
+  assert dataset.manifest().dataset_format == OPEN_CHAT_FORMAT
 
 
 def test_other_format(make_test_data: TestDataMaker) -> None:

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -95,7 +95,7 @@
   $: displayPath = getDisplayPath(pathForDisplay);
 
   $: valueNode = valueNodes[0];
-  $: value = L.value(valueNode);
+  $: value = L.value(valueNode) as string;
   $: settings = querySettings($datasetViewStore.namespace, $datasetViewStore.datasetName);
 
   // Get slots for the view. These are custom UI renderings that are a function of dataset formats.
@@ -206,7 +206,7 @@
 </script>
 
 <div class="flex w-full flex-row gap-x-4 p-2">
-  {#if isLeaf}
+  {#if isLeaf && value != null}
     <div class="relative mr-4 flex w-28 flex-row font-mono font-medium text-neutral-500 md:w-36">
       <div class="z-100 sticky top-16 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}
@@ -288,7 +288,7 @@
           {#if colCompareState == null}
             <ItemMediaTextContent
               hidden={markdown}
-              text={formatValue(value)}
+              text={value}
               {row}
               path={rootPath}
               {field}
@@ -322,7 +322,7 @@
     <!-- Repeated values will render <ItemMedia> again. -->
     <div class="my-2 flex w-full flex-col rounded border border-neutral-200">
       <div class="m-2 flex flex-col gap-y-2">
-        <div title={displayPath} class="mx-2 mt-2 truncate font-mono font-medium text-neutral-500">
+        <div title={displayPath} class="mx-2 my-2 truncate font-mono font-medium text-neutral-500">
           {displayPath}
         </div>
         {#each nextRootPaths as nextRootPath}

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -26,7 +26,6 @@
     type LilacValueNode,
     type Path
   } from '$lilac';
-  import {SkeletonText} from 'carbon-components-svelte';
   import {
     CatalogPublish,
     ChevronDown,
@@ -65,7 +64,7 @@
   }
 
   $: valueNodes = row != null ? getValueNodes(row, rootPath!) : [];
-  $: isLeaf = valueNodes.length <= 1;
+  $: isLeaf = pathIsMatching(mediaPath, rootPath);
 
   // Get the list of next root paths for children of a repeated node.
   $: nextRootPaths = valueNodes.map(v => {
@@ -206,7 +205,7 @@
 </script>
 
 <div class="flex w-full flex-row gap-x-4 p-2">
-  {#if isLeaf && value != null}
+  {#if isLeaf}
     <div class="relative mr-4 flex w-28 flex-row font-mono font-medium text-neutral-500 md:w-36">
       <div class="z-100 sticky top-16 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}
@@ -284,7 +283,7 @@
       {/if}
 
       <div class="grow pt-1">
-        {#if row != null}
+        {#if row != null && value != null}
           {#if colCompareState == null}
             <ItemMediaTextContent
               hidden={markdown}
@@ -314,7 +313,7 @@
             />
           {/if}
         {:else}
-          <SkeletonText lines={3} paragraph class="w-full" />
+          <span class="ml-12 italic">null</span>
         {/if}
       </div>
     </div>

--- a/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
@@ -448,7 +448,6 @@
         let bgScoreClass = '';
         if (renderSpan.isConceptSearch || renderSpan.isSemanticSearch) {
           const score = renderSpan.value as number;
-          console.log(score);
           if (score < 0.55) {
             bgScoreClass = 'bg-blue-50';
           } else if (score < 0.6) {

--- a/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
@@ -627,7 +627,7 @@
     class="editor-container ml-6 h-64"
     class:hidden
     bind:this={editorContainer}
-    class:invisible={!editorReady}
+    class:invisible={!editorReady || text == null}
   />
 </div>
 

--- a/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
@@ -444,6 +444,26 @@
           endPosition.column
         );
 
+        // Map the score to a class.
+        let bgScoreClass = '';
+        if (renderSpan.isConceptSearch || renderSpan.isSemanticSearch) {
+          const score = renderSpan.value as number;
+          console.log(score);
+          if (score < 0.55) {
+            bgScoreClass = 'bg-blue-50';
+          } else if (score < 0.6) {
+            bgScoreClass = 'bg-blue-100';
+          } else if (score < 0.7) {
+            bgScoreClass = 'bg-blue-200';
+          } else if (score < 0.8) {
+            bgScoreClass = 'bg-blue-300';
+          } else if (score < 0.9) {
+            bgScoreClass = 'bg-blue-400';
+          } else {
+            bgScoreClass = 'bg-blue-500';
+          }
+        }
+
         if (renderSpan.isKeywordSearch) {
           spanDecorations.push({
             range,
@@ -464,7 +484,7 @@
           spanDecorations.push({
             range,
             options: {
-              className: 'concept-search-bg',
+              className: 'concept-search-bg ' + bgScoreClass,
               inlineClassName: 'concept-search-text',
               hoverMessage: hoverCard,
               glyphMarginClassName: 'concept-search-bg',
@@ -480,7 +500,7 @@
           spanDecorations.push({
             range,
             options: {
-              className: 'semantic-search-bg',
+              className: 'semantic-search-bg ' + bgScoreClass,
               inlineClassName: 'semantic-search-text',
               hoverMessage: hoverCard,
               glyphMarginClassName: 'semantic-search-bg',
@@ -627,7 +647,7 @@
     class="editor-container ml-6 h-64"
     class:hidden
     bind:this={editorContainer}
-    class:invisible={!editorReady || text == null}
+    class:invisible={!editorReady}
   />
 </div>
 
@@ -645,7 +665,7 @@
 
   /** Concept and semantic search */
   :global(.concept-search-bg, .semantic-search-bg) {
-    @apply bg-blue-400 bg-opacity-20;
+    @apply bg-opacity-20;
   }
   :global(.concept-search-text, .semantic-search-text) {
     @apply text-black;

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -131,7 +131,7 @@
 
 <div class="relative flex w-full flex-col rounded md:flex-col">
   <!-- Header -->
-  <div style="z-index: 500;" class="sticky top-0 flex w-full flex-row justify-between">
+  <div style="z-index: 500;" class="sticky top-0 flex w-full flex-row justify-between bg-white">
     <div
       class="mx-4 flex w-full rounded-t border border-neutral-300 bg-violet-200 bg-opacity-70 py-2"
     >

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -131,7 +131,7 @@
 
 <div class="relative flex w-full flex-col rounded md:flex-col">
   <!-- Header -->
-  <div style="z-index: 500;" class="sticky top-0 flex w-full flex-row justify-between bg-white">
+  <div class="sticky top-0 z-10 flex w-full flex-row justify-between bg-white">
     <div
       class="mx-4 flex w-full rounded-t border border-neutral-300 bg-violet-200 bg-opacity-70 py-2"
     >
@@ -217,7 +217,7 @@
       </div>
     </div>
   </div>
-  <div class="px-4">
+  <div class="flex w-full flex-row px-4">
     <div
       class={`flex flex-col ${!$datasetViewStore.showMetadataPanel ? 'grow ' : 'w-2/3'}`}
       bind:clientHeight={mediaHeight}
@@ -225,11 +225,7 @@
       <div class="rounded-b border-b border-l border-r border-neutral-300">
         {#if mediaFields.length > 0}
           {#each mediaFields as mediaField, i (serializePath(mediaField.path))}
-            <div
-              class:border-b={i < mediaFields.length - 1}
-              class:pb-2={i < mediaFields.length - 1}
-              class="flex h-full w-full flex-col border-neutral-200"
-            >
+            <div class="flex w-full flex-col">
               <ItemMedia mediaPath={mediaField.path} {row} field={mediaField} {highlightedFields} />
             </div>
           {/each}

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -224,7 +224,7 @@
     >
       <div class="rounded-b border-b border-l border-r border-neutral-300">
         {#if mediaFields.length > 0}
-          {#each mediaFields as mediaField, i (serializePath(mediaField.path))}
+          {#each mediaFields as mediaField (serializePath(mediaField.path))}
             <div class="flex w-full flex-col">
               <ItemMedia mediaPath={mediaField.path} {row} field={mediaField} {highlightedFields} />
             </div>

--- a/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
+++ b/web/blueprint/src/lib/components/datasetView/spanHighlight.ts
@@ -6,6 +6,7 @@ import {
   serializePath,
   valueAtPath,
   type DataType,
+  type DataTypeCasted,
   type LilacValueNode,
   type LilacValueNodeCasted,
   type Path,
@@ -58,6 +59,8 @@ export interface MonacoRenderSpan {
   isSemanticSearch: boolean;
   isLeafSpan: boolean;
   hasNonNumericMetadata: boolean;
+
+  value: DataTypeCasted;
 
   // The text for this render span.
   text: string;
@@ -125,7 +128,8 @@ export function getMonacoRenderSpans(
           hasNonNumericMetadata,
           namedValue,
           path,
-          text
+          text,
+          value
         });
       }
     }


### PR DESCRIPTION
Some UI fixes come from breakages I made in the last PR.

- Concepts and semantic search now get tailwind classes based on their score (the only way to control it).
- Fix issue with borders not showing up in the right places
- Fix issue with metadata panel not opening to the right.
- Fix issue with multi-labeling showing up behind the header

https://lilacai-nikhil-staging.hf.space/datasets#local/one_openchat

Now the OpenChat format is supported for showing the special titles.