### PR TITLE
Fix bug with ItemMedia not rendering media fields that are deeply nested siblings.

### DIFF
--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -1,16 +1,4 @@
 datasets:
-  - name: imdb
-    namespace: lilac
-    settings:
-      tags: [machine-learning]
-      ui:
-        media_paths:
-          - text
-      preferred_embedding: 'gte-small'
-    source:
-      source_name: huggingface
-      dataset_name: imdb
-
   - namespace: lilac
     name: glaive
     source:
@@ -39,38 +27,6 @@ datasets:
     source:
       source_name: huggingface
       dataset_name: OpenAssistant/oasst1
-
-  - name: wikitext-2-raw-v1
-    namespace: lilac
-    settings:
-      tags: [machine-learning]
-      ui:
-        media_paths:
-          - text
-      preferred_embedding: 'gte-small'
-
-    source:
-      config_name: wikitext-2-raw-v1
-      dataset_name: wikitext
-      source_name: huggingface
-
-  - name: textbook_quality_programming
-    namespace: lilac
-    source:
-      dataset_name: vikp/textbook_quality_programming
-      source_name: huggingface
-    settings:
-      tags: [machine-learning]
-      ui:
-        media_paths:
-          - - outline
-            - '*'
-          - - concepts
-            - '*'
-          - markdown
-        markdown_paths:
-          - markdown
-      preferred_embedding: gte-small
 
   - name: databricks-dolly-15k-curated-en
     namespace: lilac
@@ -109,94 +65,13 @@ datasets:
       dataset_name: Open-Orca/OpenOrca
       sample_size: 100000
 
-  - name: opus100-en-es-validation
-    namespace: lilac
-    settings:
-      tags: [machine-learning]
-      ui:
-        media_paths:
-          - [translation, es]
-          - [translation, en]
-      preferred_embedding: 'gte-small'
-    source:
-      config_name: en-es
-      dataset_name: opus100
-      source_name: huggingface
-      split: validation
-
-  # Science datasets
-  - name: science-qa-derek-thomas
-    namespace: lilac
-    settings:
-      tags: [science]
-      ui:
-        media_paths: [lecture]
-      preferred_embedding: 'gte-small'
-    source:
-      dataset_name: derek-thomas/ScienceQA
-      source_name: huggingface
-
-  # Business datasets.
-  - name: enron-emails
-    namespace: lilac
-    settings:
-      tags: [business]
-      ui:
-        media_paths: [text]
-      preferred_embedding: 'gte-small'
-    source:
-      config_name: enron_emails
-      dataset_name: EleutherAI/pile
-      sample_size: 100000
-      source_name: huggingface
-
-  # Other datasets.
-  - name: the_movies_dataset
-    namespace: lilac
-    settings:
-      tags: [other]
-      ui:
-        media_paths: [overview]
-      preferred_embedding: 'gte-small'
-    source:
-      filepaths:
-        [
-          'https://storage.googleapis.com/lilac-data/datasets/the_movies_dataset/the_movies_dataset.csv'
-        ]
-      source_name: csv
-
 signals:
   - signal_name: pii
   - signal_name: text_statistics
-  - signal_name: near_dup
   - signal_name: lang_detection
   - signal_name: concept_score
     namespace: lilac
-    concept_name: negative-sentiment
-    embedding: gte-small
-  - signal_name: concept_score
-    namespace: lilac
-    concept_name: non-english
-    embedding: gte-small
-  - signal_name: concept_score
-    namespace: lilac
-    concept_name: positive-sentiment
-    embedding: gte-small
-  - signal_name: concept_score
-    namespace: lilac
     concept_name: profanity
-    embedding: gte-small
-  - signal_name: concept_score
-    namespace: lilac
-    concept_name: question
-    embedding: gte-small
-  - signal_name: concept_score
-    namespace: lilac
-    concept_name: source-code
-    embedding: gte-small
-  - signal_name: concept_score
-    namespace: lilac
-    concept_name: toxicity
     embedding: gte-small
 
 concept_model_cache_embeddings:

--- a/web/blueprint/src/lib/components/datasetView/DatasetPivotResult.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetPivotResult.svelte
@@ -12,7 +12,7 @@
   import Carousel from 'svelte-carousel';
 
   import {datasetLink} from '$lib/utils';
-  import {ROWID, serializePath, type BinaryFilter, type Path, type UnaryFilter} from '$lilac';
+  import {ROWID, type BinaryFilter, type Path, type UnaryFilter} from '$lilac';
   import {SkeletonText} from 'carbon-components-svelte';
   import {ChevronLeft, ChevronRight, Information} from 'carbon-icons-svelte';
   import {createEventDispatcher} from 'svelte';
@@ -53,7 +53,9 @@
   $: countQuery = shouldLoad
     ? querySelectGroups($store.namespace, $store.datasetName, {
         leaf_path: path,
-        filters
+        filters,
+        // Explicitly set the limit to null to get all the groups, not just the top 100.
+        limit: null
       })
     : null;
   $: counts = ($countQuery?.data?.counts || []).map(([name, count]) => ({
@@ -120,9 +122,7 @@
                 <div class="leading-2 text-lg">{groupPercentage}%</div>
                 <div
                   use:hoverTooltip={{
-                    text:
-                      `${groupPercentage}% of ${serializePath(parentPath)}="${parentValue}"\n` +
-                      `${totalPercentage}% of total`
+                    text: `${groupPercentage}% of ${parentValue}\n` + `${totalPercentage}% of total`
                   }}
                 >
                   <Information />

--- a/web/blueprint/src/lib/components/datasetView/DatasetPivotResult.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetPivotResult.svelte
@@ -20,7 +20,6 @@
 
   export let filter: BinaryFilter | UnaryFilter;
   export let path: Path;
-  export let parentPath: Path;
   export let parentValue: string;
   export let numRowsInQuery: number | undefined;
   // When true, queries will be issued. This allows us to progressively load without spamming the

--- a/web/blueprint/src/lib/components/datasetView/DatasetPivotViewer.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetPivotViewer.svelte
@@ -53,7 +53,9 @@
     outerLeafPath != null
       ? querySelectGroups($store.namespace, $store.datasetName, {
           leaf_path: outerLeafPath,
-          filters: selectOptions.filters
+          filters: selectOptions.filters,
+          // Explicitly set the limit to null to get all the groups, not just the top 100.
+          limit: null
         })
       : null;
   $: outerCounts = ($outerCountQuery?.data?.counts || []).map(([name, count]) => ({

--- a/web/blueprint/src/lib/components/datasetView/DatasetPivotViewer.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetPivotViewer.svelte
@@ -192,7 +192,6 @@
                     ? {path: outerLeafPath, op: 'not_exists'}
                     : {path: outerLeafPath, op: 'equals', value: outerCount.name}}
                   path={innerLeafPath}
-                  parentPath={outerLeafPath}
                   parentValue={outerCount.name}
                   {numRowsInQuery}
                 />

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -232,11 +232,11 @@
 {#if isLeaf}
   <div class="flex w-full flex-row gap-x-4" class:border={isRepeated}>
     <div
-      class="relative mr-4 flex w-28 flex-row rounded border-neutral-200 p-2 font-mono font-medium text-neutral-500 md:w-36"
+      class="relative mr-4 flex w-28 flex-row rounded border-neutral-200 px-2 font-mono font-medium text-neutral-500 md:w-36"
     >
       <div class="z-100 sticky top-16 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}
-          <div title={displayPath} class="mx-2 mt-2 w-full flex-initial truncate">
+          <div title={displayPath} class="m-2 w-full flex-initial truncate">
             {displayPath}
           </div>
         {/if}

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -232,7 +232,7 @@
 {#if isLeaf}
   <div class="flex w-full flex-row gap-x-4" class:border={isRepeated}>
     <div
-      class="relative mr-4 flex w-28 flex-row rounded border-neutral-200 px-4 py-2 font-mono font-medium text-neutral-500 md:w-36"
+      class="relative mr-4 flex w-28 flex-row rounded border-neutral-200 p-2 font-mono font-medium text-neutral-500 md:w-36"
     >
       <div class="z-100 sticky top-16 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}

--- a/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMedia.svelte
@@ -17,9 +17,11 @@
     L,
     PATH_WILDCARD,
     formatValue,
+    getField,
     getValueNodes,
     pathIsEqual,
     pathIsMatching,
+    pathMatchesPrefix,
     petals,
     type DataTypeCasted,
     type LilacField,
@@ -47,40 +49,65 @@
   export let row: LilacValueNode | undefined | null = undefined;
   export let field: LilacField;
   export let highlightedFields: LilacField[];
+  export let mediaFields: LilacField[];
   // The root path contains the sub-path up to the point of this leaf.
   export let rootPath: Path | undefined = undefined;
-  // The showPath is a subset of the path that will be displayed for this node.
-  export let showPath: Path | undefined = undefined;
   export let isFetching: boolean | undefined = undefined;
 
-  // Choose the root path which is up to the point of the next repeated value.
-  $: firstRepeatedIndex = mediaPath.findIndex(p => p === PATH_WILDCARD);
+  let childPathParts: string[];
+  // Find all the children path parts that match a media field.
   $: {
+    const childPathPartsSet = new Set<string>();
+
     if (rootPath == null) {
-      if (firstRepeatedIndex != -1) {
-        rootPath = mediaPath.slice(0, firstRepeatedIndex + 1);
-      } else {
-        rootPath = mediaPath;
+      for (const field of mediaFields) {
+        const pathPart = field.path[0];
+        childPathPartsSet.add(pathPart);
       }
+    } else {
+      for (const field of mediaFields) {
+        if (!pathMatchesPrefix(field.path, rootPath)) continue;
+        const lastMediaPath = field.path[rootPath.length];
+        if (lastMediaPath == null) continue;
+
+        const subPath = [...rootPath, field.path[rootPath.length]];
+        const valueNodes = getValueNodes(row!, subPath);
+        for (const childNode of valueNodes) {
+          const childPath = L.path(childNode)![rootPath.length];
+          if (childPath != null) {
+            childPathPartsSet.add(childPath);
+          }
+        }
+      }
+    }
+    childPathParts = Array.from(childPathPartsSet);
+  }
+  $: isLeaf = childPathParts.length === 0;
+
+  $: schema = queryDatasetSchema($datasetViewStore.namespace, $datasetViewStore.datasetName);
+
+  $: isRepeatedParent = pathIsRepeated(rootPath?.slice(0, -1));
+  $: isRepeated = pathIsRepeated(rootPath);
+  function pathIsRepeated(path?: Path | null) {
+    return $schema.data != null && path != null
+      ? getField($schema.data, path)?.repeated_field != null
+      : false;
+  }
+
+  let displayPath: string;
+  $: {
+    if (rootPath != null) {
+      if (isRepeatedParent) {
+        displayPath = getDisplayPath(rootPath.slice(-2));
+      } else {
+        displayPath = rootPath[rootPath.length - 1];
+      }
+    } else {
+      displayPath = '';
     }
   }
 
   $: valueNodes = row != null ? getValueNodes(row, rootPath!) : [];
-  $: isLeaf = pathIsMatching(mediaPath, rootPath) && valueNodes.length === 1;
-
-  // Get the list of next root paths for children of a repeated node.
-  $: nextRootPaths = valueNodes.map(v => {
-    const path = L.path(v)!;
-    const nextRepeatedIdx = mediaPath.findIndex((p, i) => p === PATH_WILDCARD && i >= path.length);
-    const showPath = mediaPath.slice(nextRepeatedIdx).filter(p => p !== PATH_WILDCARD);
-    return {
-      rootPath: [
-        ...path,
-        ...mediaPath.slice(path.length, nextRepeatedIdx === -1 ? undefined : nextRepeatedIdx)
-      ],
-      showPath
-    };
-  });
 
   // The child component will communicate this back upwards to this component.
   let textIsOverBudget = false;
@@ -90,10 +117,6 @@
 
   const datasetViewStore = getDatasetViewContext();
   const appSettings = getSettingsContext();
-
-  $: pathForDisplay = showPath != null ? showPath : rootPath!;
-
-  $: displayPath = getDisplayPath(pathForDisplay);
 
   $: value = L.value(valueNodes[0]) as string;
 
@@ -128,7 +151,6 @@
       ? L.value(getValueNodes(row, resolveRepeatedIndices(titlePath))[0])
       : null;
 
-  $: schema = queryDatasetSchema($datasetViewStore.namespace, $datasetViewStore.datasetName);
   // Compare media paths should contain media paths with resolved path wildcards as sometimes the
   // user wants to compare items in an array.
   // NOTE: We do not use media paths here to allow the user to compare to a field they didn't
@@ -163,6 +185,7 @@
   $: spanValuePaths = getSpanValuePaths(field, highlightedFields);
 
   function findSimilar(searchText: DataTypeCasted) {
+    if (rootPath == null) return;
     let embedding = computedEmbeddings[0];
 
     if ($settings.data?.preferred_embedding != null) {
@@ -178,7 +201,7 @@
       }
     }
     datasetViewStore.addSearch({
-      path: field.path,
+      path: rootPath,
       type: 'semantic',
       query: searchText as string,
       query_type: 'document',
@@ -206,9 +229,11 @@
   $: markdown = userPreview !== undefined ? userPreview : datasetSettingsMarkdown;
 </script>
 
-<div class="flex w-full flex-row gap-x-4 p-2">
-  {#if isLeaf}
-    <div class="relative mr-4 flex w-28 flex-row font-mono font-medium text-neutral-500 md:w-36">
+{#if isLeaf}
+  <div class="flex w-full flex-row gap-x-4" class:border={isRepeated}>
+    <div
+      class="relative mr-4 flex w-28 flex-row rounded border-neutral-200 px-4 py-2 font-mono font-medium text-neutral-500 md:w-36"
+    >
       <div class="z-100 sticky top-16 flex w-full flex-col gap-y-2 self-start">
         {#if displayPath != '' && titleValue == null}
           <div title={displayPath} class="mx-2 mt-2 w-full flex-initial truncate">
@@ -314,26 +339,35 @@
         {/if}
       </div>
     </div>
-  {:else}
-    <!-- Repeated values will render <ItemMedia> again. -->
-    <div class="my-2 flex w-full flex-col rounded border border-neutral-200">
-      <div class="m-2 flex flex-col gap-y-2">
-        <div title={displayPath} class="mx-2 my-2 truncate font-mono font-medium text-neutral-500">
-          {displayPath}
-        </div>
-        {#each nextRootPaths as nextRootPath}
-          <div class="m-2 rounded border border-neutral-100">
-            <svelte:self
-              rootPath={nextRootPath.rootPath}
-              showPath={nextRootPath.showPath}
-              {row}
-              {field}
-              {highlightedFields}
-              {mediaPath}
-            />
-          </div>
-        {/each}
+  </div>
+{:else}
+  <!-- Repeated values will render <ItemMedia> again. -->
+  <div class="flex flex-col">
+    {#if !isRepeated && displayPath}
+      <div title={displayPath} class="mx-4 my-2 truncate font-mono font-medium text-neutral-500">
+        {displayPath}
       </div>
-    </div>
-  {/if}
-</div>
+    {/if}
+    {#each childPathParts as childPathPart, i}
+      {@const childPath = [...(rootPath || []), childPathPart]}
+      {@const childIsRepeated = pathIsRepeated(childPath)}
+      {@const borderColor =
+        rootPath && rootPath.length > 1 ? 'border-neutral-200' : 'border-neutral-300'}
+      <div
+        class={borderColor}
+        class:mx-4={!isRepeated && displayPath}
+        class:m-2={!childIsRepeated}
+        class:border-b={i < childPathParts.length - 1}
+      >
+        <svelte:self
+          rootPath={[...(rootPath || []), childPathPart]}
+          {mediaFields}
+          {row}
+          {field}
+          {highlightedFields}
+          {mediaPath}
+        />
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/web/blueprint/src/lib/components/datasetView/RowItem.svelte
+++ b/web/blueprint/src/lib/components/datasetView/RowItem.svelte
@@ -19,7 +19,6 @@
     formatValue,
     getRowLabels,
     getSchemaLabels,
-    serializePath,
     type AddLabelsOptions,
     type LilacField,
     type RemoveLabelsOptions
@@ -306,18 +305,17 @@
         {#if $rowQuery?.isFetching}
           <SkeletonText class="w-20" />
         {/if}
-        {#if mediaFields.length > 0}
-          {#each mediaFields as mediaField (serializePath(mediaField.path))}
-            <div class="flex w-full flex-col">
-              <ItemMedia
-                mediaPath={mediaField.path}
-                {row}
-                field={mediaField}
-                {highlightedFields}
-                isFetching={$rowQuery?.isFetching}
-              />
-            </div>
-          {/each}
+        {#if mediaFields.length > 0 && row != null}
+          <div class="flex w-full flex-col">
+            <ItemMedia
+              mediaPath={[]}
+              {mediaFields}
+              {row}
+              field={mediaFields[0]}
+              {highlightedFields}
+              isFetching={$rowQuery?.isFetching}
+            />
+          </div>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
https://lilacai-nikhil-staging.hf.space/datasets#local/Capybara
https://lilacai-nikhil-staging.hf.space/datasets#lilac/OpenOrca-100k

<img width="1266" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/eeab53b9-17d9-4e33-8b91-3c6c550fea1a">

Click around other datasets.

Also:
- Fix bug with limit of select_groups from the pivot viewer.
- Removes some dead datasts in the demo config.