### PR TITLE
Fixes incorrect destructuring

### DIFF
--- a/lilac/concepts/concept.py
+++ b/lilac/concepts/concept.py
@@ -362,6 +362,6 @@ class ConceptModel:
     missing_ids = texts_of_missing_embeddings.keys()
     missing_embeddings = embed_fn(list(texts_of_missing_embeddings.values()))
 
-    for id, (embedding,) in zip(missing_ids, missing_embeddings):
+    for id, (embedding, *_) in zip(missing_ids, missing_embeddings):
       concept_embeddings[id] = embedding['vector'] / np.linalg.norm(embedding['vector'])
     self._embeddings = concept_embeddings


### PR DESCRIPTION
I have been playing with your library and I was unable to use any concepts because of following errors:
```
  File "/Users/hynekkdylicek/.pyenv/versions/dev/lib/python3.11/site-packages/lilac/concepts/concept.py", line 365, in _compute_embeddings
    for id, (embedding,) in zip(missing_ids, missing_embeddings):
            ^^^^^^^^^^^
ValueError: too many values to unpack (expected 1)
```


The problem is that the missing_embeddings can contain multiple embeddings (which I assume happens at long documents):
```
[{'vector': array([ 6.82974933e-...e=float32), 'span': (...)}, {'vector': array([ 4.36740592e-...e=float32), 'span': (...)}]
```

This PR fixes this by correctly desctructuring the touple