### PR TITLE
Add signal.map customization

### DIFF
--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1027,11 +1027,13 @@ class DatasetDuckDB(Dataset):
     _consume_iterator(
       progress_bar(
         self._dispatch_workers(
-          joblib.Parallel(n_jobs=1, backend='threading', return_as='generator'),
+          joblib.Parallel(
+            n_jobs=signal.map_parallelism, backend=signal.map_strategy, return_as='generator'
+          ),
           signal,
           output_path,
           jsonl_cache_filepath,
-          batch_size=None,
+          batch_size=signal.map_batch_size,
           select_path=input_path,
           overwrite=overwrite,
           query_options=query_params,
@@ -1125,11 +1127,13 @@ class DatasetDuckDB(Dataset):
 
     output_items = progress_bar(
       self._dispatch_workers(
-        joblib.Parallel(n_jobs=1, backend='threading', return_as='generator'),
+        joblib.Parallel(
+          n_jobs=signal.map_parallelism, backend=signal.map_strategy, return_as='generator'
+        ),
         signal,
         output_path,
         jsonl_cache_filepath,
-        batch_size=None,
+        batch_size=signal.map_batch_size,
         select_path=input_path,
         overwrite=overwrite,
         query_options=query_params,

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1028,7 +1028,7 @@ class DatasetDuckDB(Dataset):
       progress_bar(
         self._dispatch_workers(
           joblib.Parallel(
-            n_jobs=signal.map_parallelism, backend=signal.map_strategy, return_as='generator'
+            n_jobs=signal.map_parallelism, prefer=signal.map_strategy, return_as='generator'
           ),
           signal,
           output_path,
@@ -1128,7 +1128,7 @@ class DatasetDuckDB(Dataset):
     output_items = progress_bar(
       self._dispatch_workers(
         joblib.Parallel(
-          n_jobs=signal.map_parallelism, backend=signal.map_strategy, return_as='generator'
+          n_jobs=signal.map_parallelism, prefer=signal.map_strategy, return_as='generator'
         ),
         signal,
         output_path,

--- a/lilac/data/dataset_map_test.py
+++ b/lilac/data/dataset_map_test.py
@@ -4,6 +4,7 @@ import inspect
 import re
 import time
 from typing import ClassVar, Iterable, Iterator, Optional
+from unittest.mock import ANY
 
 import pytest
 from typing_extensions import override
@@ -157,11 +158,7 @@ def test_map_signal(
       {
         'text': field(
           'string',
-          fields={
-            'test_signal': field(
-              fields={'len': 'int32', 'firstchar': 'string'}, signal={'signal_name': 'test_signal'}
-            )
-          },
+          fields={'test_signal': field(fields={'len': 'int32', 'firstchar': 'string'}, signal=ANY)},
         ),
         'output_text': field(
           fields={'result': 'string'},
@@ -791,11 +788,7 @@ def test_map_over_enriched_item(make_test_data: TestDataMaker) -> None:
       {
         'text': field(
           'string',
-          fields={
-            'test_signal': field(
-              fields={'len': 'int32', 'firstchar': 'string'}, signal={'signal_name': 'test_signal'}
-            )
-          },
+          fields={'test_signal': field(fields={'len': 'int32', 'firstchar': 'string'}, signal=ANY)},
         ),
         'output_text': field(
           fields={'result': 'string'},
@@ -1060,11 +1053,7 @@ def test_signal_on_map_output(make_test_data: TestDataMaker) -> None:
         'text': 'string',
         'double': field(
           'string',
-          fields={
-            'test_signal': field(
-              fields={'len': 'int32', 'firstchar': 'string'}, signal={'signal_name': 'test_signal'}
-            )
-          },
+          fields={'test_signal': field(fields={'len': 'int32', 'firstchar': 'string'}, signal=ANY)},
           map=MapInfo(
             fn_name='_map_fn', fn_source=inspect.getsource(_map_fn), date_created=TEST_TIME
           ),

--- a/lilac/load_test.py
+++ b/lilac/load_test.py
@@ -2,6 +2,7 @@
 
 import os
 import pathlib
+import re
 from typing import ClassVar, Iterable, Iterator, Optional, cast
 
 import numpy as np
@@ -303,9 +304,7 @@ def test_load_twice_no_overwrite(tmp_path: pathlib.Path, capsys: pytest.CaptureF
 
   second_manifest = get_dataset('namespace', 'test').manifest()
   assert first_manifest == second_manifest
-  assert (
-    'Signal  TestSignal({"signal_name":"test_signal"}) already exists' in capsys.readouterr().out
-  )
+  assert re.search('Signal  TestSignal(.*) already exists', capsys.readouterr().out)
 
 
 def test_load_twice_overwrite(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture) -> None:

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -31,6 +31,7 @@ from .schema import (
   SignalInputType,
   field,
 )
+from .tasks import TaskExecutionType
 
 
 def _signal_schema_extra(schema: dict[str, Any], signal: Type['Signal']) -> None:
@@ -70,6 +71,11 @@ class Signal(BaseModel):
 
   # The output type is the logical type, and treated in a special way in the UI.
   output_type: OutputType = None
+
+  # See lilac.data.dataset.Dataset.map for definitions and semantics.
+  map_batch_size: int = -1
+  map_parallelism: int = 1
+  map_strategy: TaskExecutionType = 'threads'
 
   @model_serializer(mode='wrap', when_used='always')
   def serialize_model(self, serializer: Callable[..., dict[str, Any]]) -> dict[str, Any]:

--- a/lilac/signal_test.py
+++ b/lilac/signal_test.py
@@ -64,7 +64,13 @@ def test_signal_serialization() -> None:
   signal = TestSignal(query='test')
 
   # The class variables should not be included.
-  assert signal.model_dump(exclude_none=True) == {'signal_name': 'test_signal', 'query': 'test'}
+  assert signal.model_dump(exclude_none=True) == {
+    'signal_name': 'test_signal',
+    'query': 'test',
+    'map_batch_size': -1,
+    'map_parallelism': 1,
+    'map_strategy': 'threads',
+  }
 
 
 def test_get_signal_cls() -> None:


### PR DESCRIPTION
Some design ideas:

Constraint map_fn to just take a plain Callable, instead of Union[Callable, Signal], which means we would remove the Embedding/VectorSignal/Signal branches inside dataset._dispatch_workers. I'm also hoping to remove the other ad-hoc  batch/map/parallel implementation that lives inside embedding.compute_split_embeddings, and get everything on top of the same map API.

Difficulties... Signal.compute becomes polymorphic - it could have a signature of Item -> Item, List[Item] -> List[Item], or Iterator[Item] -> Iterator[Item] depending on whether Signal.map_batch_size is -1, int, or None.

I also have no idea why VectorSignal.vector_compute looks so complicated...

The above sequence would be a breaking change for users, but I suspect it will remove a lot of complexity from their code so it'd be welcome.