### PR TITLE
Allows non folder exports

### DIFF
--- a/lilac/router_dataset.py
+++ b/lilac/router_dataset.py
@@ -294,7 +294,10 @@ def serve_dataset_file(filepath: str) -> FileResponse:
 def export_dataset(namespace: str, dataset_name: str, options: ExportOptions) -> str:
   """Export the dataset to one of the supported file formats."""
   dataset = get_dataset(namespace, dataset_name)
-  os.makedirs(os.path.dirname(options.filepath), exist_ok=True)
+  # Only create the directory if the filepath has a directory.
+  dirname = os.path.dirname(options.filepath)
+  if dirname:
+    os.makedirs(dirname, exist_ok=True)
 
   if options.format == 'csv':
     dataset.to_csv(


### PR DESCRIPTION
I was unable to export the dataset from UI, when I only specified the name of the file.
The problem. is that python can't create empty directories, but if we don't specify one the code still attempts to create a directory. This will cause an error.

This PR fixes it