### PR TITLE
Progress bar

### DIFF
--- a/lilac/router_data_loader.py
+++ b/lilac/router_data_loader.py
@@ -98,7 +98,7 @@ async def load(
       task_id,
     )
 
-  thread = Thread(target=run)
+  thread = Thread(target=run, daemon=True)
   thread.start()
 
   return LoadDatasetResponse(task_id=task_id)


### PR DESCRIPTION
The performance degradation Nikhil observed in https://github.com/lilacai/lilac/issues/1029 is partially cosmetic - now that tqdm is getting very bursty batches of completed items, it's not updating at the right frequency and it's often one batch behind. I fiddled around with tqdm update/refreshing params but couldn't really get tqdm to update more frequently.

The daemon=True change ensures that the background threads actually exit when you ctrl+C the server.