### PR TITLE
remove VectorCompute path in dispatch_workers

### DIFF
--- a/lilac/data/dataset_compute_signal_chain_test.py
+++ b/lilac/data/dataset_compute_signal_chain_test.py
@@ -8,14 +8,13 @@ import pytest
 from pytest_mock import MockerFixture
 from typing_extensions import override
 
-from ..embeddings.vector_store import VectorDBIndex
 from ..schema import (
   EMBEDDING_KEY,
   Field,
   Item,
-  PathKey,
   RichData,
   SignalInputType,
+  SpanVector,
   field,
   lilac_embedding,
   schema,
@@ -97,9 +96,10 @@ class TestEmbeddingSumSignal(VectorSignal):
     return field('float32')
 
   @override
-  def vector_compute(self, keys: Iterable[PathKey], vector_index: VectorDBIndex) -> Iterator[Item]:
+  def vector_compute(
+    self, all_vector_spans: Iterable[list[SpanVector]]
+  ) -> Iterator[Optional[Item]]:
     # The signal just sums the values of the embedding.
-    all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
       yield float(vector_spans[0]['vector'].sum())
 

--- a/lilac/data/dataset_select_rows_schema_test.py
+++ b/lilac/data/dataset_select_rows_schema_test.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from typing_extensions import override
 
-from ..embeddings.vector_store import VectorDBIndex
 from ..schema import (
   EMBEDDING_KEY,
   PATH_WILDCARD,
@@ -14,7 +13,7 @@ from ..schema import (
   Item,
   RichData,
   SignalInputType,
-  VectorKey,
+  SpanVector,
   field,
   lilac_embedding,
   schema,
@@ -123,10 +122,9 @@ class TestEmbeddingSumSignal(VectorSignal):
 
   @override
   def vector_compute(
-    self, keys: Iterable[VectorKey], vector_index: VectorDBIndex
-  ) -> Iterator[Item]:
+    self, all_vector_spans: Iterable[list[SpanVector]]
+  ) -> Iterator[Optional[Item]]:
     # The signal just sums the values of the embedding.
-    all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
       yield vector_spans[0]['vector'].sum()
 

--- a/lilac/data/dataset_select_rows_sort_test.py
+++ b/lilac/data/dataset_select_rows_sort_test.py
@@ -11,9 +11,9 @@ from ..schema import (
   ROWID,
   Field,
   Item,
-  PathKey,
   RichData,
   SignalInputType,
+  SpanVector,
   VectorKey,
   field,
   lilac_embedding,
@@ -470,9 +470,8 @@ class TopKSignal(VectorSignal):
 
   @override
   def vector_compute(
-    self, keys: Iterable[PathKey], vector_index: VectorDBIndex
+    self, all_vector_spans: Iterable[list[SpanVector]]
   ) -> Iterator[Optional[Item]]:
-    all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
       embeddings = np.array([vector_span['vector'] for vector_span in vector_spans])
       scores = embeddings.dot(self._query).reshape(-1)

--- a/lilac/data/dataset_select_rows_udf_test.py
+++ b/lilac/data/dataset_select_rows_udf_test.py
@@ -9,7 +9,6 @@ from typing_extensions import override
 
 from ..concepts.concept import ExampleIn
 from ..concepts.db_concept import ConceptUpdate, DiskConceptDB
-from ..embeddings.vector_store import VectorDBIndex
 from ..schema import (
   ROWID,
   SPAN_KEY,
@@ -17,7 +16,7 @@ from ..schema import (
   Item,
   RichData,
   SignalInputType,
-  VectorKey,
+  SpanVector,
   field,
   lilac_embedding,
   span,
@@ -96,10 +95,9 @@ class TestEmbeddingSumSignal(VectorSignal):
 
   @override
   def vector_compute(
-    self, keys: Iterable[VectorKey], vector_index: VectorDBIndex
-  ) -> Iterator[Item]:
+    self, all_vector_spans: Iterable[list[SpanVector]]
+  ) -> Iterator[Optional[Item]]:
     # The signal just sums the values of the embedding.
-    all_vector_spans = vector_index.get(keys)
     for vector_spans in all_vector_spans:
       yield vector_spans[0]['vector'].sum()
 

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -28,6 +28,7 @@ from .schema import (
   Item,
   PathKey,
   SignalInputType,
+  SpanVector,
   field,
 )
 from .tasks import TaskExecutionType
@@ -234,14 +235,11 @@ class VectorSignal(Signal, abc.ABC):
   model_config = ConfigDict(json_schema_extra=_vector_signal_schema_extra)
 
   @abc.abstractmethod
-  def vector_compute(
-    self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterator[Optional[Item]]:
+  def vector_compute(self, vector_spans: Iterable[list[SpanVector]]) -> Iterator[Optional[Item]]:
     """Compute the signal for an iterable of keys that point to documents or images.
 
     Args:
-      keys: An iterable of value ids (at row-level or lower) to lookup precomputed embeddings.
-      vector_index: The vector index to lookup pre-computed embeddings.
+      vector_spans: Precomputed embeddings over spans of a document.
 
     Returns:
       An iterable of items. Sparse signals should return "None" for skipped inputs.

--- a/lilac/signals/cluster_dbscan.py
+++ b/lilac/signals/cluster_dbscan.py
@@ -7,8 +7,7 @@ from sklearn.cluster import DBSCAN
 from typing_extensions import override
 
 from ..embeddings.embedding import get_embed_fn
-from ..embeddings.vector_store import VectorDBIndex
-from ..schema import Field, Item, PathKey, RichData, SignalInputType, SpanVector, field, span
+from ..schema import Field, Item, RichData, SignalInputType, SpanVector, field, span
 from ..signal import OutputType, VectorSignal
 from ..utils import DebugTimer
 
@@ -53,10 +52,7 @@ class ClusterDBSCAN(VectorSignal):
     return self._cluster_span_vectors(span_vectors)
 
   @override
-  def vector_compute(
-    self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterator[Optional[Item]]:
-    span_vectors = vector_index.get(keys)
+  def vector_compute(self, span_vectors: Iterable[list[SpanVector]]) -> Iterator[Optional[Item]]:
     return self._cluster_span_vectors(span_vectors)
 
   def _cluster_span_vectors(

--- a/lilac/signals/cluster_hdbscan.py
+++ b/lilac/signals/cluster_hdbscan.py
@@ -6,8 +6,7 @@ from pydantic import Field as PyField
 from typing_extensions import override
 
 from ..embeddings.embedding import get_embed_fn
-from ..embeddings.vector_store import VectorDBIndex
-from ..schema import Field, Item, PathKey, RichData, SignalInputType, SpanVector, field, span
+from ..schema import Field, Item, RichData, SignalInputType, SpanVector, field, span
 from ..signal import OutputType, VectorSignal
 from ..utils import DebugTimer
 
@@ -64,10 +63,7 @@ class ClusterHDBScan(VectorSignal):
     )
 
   @override
-  def vector_compute(
-    self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterator[Optional[Item]]:
-    span_vectors = vector_index.get(keys)
+  def vector_compute(self, span_vectors: Iterable[list[SpanVector]]) -> Iterator[Optional[Item]]:
     return cluster_span_vectors(
       span_vectors, self.min_cluster_size, self.umap_n_components, self.umap_random_state
     )

--- a/lilac/signals/concept_scorer.py
+++ b/lilac/signals/concept_scorer.py
@@ -90,10 +90,7 @@ class ConceptSignal(VectorSignal):
     return self._score_span_vectors(span_vectors)
 
   @override
-  def vector_compute(
-    self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterator[Optional[Item]]:
-    span_vectors = vector_index.get(keys)
+  def vector_compute(self, span_vectors: Iterable[list[SpanVector]]) -> Iterator[Optional[Item]]:
     return self._score_span_vectors(span_vectors)
 
   @override
@@ -104,7 +101,7 @@ class ConceptSignal(VectorSignal):
     query: np.ndarray = concept_model.coef(self.draft).astype(np.float32)
     query /= np.linalg.norm(query)
     topk_keys = [key for key, _ in vector_index.topk(query, topk, rowids)]
-    return list(zip(topk_keys, self.vector_compute(topk_keys, vector_index)))
+    return list(zip(topk_keys, self.vector_compute(vector_index.get(topk_keys))))
 
   @override
   def key(self, is_computed_signal: Optional[bool] = False) -> str:

--- a/lilac/signals/concept_scorer_test.py
+++ b/lilac/signals/concept_scorer_test.py
@@ -160,7 +160,7 @@ def test_concept_model_vector_score(
     },
   )
 
-  scores = cast(list[Item], list(signal.vector_compute([('1',), ('2',), ('3',)], vector_index)))
+  scores = cast(list[Item], list(signal.vector_compute(vector_index.get([('1',), ('2',), ('3',)]))))
   assert scores[0][0]['score'] > 0.5  # '1' is in the concept.
   assert scores[1][0]['score'] < 0.5  # '2' is not in the concept.
   assert (
@@ -251,7 +251,7 @@ def test_concept_model_draft(
     vector_store, {('1',): [[1.0, 0.0, 0.0]], ('2',): [[0.9, 0.1, 0.0]], ('3',): [[0.1, 0.9, 0.0]]}
   )
 
-  scores = cast(list[Item], list(signal.vector_compute([('1',), ('2',), ('3',)], vector_index)))
+  scores = cast(list[Item], list(signal.vector_compute(vector_index.get([('1',), ('2',), ('3',)]))))
   assert scores[0][0]['score'] > 0.5
   assert scores[1][0]['score'] > 0.5
   assert scores[2][0]['score'] < 0.5
@@ -260,7 +260,7 @@ def test_concept_model_draft(
   vector_index = make_vector_index(
     vector_store, {('1',): [[1.0, 0.0, 0.0]], ('2',): [[0.9, 0.1, 0.0]], ('3',): [[0.1, 0.2, 0.3]]}
   )
-  draft_scores = draft_signal.vector_compute([('1',), ('2',), ('3',)], vector_index)
+  draft_scores = draft_signal.vector_compute(vector_index.get([('1',), ('2',), ('3',)]))
   assert draft_scores != scores
 
 

--- a/lilac/signals/semantic_similarity.py
+++ b/lilac/signals/semantic_similarity.py
@@ -87,10 +87,7 @@ class SemanticSimilaritySignal(VectorSignal):
     return self._score_span_vectors(span_vectors)
 
   @override
-  def vector_compute(
-    self, keys: Iterable[PathKey], vector_index: VectorDBIndex
-  ) -> Iterator[Optional[Item]]:
-    span_vectors = vector_index.get(keys)
+  def vector_compute(self, span_vectors: Iterable[list[SpanVector]]) -> Iterator[Optional[Item]]:
     return self._score_span_vectors(span_vectors)
 
   @override
@@ -99,4 +96,4 @@ class SemanticSimilaritySignal(VectorSignal):
   ) -> list[tuple[PathKey, Optional[Item]]]:
     query = self._get_search_embedding()
     topk_keys = [key for key, _ in vector_index.topk(query, topk, rowids)]
-    return list(zip(topk_keys, self.vector_compute(topk_keys, vector_index)))
+    return list(zip(topk_keys, self.vector_compute(vector_index.get(topk_keys))))

--- a/lilac/signals/semantic_similarity_test.py
+++ b/lilac/signals/semantic_similarity_test.py
@@ -85,7 +85,7 @@ def test_semantic_similarity_compute_keys(mocker: MockerFixture) -> None:
   embed_mock = mocker.spy(TestEmbedding, 'compute')
 
   signal = SemanticSimilaritySignal(query='hello', embedding=TestEmbedding.name)
-  scores = list(signal.vector_compute([('1',), ('2',), ('3',)], vector_index))
+  scores = list(signal.vector_compute(vector_index.get([('1',), ('2',), ('3',)])))
 
   # Embeddings should be called only 1 time for the search.
   assert embed_mock.call_count == 1

--- a/web/lib/fastapi_client/models/ConceptLabelsSignal.ts
+++ b/web/lib/fastapi_client/models/ConceptLabelsSignal.ts
@@ -9,7 +9,7 @@
 export type ConceptLabelsSignal = {
     signal_name: 'concept_labels';
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
     namespace: string;

--- a/web/lib/fastapi_client/models/ConceptSignal.ts
+++ b/web/lib/fastapi_client/models/ConceptSignal.ts
@@ -9,7 +9,7 @@
 export type ConceptSignal = {
     signal_name: 'concept_score';
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
     /**

--- a/web/lib/fastapi_client/models/SemanticSimilaritySignal.ts
+++ b/web/lib/fastapi_client/models/SemanticSimilaritySignal.ts
@@ -12,7 +12,7 @@
 export type SemanticSimilaritySignal = {
     signal_name: 'semantic_similarity';
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
     /**

--- a/web/lib/fastapi_client/models/Signal.ts
+++ b/web/lib/fastapi_client/models/Signal.ts
@@ -9,7 +9,7 @@
 export type Signal = {
     signal_name: string;
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
 };

--- a/web/lib/fastapi_client/models/SubstringSignal.ts
+++ b/web/lib/fastapi_client/models/SubstringSignal.ts
@@ -9,7 +9,7 @@
 export type SubstringSignal = {
     signal_name: 'substring_search';
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
     query: string;

--- a/web/lib/fastapi_client/models/TextEmbeddingSignal.ts
+++ b/web/lib/fastapi_client/models/TextEmbeddingSignal.ts
@@ -9,7 +9,7 @@
 export type TextEmbeddingSignal = {
     signal_name: string;
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
     /**

--- a/web/lib/fastapi_client/models/TextSignal.ts
+++ b/web/lib/fastapi_client/models/TextSignal.ts
@@ -9,7 +9,7 @@
 export type TextSignal = {
     signal_name: string;
     output_type?: ('embedding' | 'cluster' | null);
-    map_batch_size?: number;
+    map_batch_size?: (number | null);
     map_parallelism?: number;
     map_strategy?: 'processes' | 'threads';
 };


### PR DESCRIPTION
Breaking change: VectorSignal.vector_compute takes a set of spanvectors now, instead of a set of pathkeys and a vectordb