### PR TITLE
Add keyboard shortcuts for fast labeling.

### DIFF
--- a/lilac/config.py
+++ b/lilac/config.py
@@ -89,6 +89,8 @@ class DatasetUISettings(BaseModel):
   markdown_paths: list[PathTuple] = []
   model_config = ConfigDict(extra='forbid')
   view_type: Literal['scroll', 'single_item'] = 'single_item'
+  # Maps a label to a keycode.
+  label_keyboard_shortcuts: dict[str, str] = {}
 
   @field_validator('media_paths', mode='before')
   @classmethod

--- a/lilac/config.py
+++ b/lilac/config.py
@@ -90,7 +90,7 @@ class DatasetUISettings(BaseModel):
   model_config = ConfigDict(extra='forbid')
   view_type: Literal['scroll', 'single_item'] = 'single_item'
   # Maps a label to a keycode.
-  label_keyboard_shortcuts: dict[str, str] = {}
+  label_to_keycode: dict[str, str] = {}
 
   @field_validator('media_paths', mode='before')
   @classmethod

--- a/web/blueprint/src/lib/components/datasetView/Dataset.svelte
+++ b/web/blueprint/src/lib/components/datasetView/Dataset.svelte
@@ -159,7 +159,7 @@
       {:else if itemsViewType == 'scroll'}
         <ScrollView />
       {:else if itemsViewType == 'single_item'}
-        <SingleItemView />
+        <SingleItemView {settingsOpen} />
       {/if}
     </div>
   </div>

--- a/web/blueprint/src/lib/components/datasetView/DatasetSettingsKeyboardShortcuts.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetSettingsKeyboardShortcuts.svelte
@@ -33,7 +33,7 @@
     <div class="text-lg text-gray-700">Label shortcuts</div>
     <div class="text-sm text-gray-500">
       <p>
-        Keyboard shortcuts for labeling rows. Key codes are standard browser <a
+        Keyboard shortcuts for toggling a label on a row. Key codes are standard browser <a
           href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code">key codes</a
         >.
       </p>

--- a/web/blueprint/src/lib/components/datasetView/DatasetSettingsKeyboardShortcuts.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetSettingsKeyboardShortcuts.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import type {DatasetSettings} from '$lilac';
+  import {Keyboard, Tag} from 'carbon-icons-svelte';
+  import {hoverTooltip} from '../common/HoverTooltip';
+
+  export let newSettings: DatasetSettings | null;
+  export let labels: string[] | undefined;
+
+  const INVALID_KEYCODES = ['ArrowLeft', 'ArrowRight', 'Delete', 'Backspace'];
+
+  let activeSetLabelIndex: number | undefined = undefined;
+
+  function onKeyDown(key: KeyboardEvent) {
+    if (activeSetLabelIndex == null || newSettings == null || labels == null) {
+      return;
+    }
+    if (INVALID_KEYCODES.includes(key.code)) {
+      return;
+    }
+    if (newSettings.ui == null) {
+      newSettings.ui = {};
+    }
+    if (newSettings.ui.label_keyboard_shortcuts == null) {
+      newSettings.ui.label_keyboard_shortcuts = {};
+    }
+    newSettings.ui.label_keyboard_shortcuts[labels[activeSetLabelIndex]] = key.code;
+    activeSetLabelIndex = undefined;
+  }
+</script>
+
+<div class="mb-8 flex flex-col gap-y-4">
+  <section class="flex flex-col gap-y-1">
+    <div class="text-lg text-gray-700">Label shortcuts</div>
+    <div class="text-sm text-gray-500">
+      <p>
+        Keyboard shortcuts for labeling rows. Key codes are standard browser <a
+          href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code">key codes</a
+        >.
+      </p>
+      <br />
+      <p>
+        To edit a key code, click the keyboard icon, and press the corresponding key on the keyboard
+        to set the shortcut.
+      </p>
+    </div>
+
+    <table class="mt-4">
+      {#each labels || [] as label, i}
+        <tr class="h-12 items-center gap-x-8 gap-y-1">
+          <td class="w-36">
+            <div
+              class="flex w-fit flex-row items-center gap-x-2 rounded-lg border border-gray-300 bg-transparent bg-white p-1"
+            >
+              <Tag />
+              {label}
+            </div>
+          </td>
+          <td class="flex h-8 w-16 flex-row items-center gap-x-1">
+            <button
+              class="flex h-full w-16 items-center rounded border border-gray-300 p-1"
+              class:bg-blue-300={i === activeSetLabelIndex}
+              use:hoverTooltip={{text: 'Set keyboard shortcut'}}
+              on:click={() => {
+                activeSetLabelIndex = i;
+              }}
+              ><Keyboard />
+            </button>
+            <input
+              disabled
+              type="text"
+              class="h-8 w-16 rounded border border-neutral-200 px-2 text-center"
+              value={newSettings?.ui?.label_keyboard_shortcuts?.[label] || ''}
+            />
+          </td>
+        </tr>
+      {/each}
+    </table>
+  </section>
+</div>
+<svelte:window on:keydown={onKeyDown} />

--- a/web/blueprint/src/lib/components/datasetView/DatasetSettingsKeyboardShortcuts.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetSettingsKeyboardShortcuts.svelte
@@ -20,10 +20,10 @@
     if (newSettings.ui == null) {
       newSettings.ui = {};
     }
-    if (newSettings.ui.label_keyboard_shortcuts == null) {
-      newSettings.ui.label_keyboard_shortcuts = {};
+    if (newSettings.ui.label_to_keycode == null) {
+      newSettings.ui.label_to_keycode = {};
     }
-    newSettings.ui.label_keyboard_shortcuts[labels[activeSetLabelIndex]] = key.code;
+    newSettings.ui.label_to_keycode[labels[activeSetLabelIndex]] = key.code;
     activeSetLabelIndex = undefined;
   }
 </script>
@@ -69,7 +69,7 @@
               disabled
               type="text"
               class="h-8 w-16 rounded border border-neutral-200 px-2 text-center"
-              value={newSettings?.ui?.label_keyboard_shortcuts?.[label] || ''}
+              value={newSettings?.ui?.label_to_keycode?.[label] || ''}
             />
           </td>
         </tr>

--- a/web/blueprint/src/lib/components/datasetView/DatasetSettingsModal.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetSettingsModal.svelte
@@ -3,13 +3,14 @@
   import {
     DATASETS_TAG,
     deleteDatasetMutation,
+    queryDatasetSchema,
     queryDatasets,
     querySettings,
     updateDatasetSettingsMutation
   } from '$lib/queries/datasetQueries';
   import {queryClient} from '$lib/queries/queryClient';
   import {datasetIdentifier} from '$lib/utils';
-  import type {DatasetSettings} from '$lilac';
+  import {getSchemaLabels, type DatasetSettings} from '$lilac';
   import {
     ComboBox,
     ComposedModal,
@@ -22,6 +23,7 @@
   import CommandSelectList from '../commands/selectors/CommandSelectList.svelte';
   import RemovableTag from '../common/RemovableTag.svelte';
   import DatasetSettingsFields from './DatasetSettingsFields.svelte';
+  import DatasetSettingsKeyboardShortcuts from './DatasetSettingsKeyboardShortcuts.svelte';
 
   export let namespace: string;
   export let name: string;
@@ -52,7 +54,7 @@
 
   $: identifier = datasetIdentifier(namespace, name);
 
-  let settingsPage: 'fields' | 'tags' | 'administration' = 'fields';
+  let settingsPage: 'fields' | 'tags' | 'keyboard_shortcuts' | 'administration' = 'fields';
 
   function parseSettings(settings: DatasetSettings | undefined): DatasetSettings | null {
     if (settings == null) return null;
@@ -102,6 +104,9 @@
     }
     newSettings.tags = newSettings.tags.filter(t => t !== tag);
   }
+
+  $: schema = queryDatasetSchema(namespace, name);
+  $: labels = $schema.data && getSchemaLabels($schema.data);
 </script>
 
 <ComposedModal {open} on:submit={submit} on:close={() => (open = false)}>
@@ -116,6 +121,7 @@
               value: 'fields'
             },
             {title: 'Tags', value: 'tags'},
+            {title: 'Keyboard shortcuts', value: 'keyboard_shortcuts'},
             {title: 'Administration', value: 'administration'}
           ]}
           item={settingsPage}
@@ -156,6 +162,8 @@
               placeholder={'Add a tag'}
             />
           </div>
+        {:else if settingsPage === 'keyboard_shortcuts'}
+          <DatasetSettingsKeyboardShortcuts bind:newSettings {labels} />
         {:else if settingsPage === 'administration'}
           <div class="flex flex-col gap-y-6">
             <section class="flex flex-col gap-y-1">

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -154,7 +154,6 @@
 
   function onKeyDown(key: KeyboardEvent) {
     // Keyboard shortcuts are disabled in scroll-view and when settings are open.
-    console.log(settingsOpen);
     if (itemsViewType !== 'single_item' || settingsOpen) {
       return;
     }

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -1,33 +1,33 @@
 <script lang="ts">
   import {
-      addLabelsMutation,
-      queryDatasetSchema,
-      queryRowMetadata,
-      querySelectRowsSchema,
-      querySettings,
-      removeLabelsMutation
+    addLabelsMutation,
+    queryDatasetSchema,
+    queryRowMetadata,
+    querySelectRowsSchema,
+    querySettings,
+    removeLabelsMutation
   } from '$lib/queries/datasetQueries';
-  import { queryAuthInfo } from '$lib/queries/serverQueries';
+  import {queryAuthInfo} from '$lib/queries/serverQueries';
   import {
-      getDatasetViewContext,
-      getSelectRowsOptions,
-      getSelectRowsSchemaOptions
+    getDatasetViewContext,
+    getSelectRowsOptions,
+    getSelectRowsSchemaOptions
   } from '$lib/stores/datasetViewStore';
-  import { getNotificationsContext } from '$lib/stores/notificationsStore';
-  import { SIDEBAR_TRANSITION_TIME_MS } from '$lib/view_utils';
+  import {getNotificationsContext} from '$lib/stores/notificationsStore';
+  import {SIDEBAR_TRANSITION_TIME_MS} from '$lib/view_utils';
   import {
-      formatValue,
-      getRowLabels,
-      getSchemaLabels,
-      serializePath,
-      type AddLabelsOptions,
-      type LilacField,
-      type RemoveLabelsOptions
+    formatValue,
+    getRowLabels,
+    getSchemaLabels,
+    serializePath,
+    type AddLabelsOptions,
+    type LilacField,
+    type RemoveLabelsOptions
   } from '$lilac';
-  import { SkeletonText } from 'carbon-components-svelte';
-  import { ChevronLeft, ChevronRight, Tag } from 'carbon-icons-svelte';
-  import { slide } from 'svelte/transition';
-  import { hoverTooltip } from '../common/HoverTooltip';
+  import {SkeletonText} from 'carbon-components-svelte';
+  import {ChevronLeft, ChevronRight, Tag} from 'carbon-icons-svelte';
+  import {slide} from 'svelte/transition';
+  import {hoverTooltip} from '../common/HoverTooltip';
   import DeleteRowsButton from './DeleteRowsButton.svelte';
   import EditLabel from './EditLabel.svelte';
   import ItemMedia from './ItemMedia.svelte';

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -1,33 +1,33 @@
 <script lang="ts">
   import {
-    addLabelsMutation,
-    queryDatasetSchema,
-    queryRowMetadata,
-    querySelectRowsSchema,
-    querySettings,
-    removeLabelsMutation
+      addLabelsMutation,
+      queryDatasetSchema,
+      queryRowMetadata,
+      querySelectRowsSchema,
+      querySettings,
+      removeLabelsMutation
   } from '$lib/queries/datasetQueries';
-  import {queryAuthInfo} from '$lib/queries/serverQueries';
+  import { queryAuthInfo } from '$lib/queries/serverQueries';
   import {
-    getDatasetViewContext,
-    getSelectRowsOptions,
-    getSelectRowsSchemaOptions
+      getDatasetViewContext,
+      getSelectRowsOptions,
+      getSelectRowsSchemaOptions
   } from '$lib/stores/datasetViewStore';
-  import {getNotificationsContext} from '$lib/stores/notificationsStore';
-  import {SIDEBAR_TRANSITION_TIME_MS} from '$lib/view_utils';
+  import { getNotificationsContext } from '$lib/stores/notificationsStore';
+  import { SIDEBAR_TRANSITION_TIME_MS } from '$lib/view_utils';
   import {
-    formatValue,
-    getRowLabels,
-    getSchemaLabels,
-    serializePath,
-    type AddLabelsOptions,
-    type LilacField,
-    type RemoveLabelsOptions
+      formatValue,
+      getRowLabels,
+      getSchemaLabels,
+      serializePath,
+      type AddLabelsOptions,
+      type LilacField,
+      type RemoveLabelsOptions
   } from '$lilac';
-  import {SkeletonText} from 'carbon-components-svelte';
-  import {ChevronLeft, ChevronRight, Tag} from 'carbon-icons-svelte';
-  import {slide} from 'svelte/transition';
-  import {hoverTooltip} from '../common/HoverTooltip';
+  import { SkeletonText } from 'carbon-components-svelte';
+  import { ChevronLeft, ChevronRight, Tag } from 'carbon-icons-svelte';
+  import { slide } from 'svelte/transition';
+  import { hoverTooltip } from '../common/HoverTooltip';
   import DeleteRowsButton from './DeleteRowsButton.svelte';
   import EditLabel from './EditLabel.svelte';
   import ItemMedia from './ItemMedia.svelte';
@@ -98,7 +98,7 @@
   }
 
   function addLabel(label: string) {
-    if (rowId == null) {
+    if (rowId == null || !canEditLabels) {
       return;
     }
     const addLabelsOptions: AddLabelsOptions = {
@@ -127,7 +127,7 @@
   }
 
   function removeLabel(label: string) {
-    if (rowId == null) {
+    if (rowId == null || !canEditLabels) {
       return;
     }
     const body: RemoveLabelsOptions = {

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -150,7 +150,7 @@
     });
   }
 
-  $: labelKeyboardShortcuts = $settingsQuery.data?.ui?.label_keyboard_shortcuts || {};
+  $: labelKeyboardShortcuts = $settingsQuery.data?.ui?.label_to_keycode || {};
 
   function onKeyDown(key: KeyboardEvent) {
     // Keyboard shortcuts are disabled in scroll-view and when settings are open.

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -27,6 +27,7 @@
   import {SkeletonText} from 'carbon-components-svelte';
   import {ChevronLeft, ChevronRight, Tag} from 'carbon-icons-svelte';
   import {slide} from 'svelte/transition';
+  import {hoverTooltip} from '../common/HoverTooltip';
   import DeleteRowsButton from './DeleteRowsButton.svelte';
   import EditLabel from './EditLabel.svelte';
   import ItemMedia from './ItemMedia.svelte';
@@ -193,7 +194,15 @@
           class:opacity-50={disableLabels}
         >
           {#each schemaLabels || [] as label}
-            <div class:opacity-50={labelsInProgress.has(label)}>
+            <div
+              class:opacity-50={labelsInProgress.has(label)}
+              use:hoverTooltip={{
+                text:
+                  labelKeyboardShortcuts[label] != null
+                    ? `Keyboard: ${labelKeyboardShortcuts[label]}`
+                    : ''
+              }}
+            >
               <LabelPill
                 {label}
                 disabled={labelsInProgress.has(label) || disableLabels}

--- a/web/blueprint/src/lib/components/datasetView/SingleItemView.svelte
+++ b/web/blueprint/src/lib/components/datasetView/SingleItemView.svelte
@@ -8,6 +8,9 @@
   import RowItem from './RowItem.svelte';
   import SingleItemSelectRows from './SingleItemSelectRows.svelte';
 
+  // True when the settings modal is open. Used to disable keyboard shortcuts.
+  export let settingsOpen = false;
+
   const store = getDatasetViewContext();
   const DEFAULT_LIMIT_SELECT_ROW_IDS = 5;
 
@@ -69,14 +72,11 @@
     }
   }
 
-  let openDeleteModal = false;
   function onKeyDown(key: KeyboardEvent) {
     if (key.code === 'ArrowLeft') {
       updateSequentialRowId('previous');
     } else if (key.code === 'ArrowRight') {
       updateSequentialRowId('next');
-    } else if (key.code === 'Delete' || key.code === 'Backspace') {
-      openDeleteModal = true;
     }
   }
 </script>
@@ -100,7 +100,7 @@
     {mediaFields}
     {highlightedFields}
     {updateSequentialRowId}
-    bind:openDeleteModal
+    {settingsOpen}
   />
 </div>
 <svelte:window on:keydown={onKeyDown} />

--- a/web/blueprint/src/lib/queries/datasetQueries.ts
+++ b/web/blueprint/src/lib/queries/datasetQueries.ts
@@ -290,6 +290,7 @@ function invalidateQueriesLabelEdit(
   const schemaLabels = getSchemaLabels(schema);
   const labelExists = schemaLabels.includes(options.label_name);
 
+  console.log('label exists = ', labelExists);
   if (!labelExists) {
     queryClient.invalidateQueries([DATASETS_TAG, 'getManifest']);
     queryClient.invalidateQueries([DATASETS_TAG, 'selectRowsSchema']);

--- a/web/blueprint/src/lib/queries/datasetQueries.ts
+++ b/web/blueprint/src/lib/queries/datasetQueries.ts
@@ -290,7 +290,6 @@ function invalidateQueriesLabelEdit(
   const schemaLabels = getSchemaLabels(schema);
   const labelExists = schemaLabels.includes(options.label_name);
 
-  console.log('label exists = ', labelExists);
   if (!labelExists) {
     queryClient.invalidateQueries([DATASETS_TAG, 'getManifest']);
     queryClient.invalidateQueries([DATASETS_TAG, 'selectRowsSchema']);

--- a/web/lib/fastapi_client/models/DatasetUISettings.ts
+++ b/web/lib/fastapi_client/models/DatasetUISettings.ts
@@ -10,6 +10,6 @@ export type DatasetUISettings = {
     media_paths?: Array<Array<string>>;
     markdown_paths?: Array<Array<string>>;
     view_type?: 'scroll' | 'single_item';
-    label_keyboard_shortcuts?: Record<string, string>;
+    label_to_keycode?: Record<string, string>;
 };
 

--- a/web/lib/fastapi_client/models/DatasetUISettings.ts
+++ b/web/lib/fastapi_client/models/DatasetUISettings.ts
@@ -10,5 +10,6 @@ export type DatasetUISettings = {
     media_paths?: Array<Array<string>>;
     markdown_paths?: Array<Array<string>>;
     view_type?: 'scroll' | 'single_item';
+    label_keyboard_shortcuts?: Record<string, string>;
 };
 


### PR DESCRIPTION
This PR allows users to customize keyboard shortcuts for labels for a dataset.

NOTE: This persists across all users and is written to dataset settings.

https://huggingface.co/spaces/lilacai/nikhil_staging

https://github.com/lilacai/lilac/assets/1100749/4e9e014c-c8f3-4433-816b-0754ad0ce0ec

