### PR TITLE
Fix a bug with OpenAI embeddings after upgrading.

### DIFF
--- a/lilac/embeddings/openai.py
+++ b/lilac/embeddings/openai.py
@@ -1,5 +1,5 @@
 """OpenAI embeddings."""
-from typing import Any, ClassVar, Optional
+from typing import ClassVar, Optional
 
 import numpy as np
 from tenacity import retry, stop_after_attempt, wait_random_exponential
@@ -86,11 +86,11 @@ class OpenAIEmbedding(TextEmbeddingSignal):
       # See https://github.com/search?q=repo%3Aopenai%2Fopenai-python+replace+newlines&type=code
       texts = [text.replace('\n', ' ') for text in texts]
 
-      response: Any = client.embeddings.create(
+      response = client.embeddings.create(
         input=texts,
         model=API_EMBEDDING_MODEL,
       )
-      return [np.array(embedding['embedding'], dtype=np.float32) for embedding in response['data']]
+      return [np.array(embedding.embedding, dtype=np.float32) for embedding in response.data]
 
     return chunked_compute_embedding(
       embed_fn, docs, self.map_batch_size, chunker=clustering_spacy_chunker

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -59,6 +59,14 @@
   let signalPropertyValues: Record<string, Record<string, JSONSchema4Type>> = {};
   let errors: JSONError[] = [];
 
+  const HIDDEN_PROPERTIES = [
+    // Hide the signal name as it's just used for type coersion.
+    '/signal_name',
+    // Hide the embedding input type from the compute embedding menu as we're always computing
+    // document level embeddings.
+    '/embed_input_type'
+  ];
+
   // Set the signal values if we are editing a signal
   if (
     (command.command === Command.EditPreviewConcept ||
@@ -182,7 +190,7 @@
               bind:value={signalPropertyValues[signalInfo?.name]}
               bind:validationErrors={errors}
               showDescription={false}
-              hiddenProperties={['/signal_name']}
+              hiddenProperties={HIDDEN_PROPERTIES}
               customComponents={customComponents[signalInfo?.name]}
             />
           {/key}


### PR DESCRIPTION
Fixes https://github.com/lilacai/lilac/issues/1036

Also removes "Embedding input type" from the UI as it's a bit confusing, and doesn't make sense from the perspective of full-dataset embedding.