### PR TITLE
Improve auto-binning, and sorting of histograms.

### DIFF
--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1588,7 +1588,6 @@ class DatasetDuckDB(Dataset):
       # Replace any NaT with None and pd.Timestamp to native datetime objects.
       counts = [(None if pd.isnull(val) else val.to_pydatetime(), count) for val, count in counts]
 
-    print('counts', counts, 'bins', named_bins)
     return SelectGroupsResult(too_many_distinct=False, counts=counts, bins=named_bins)
 
   def _topk_udf_to_sort_by(

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1588,6 +1588,7 @@ class DatasetDuckDB(Dataset):
       # Replace any NaT with None and pd.Timestamp to native datetime objects.
       counts = [(None if pd.isnull(val) else val.to_pydatetime(), count) for val, count in counts]
 
+    print('counts', counts, 'bins', named_bins)
     return SelectGroupsResult(too_many_distinct=False, counts=counts, bins=named_bins)
 
   def _topk_udf_to_sort_by(
@@ -3313,11 +3314,19 @@ def _normalize_bins(bins: Optional[Union[Sequence[Bin], Sequence[float]]]) -> Op
 def _auto_bins(stats: StatsResult, num_bins: int) -> list[Bin]:
   min_val = cast(float, stats.min_val)
   max_val = cast(float, stats.max_val)
+  value_range = max_val - min_val
+  # Select a round ndigits as a function of the value range. We offset it by 2 to allow for some
+  # decimal places as a function of the range.
+  round_ndigits = -1 * round(math.log10(value_range)) + 3
   bin_width = (max_val - min_val) / num_bins
-  bins: list[Bin] = []
+  bins: list = []
+  last_end_val = None
   for i in range(num_bins):
-    start = None if i == 0 else min_val + i * bin_width
     end = None if i == num_bins - 1 else min_val + (i + 1) * bin_width
+    if end:
+      end = round(end, round_ndigits)
+    start = last_end_val
+    last_end_val = end
     bins.append((str(i), start, end))
   return bins
 

--- a/web/blueprint/src/lib/components/schemaView/FieldDetails.svelte
+++ b/web/blueprint/src/lib/components/schemaView/FieldDetails.svelte
@@ -88,7 +88,7 @@
             </span>
             <span>Total count</span>
           </td>
-          <td>{formatValue(stats.total_count)}</td>
+          <td class="stats-label">{formatValue(stats.total_count)}</td>
         </tr>
         <tr>
           <td>
@@ -99,7 +99,7 @@
             </span>
             <span>Unique values</span>
           </td>
-          <td>~{formatValue(stats.approx_count_distinct)}</td>
+          <td class="stats-label">~{formatValue(stats.approx_count_distinct)}</td>
         </tr>
         {#if stats.avg_text_length}
           <tr>
@@ -109,7 +109,7 @@
               </span>
               <span>Average text length</span>
             </td>
-            <td>{formatValue(stats.avg_text_length)}</td>
+            <td class="stats-label">{formatValue(stats.avg_text_length)}</td>
           </tr>
         {/if}
         {#if stats.min_val && stats.max_val}
@@ -120,7 +120,8 @@
               </span>
               <span>Range</span>
             </td>
-            <td>{formatValue(stats.min_val)} .. {formatValue(stats.max_val)}</td>
+            <td class="stats-label">{formatValue(stats.min_val)} .. {formatValue(stats.max_val)}</td
+            >
           </tr>
         {/if}
       </tbody>
@@ -148,5 +149,8 @@
   }
   .stats-table td:last-child {
     @apply truncate py-2 pl-2;
+  }
+  .stats-label {
+    font-family: 'inconsolata variable';
   }
 </style>

--- a/web/blueprint/src/lib/components/schemaView/Histogram.svelte
+++ b/web/blueprint/src/lib/components/schemaView/Histogram.svelte
@@ -44,12 +44,14 @@
       class="flex items-center p-0 text-left text-xs text-black hover:bg-gray-200"
       on:click={() => dispatch('row-click', {value})}
     >
-      <div title={groupName} class="w-48 flex-none truncate px-2">{groupName}</div>
+      <div title={groupName} class="histogram-label histogram-bar w-48 flex-none truncate px-2">
+        {groupName}
+      </div>
       <div class="w-36 border-l border-gray-300 pl-2">
         <div
           title={formattedCount}
           style:width={barWidth}
-          class="histogram-bar my-px bg-indigo-200 pl-2 text-xs leading-5"
+          class="histogram-label histogram-bar my-px bg-indigo-200 pl-2 text-xs leading-5"
         >
           {formattedCount}
         </div>
@@ -57,3 +59,9 @@
     </button>
   {/each}
 </div>
+
+<style>
+  .histogram-label {
+    font-family: 'inconsolata variable';
+  }
+</style>

--- a/web/blueprint/src/lib/components/schemaView/Histogram.svelte
+++ b/web/blueprint/src/lib/components/schemaView/Histogram.svelte
@@ -7,6 +7,12 @@
   export let bins: Record<string, [number | null, number | null]> | null;
   $: maxCount = Math.max(...counts.map(([_, count]) => count));
 
+  // Sort the counts by the index of their value in the named bins.
+  $: binKeys = bins != null ? (Object.keys(bins) as LeafValue[]) : [];
+  $: sortedCounts = counts
+    .slice()
+    .sort(([aValue], [bValue]) => binKeys.indexOf(aValue) - binKeys.indexOf(bValue));
+
   function formatValueOrBin(value: LeafValue): string {
     if (value == null) {
       return formatValue(value);
@@ -29,7 +35,7 @@
 </script>
 
 <div class="histogram">
-  {#each counts as [value, count]}
+  {#each sortedCounts as [value, count]}
     {@const groupName = formatValueOrBin(value)}
     {@const barWidth = `${(count / maxCount) * 100}%`}
     {@const formattedCount = formatValue(count)}


### PR DESCRIPTION
Demo: https://lilacai-nikhil-staging.hf.space/datasets#local/glue2&expandedStats=%7B%22premise.text_statistics.num_characters%22%3Atrue%2C%22premise.text_statistics.readability%22%3Atrue%2C%22premise.text_statistics.log(type_token_ratio)%22%3Atrue%2C%22premise.text_statistics.frac_non_ascii%22%3Atrue%7D&schemaCollapsed=false


<img width="412" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/45e93e25-2c47-48f1-b46f-5a9e5e45606a">
<img width="413" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/fa1b9160-f5e1-4b4e-b034-f127691d275c">
<img width="408" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/7312c86d-7fec-413e-82b7-f63774c87ad1">
<img width="410" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/ca8d742f-67ae-49dd-950a-8b70641c8862">

