### PR TITLE
`dataset.map` can now nest_under any repeated

### DIFF
--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -2652,7 +2652,6 @@ class DatasetDuckDB(Dataset):
       if not manifest.data_schema.has_field(nest_under):
         raise ValueError(f'The `nest_under` column {nest_under} does not exist.')
 
-      # Make sure the input path has the same cardinality as the nest_under path.
       assert paths_have_same_cardinality(
         input_path or tuple(), nest_under
       ), f'`input_path` {input_path} and `nest_under` {nest_under} have different cardinalities.'

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -151,6 +151,7 @@ from .dataset_utils import (
   create_signal_schema,
   flatten_keys,
   get_parquet_filename,
+  paths_have_same_cardinality,
   schema_contains_path,
   shard_id_to_range,
   sparse_to_dense_compute,
@@ -2648,13 +2649,13 @@ class DatasetDuckDB(Dataset):
       if output_column is None:
         raise ValueError('When using `nest_under`, you must specify an output column name.')
 
-      # Make sure nest_under does not contain any repeated values.
-      for path_part in nest_under:
-        if path_part == PATH_WILDCARD:
-          raise ValueError('Nesting map outputs under a repeated field is not yet supported.')
-
       if not manifest.data_schema.has_field(nest_under):
         raise ValueError(f'The `nest_under` column {nest_under} does not exist.')
+
+      # Make sure the input path has the same cardinality as the nest_under path.
+      assert paths_have_same_cardinality(
+        input_path or tuple(), nest_under
+      ), f'`input_path` {input_path} and `nest_under` {nest_under} have different cardinalities.'
 
     # If the user didn't provide an output_column, we make a temporary one so that we can store the
     # output JSON objects in the cache, represented in the right hierarchy.
@@ -2686,7 +2687,6 @@ class DatasetDuckDB(Dataset):
           )
           if os.path.exists(map_manifest_filepath):
             delete_file(map_manifest_filepath)
-
         else:
           raise ValueError(
             f'Cannot map to path "{output_column}" which already exists in the dataset. '
@@ -3186,6 +3186,8 @@ def _merge_cells(dest_cell: Item, source_cell: Item) -> Item:
       for key, value in source_cell.items():
         res[key] = value if key not in dest_cell else _merge_cells(dest_cell[key], value)
       return res
+    elif source_cell is None:
+      return dest_cell
     else:
       return {VALUE_KEY: source_cell, **dest_cell}
   elif isinstance(dest_cell, list):
@@ -3195,6 +3197,8 @@ def _merge_cells(dest_cell: Item, source_cell: Item) -> Item:
       _merge_cells(dest_subcell, source_subcell)
       for dest_subcell, source_subcell in zip(dest_cell, source_cell)
     ]
+  elif dest_cell is None:
+    return source_cell
   else:
     # The destination is a primitive.
     if isinstance(source_cell, list):

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -977,6 +977,65 @@ def test_map_select_subfields_of_repeated_dicts(make_test_data: TestDataMaker) -
   ]
 
 
+def test_map_nests_under_repeated(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(
+    [
+      {'people': [{'name': 'A'}, {'name': 'BB'}, {'name': 'C'}]},
+      {'people': [{'name': 'D'}, {'name': 'EEE'}]},
+    ]
+  )
+
+  dataset.map(lambda x: len(x), 'people.*.name', output_column='len_name', nest_under='people.*')
+
+  rows = list(dataset.select_rows(combine_columns=True))
+  assert rows == [
+    {
+      'people': [
+        {'name': 'A', 'len_name': 1},
+        {'name': 'BB', 'len_name': 2},
+        {'name': 'C', 'len_name': 1},
+      ]
+    },
+    {'people': [{'name': 'D', 'len_name': 1}, {'name': 'EEE', 'len_name': 3}]},
+  ]
+
+  rows = list(dataset.select_rows())
+  assert rows == [
+    {'people.*.name': ['A', 'BB', 'C'], 'people.*.len_name': [1, 2, 1]},
+    {'people.*.name': ['D', 'EEE'], 'people.*.len_name': [1, 3]},
+  ]
+
+
+def test_map_nests_under_field_of_repeated(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(
+    [
+      {'people': [{'name': 'A', 'info': {'extra': 1}}, {'name': 'BB'}, {'name': 'C'}]},
+      {'people': [{'name': 'D'}, {'name': 'EEE'}]},
+    ]
+  )
+
+  dataset.map(
+    lambda x: len(x), 'people.*.name', output_column='len_name', nest_under='people.*.info'
+  )
+
+  rows = list(dataset.select_rows(combine_columns=True))
+  assert rows == [
+    {
+      'people': [
+        {'name': 'A', 'info': {'extra': 1, 'len_name': 1}},
+        {'name': 'BB', 'info': {'len_name': 2}},
+        {'name': 'C', 'info': {'len_name': 1}},
+      ]
+    },
+    {
+      'people': [
+        {'name': 'D', 'info': {'len_name': 1}},
+        {'name': 'EEE', 'info': {'len_name': 3}},
+      ]
+    },
+  ]
+
+
 def test_signal_on_map_output(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data([{'text': 'abcd'}, {'text': 'efghi'}])
 
@@ -1239,25 +1298,22 @@ def test_map_ergonomics_invalid_args(make_test_data: TestDataMaker) -> None:
     dataset.map(_map_toomany_args, output_column='_map_toomany_args')
 
 
-def test_map_nest_under_validation(make_test_data: TestDataMaker) -> None:
+def test_map_nest_under_another_cardinality_fails(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data(
     [{'text': 'abcd', 'parent': ['a', 'b']}, {'text': 'efghi', 'parent': ['c', 'd']}]
   )
 
   def _map_fn(item: Item) -> Item:
-    return item['text'] + ' ' + item['text']
+    res = item['text'] + ' ' + item['text']
+    return res
 
   with pytest.raises(
-    ValueError, match='Nesting map outputs under a repeated field is not yet supported'
+    AssertionError,
+    match=re.escape(
+      "`input_path` None and `nest_under` ('parent', '*') have different cardinalities"
+    ),
   ):
-    dataset.map(
-      _map_fn, output_column='output', nest_under=('parent', PATH_WILDCARD), combine_columns=False
-    )
-
-  with pytest.raises(
-    ValueError, match=re.escape("The `nest_under` column ('fake',) does not exist.")
-  ):
-    dataset.map(_map_fn, output_column='output', nest_under=('fake',), combine_columns=False)
+    dataset.map(_map_fn, output_column='output', nest_under='parent.*', combine_columns=False)
 
 
 def test_map_with_span_resolving(make_test_data: TestDataMaker) -> None:

--- a/lilac/data/dataset_test_utils.py
+++ b/lilac/data/dataset_test_utils.py
@@ -88,7 +88,7 @@ def _infer_field(item: Item, diallow_pedals: bool = False) -> Field:
       del fields[SPAN_KEY]
     if not fields:
       # The object is an empty dict. We need a dummy child to represent this with parquet.
-      return Field(fields={'__empty__': Field(dtype=NULL)})
+      return Field(dtype=NULL)
     return Field(fields=fields, dtype=dtype)
   elif is_primitive(item):
     return Field(dtype=_infer_dtype(item))


### PR DESCRIPTION
You can call:

```python
before_row == {
  people: [
    {name: 'A', address: '...'},
    {'name': 'B', address: '...'}
  ]
}

dataset.map(geo_locate, input_path='people.*.address', nest_under='people.*', output_column='geo')

after_row == {
  people: [
    {name: 'A', address: '...', geo: '...'},
    {'name': 'B', address: '...', geo: '...'}
  ]
}
```