### PR TITLE
`dataset.cluster()` flattens any repeated before clustering

### DIFF
--- a/lilac/batch_utils.py
+++ b/lilac/batch_utils.py
@@ -24,7 +24,7 @@ def flatten_iter(input: Union[Iterator, Iterable], max_depth: int = -1) -> Itera
     yield from _flatten_iter(elem, max_depth)
 
 
-def flatten_iter_path(input: Union[Iterator, Iterable, dict], path: PathTuple) -> Iterator:
+def flatten_path_iter(input: Union[Iterator, Iterable, dict], path: PathTuple) -> Iterator:
   """Flattens a nested object along the provided path."""
   if not path:
     yield input
@@ -33,11 +33,11 @@ def flatten_iter_path(input: Union[Iterator, Iterable, dict], path: PathTuple) -
   rest = path[1:]
   if path_part == PATH_WILDCARD:
     for elem in cast(Iterator, input):
-      yield from flatten_iter_path(elem, rest)
+      yield from flatten_path_iter(elem, rest)
   elif path_part not in input:
     return
   else:
-    yield from flatten_iter_path(cast(dict, input)[path_part], rest)
+    yield from flatten_path_iter(cast(dict, input)[path_part], rest)
 
 
 def _unflatten_iter(

--- a/lilac/batch_utils.py
+++ b/lilac/batch_utils.py
@@ -25,7 +25,7 @@ def flatten_iter(input: Union[Iterator, Iterable], max_depth: int = -1) -> Itera
 
 
 def flatten_iter_path(input: Union[Iterator, Iterable, dict], path: PathTuple) -> Iterator:
-  """Flattens a nested iterable."""
+  """Flattens a nested object along the provided path."""
   if not path:
     yield input
     return

--- a/lilac/batch_utils.py
+++ b/lilac/batch_utils.py
@@ -5,7 +5,7 @@ import json
 from io import BytesIO
 from typing import Any, Callable, Generator, Iterable, Iterator, TypeVar, Union, cast
 
-from .schema import Item
+from .schema import PATH_WILDCARD, Item, PathTuple
 from .utils import chunks, is_primitive
 
 
@@ -22,6 +22,22 @@ def flatten_iter(input: Union[Iterator, Iterable], max_depth: int = -1) -> Itera
   """Flattens a deeply nested iterator. Primitives and dictionaries are not flattened."""
   for elem in input:
     yield from _flatten_iter(elem, max_depth)
+
+
+def flatten_iter_path(input: Union[Iterator, Iterable, dict], path: PathTuple) -> Iterator:
+  """Flattens a nested iterable."""
+  if not path:
+    yield input
+    return
+  path_part = path[0]
+  rest = path[1:]
+  if path_part == PATH_WILDCARD:
+    for elem in cast(Iterator, input):
+      yield from flatten_iter_path(elem, rest)
+  elif path_part not in input:
+    return
+  else:
+    yield from flatten_iter_path(cast(dict, input)[path_part], rest)
 
 
 def _unflatten_iter(

--- a/lilac/batch_utils_test.py
+++ b/lilac/batch_utils_test.py
@@ -8,7 +8,7 @@ from .batch_utils import (
   flat_batched_compute,
   flatten,
   flatten_iter,
-  flatten_iter_path,
+  flatten_path_iter,
   unflatten,
   unflatten_iter,
 )
@@ -105,28 +105,28 @@ def test_deep_unflatten_np() -> None:
   np.testing.assert_array_equal(result[1], [np.array([2, 2]), np.array([3, 3])])
 
 
-def test_flatten_iter_path() -> None:
+def test_flatten_path_iter() -> None:
   input = [
     {'names': [{'first': 'John', 'last': 'Doe'}, {'first': 'Jane', 'last': 'Doe'}]},
     {'names': [{'first': 'Blake', 'last': 'Smith'}, {'first': 'Rob', 'last': 'Smith'}]},
   ]
-  result = list(flatten_iter_path(input, path=('*', 'names', '*', 'first')))
+  result = list(flatten_path_iter(input, path=('*', 'names', '*', 'first')))
   assert result == ['John', 'Jane', 'Blake', 'Rob']
 
-  result = list(flatten_iter_path(input, path=('*', 'names', '*')))
+  result = list(flatten_path_iter(input, path=('*', 'names', '*')))
   assert result == [
     {'first': 'John', 'last': 'Doe'},
     {'first': 'Jane', 'last': 'Doe'},
     {'first': 'Blake', 'last': 'Smith'},
     {'first': 'Rob', 'last': 'Smith'},
   ]
-  result = list(flatten_iter_path(input, path=('*', 'names')))
+  result = list(flatten_path_iter(input, path=('*', 'names')))
   assert result == [
     [{'first': 'John', 'last': 'Doe'}, {'first': 'Jane', 'last': 'Doe'}],
     [{'first': 'Blake', 'last': 'Smith'}, {'first': 'Rob', 'last': 'Smith'}],
   ]
 
-  result = list(flatten_iter_path(input, path=tuple('*')))
+  result = list(flatten_path_iter(input, path=tuple('*')))
   assert result == [
     {'names': [{'first': 'John', 'last': 'Doe'}, {'first': 'Jane', 'last': 'Doe'}]},
     {'names': [{'first': 'Blake', 'last': 'Smith'}, {'first': 'Rob', 'last': 'Smith'}]},

--- a/lilac/batch_utils_test.py
+++ b/lilac/batch_utils_test.py
@@ -4,7 +4,14 @@ from typing import Iterable
 
 import numpy as np
 
-from .batch_utils import flat_batched_compute, flatten, flatten_iter, unflatten, unflatten_iter
+from .batch_utils import (
+  flat_batched_compute,
+  flatten,
+  flatten_iter,
+  flatten_iter_path,
+  unflatten,
+  unflatten_iter,
+)
 
 
 def test_batched_compute() -> None:
@@ -96,3 +103,31 @@ def test_deep_unflatten_np() -> None:
   assert len(result) == 2
   np.testing.assert_array_equal(result[0], [np.array([1, 1])])
   np.testing.assert_array_equal(result[1], [np.array([2, 2]), np.array([3, 3])])
+
+
+def test_flatten_iter_path() -> None:
+  input = [
+    {'names': [{'first': 'John', 'last': 'Doe'}, {'first': 'Jane', 'last': 'Doe'}]},
+    {'names': [{'first': 'Blake', 'last': 'Smith'}, {'first': 'Rob', 'last': 'Smith'}]},
+  ]
+  result = list(flatten_iter_path(input, path=('*', 'names', '*', 'first')))
+  assert result == ['John', 'Jane', 'Blake', 'Rob']
+
+  result = list(flatten_iter_path(input, path=('*', 'names', '*')))
+  assert result == [
+    {'first': 'John', 'last': 'Doe'},
+    {'first': 'Jane', 'last': 'Doe'},
+    {'first': 'Blake', 'last': 'Smith'},
+    {'first': 'Rob', 'last': 'Smith'},
+  ]
+  result = list(flatten_iter_path(input, path=('*', 'names')))
+  assert result == [
+    [{'first': 'John', 'last': 'Doe'}, {'first': 'Jane', 'last': 'Doe'}],
+    [{'first': 'Blake', 'last': 'Smith'}, {'first': 'Rob', 'last': 'Smith'}],
+  ]
+
+  result = list(flatten_iter_path(input, path=tuple('*')))
+  assert result == [
+    {'names': [{'first': 'John', 'last': 'Doe'}, {'first': 'Jane', 'last': 'Doe'}]},
+    {'names': [{'first': 'Blake', 'last': 'Smith'}, {'first': 'Rob', 'last': 'Smith'}]},
+  ]

--- a/lilac/data/cluster_test.py
+++ b/lilac/data/cluster_test.py
@@ -1,5 +1,4 @@
 """Unit tests for dataset.cluster()."""
-import re
 from typing import ClassVar, Iterable, Iterator
 
 import pytest
@@ -185,7 +184,7 @@ def test_simple_clusters(make_test_data: TestDataMaker) -> None:
             CATEGORY_MEMBERSHIP_PROB: 'float32',
             CATEGORY_TITLE: 'string',
           },
-          cluster=ClusterInfo(min_cluster_size=2, remote=False),
+          cluster=ClusterInfo(min_cluster_size=2, remote=False, input_path=('text',)),
         ),
       }
     ),
@@ -196,9 +195,22 @@ def test_simple_clusters(make_test_data: TestDataMaker) -> None:
 
 def test_nested_clusters(make_test_data: TestDataMaker) -> None:
   texts: list[list[dict[str, str]]] = [
-    [{'text': 'Can you summarize this article'}, {'text': 'Can you rewrite this in a simpler way'}],
-    [{'text': 'Can you provide a short summary of the following text'}],
-    [{'text': 'Can you simplify this text'}, {'text': '1224123531451345'}],
+    [  # Cluster 1
+      {'text': 'Can you summarize this article'},
+      {'text': 'Can you provide a short summary of the following text'},
+    ],
+    [  # Cluster 2
+      {'text': 'Can you rewrite this in a simpler way'},
+      {'text': 'Can you simplify this text'},
+    ],
+    [  # Cluster 1
+      {'text': 'Can you give a summary of the article'},
+      {'text': 'Write a short overview of the following text'},
+    ],
+    [  # Cluster 2
+      {'text': 'Can you write a simpler version'},
+      {'text': 'Give me simplified version of this text'},
+    ],
   ]
   dataset = make_test_data([{'texts': t} for t in texts])
 
@@ -211,86 +223,99 @@ def test_nested_clusters(make_test_data: TestDataMaker) -> None:
 
   dataset.cluster('texts.*.text', min_cluster_size=2, topic_fn=topic_fn)
 
-  rows = list(dataset.select_rows(['texts'], combine_columns=True))
+  rows = list(dataset.select_rows(['texts__cluster'], combine_columns=True))
   assert rows == [
     {
-      'texts': [
-        {
-          'text': 'Can you summarize this article',
-          'text__cluster': {
-            'cluster_id': 0,
-            'cluster_membership_prob': 1.0,
-            'cluster_title': 'summarization',
-            'category_id': -1,
-            'category_membership_prob': None,
-            'category_title': None,
-          },
-        },
-        {
-          'text': 'Can you rewrite this in a simpler way',
-          'text__cluster': {
-            'cluster_id': 1,
-            'cluster_membership_prob': 1.0,
-            'cluster_title': 'simplification',
-            'category_id': -1,
-            'category_membership_prob': None,
-            'category_title': None,
-          },
-        },
-      ]
+      'texts__cluster': {
+        'cluster_id': 0,
+        'cluster_membership_prob': 1.0,
+        'cluster_title': 'summarization',
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
     },
     {
-      'texts': [
-        {
-          'text': 'Can you provide a short summary of the following text',
-          'text__cluster': {
-            'cluster_id': 0,
-            'cluster_membership_prob': 1.0,
-            'cluster_title': 'summarization',
-            'category_id': -1,
-            'category_membership_prob': None,
-            'category_title': None,
-          },
-        }
-      ],
+      'texts__cluster': {
+        'cluster_id': 1,
+        'cluster_membership_prob': 1.0,
+        'cluster_title': 'simplification',
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
     },
     {
-      'texts': [
-        {
-          'text': 'Can you simplify this text',
-          'text__cluster': {
-            'cluster_id': 1,
-            'cluster_membership_prob': 1.0,
-            'cluster_title': 'simplification',
-            'category_id': -1,
-            'category_membership_prob': None,
-            'category_title': None,
-          },
-        },
-        {
-          'text': '1224123531451345',
-          'text__cluster': {
-            'cluster_id': -1,
-            'cluster_membership_prob': None,
-            'cluster_title': None,
-            'category_id': None,
-            'category_membership_prob': None,
-            'category_title': None,
-          },
-        },
-      ],
+      'texts__cluster': {
+        'cluster_id': 0,
+        'cluster_membership_prob': 1.0,
+        'cluster_title': 'summarization',
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
+    },
+    {
+      'texts__cluster': {
+        'cluster_id': 1,
+        'cluster_membership_prob': 1.0,
+        'cluster_title': 'simplification',
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
     },
   ]
 
 
-def test_path_ending_with_repeated_errors(make_test_data: TestDataMaker) -> None:
-  texts: list[list[str]] = [['a', 'b'], ['c'], ['d']]
+def test_path_ending_with_repeated(make_test_data: TestDataMaker) -> None:
+  texts: list[list[str]] = [['hello', 'teacher'], ['professor'], ['hi']]
   dataset = make_test_data([{'texts': t} for t in texts])
 
-  with pytest.raises(
-    ValueError, match=re.escape("Path ('texts', '*') must end with a field name.")
-  ):
-    dataset.cluster('texts.*')
+  def topic_fn(docs: list[tuple[str, float]]) -> str:
+    if 'hello' in docs[0][0]:
+      return 'a_cluster'
+    elif 'teacher' in docs[0][0]:
+      return 'b_cluster'
+    return 'other'
+
+  dataset.cluster('texts.*', min_cluster_size=2, topic_fn=topic_fn)
+  rows = list(dataset.select_rows(combine_columns=True))
+  assert rows == [
+    {
+      'texts': ['hello', 'teacher'],
+      'texts__cluster': {
+        'cluster_id': -1,
+        'cluster_membership_prob': None,
+        'cluster_title': None,
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
+    },
+    {
+      'texts': ['professor'],
+      'texts__cluster': {
+        'cluster_id': -1,
+        'cluster_membership_prob': None,
+        'cluster_title': None,
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
+    },
+    {
+      'texts': ['hi'],
+      'texts__cluster': {
+        'cluster_id': -1,
+        'cluster_membership_prob': None,
+        'cluster_title': None,
+        'category_id': -1,
+        'category_membership_prob': None,
+        'category_title': None,
+      },
+    },
+  ]
 
 
 def test_clusters_with_fn(make_test_data: TestDataMaker) -> None:

--- a/lilac/data/cluster_test.py
+++ b/lilac/data/cluster_test.py
@@ -223,10 +223,10 @@ def test_nested_clusters(make_test_data: TestDataMaker) -> None:
 
   dataset.cluster('texts.*.text', min_cluster_size=2, topic_fn=topic_fn)
 
-  rows = list(dataset.select_rows(['texts__cluster'], combine_columns=True))
+  rows = list(dataset.select_rows(['texts_text__cluster'], combine_columns=True))
   assert rows == [
     {
-      'texts__cluster': {
+      'texts_text__cluster': {
         'cluster_id': 0,
         'cluster_membership_prob': 1.0,
         'cluster_title': 'summarization',
@@ -236,7 +236,7 @@ def test_nested_clusters(make_test_data: TestDataMaker) -> None:
       },
     },
     {
-      'texts__cluster': {
+      'texts_text__cluster': {
         'cluster_id': 1,
         'cluster_membership_prob': 1.0,
         'cluster_title': 'simplification',
@@ -246,7 +246,7 @@ def test_nested_clusters(make_test_data: TestDataMaker) -> None:
       },
     },
     {
-      'texts__cluster': {
+      'texts_text__cluster': {
         'cluster_id': 0,
         'cluster_membership_prob': 1.0,
         'cluster_title': 'summarization',
@@ -256,7 +256,7 @@ def test_nested_clusters(make_test_data: TestDataMaker) -> None:
       },
     },
     {
-      'texts__cluster': {
+      'texts_text__cluster': {
         'cluster_id': 1,
         'cluster_membership_prob': 1.0,
         'cluster_title': 'simplification',

--- a/lilac/data/clustering.py
+++ b/lilac/data/clustering.py
@@ -3,7 +3,7 @@ import functools
 import gc
 import random
 import threading
-from typing import Any, Callable, Iterator, Optional, Union
+from typing import Any, Callable, Iterator, Optional, Union, cast
 
 import instructor
 import modal
@@ -14,7 +14,7 @@ from pydantic import (
 )
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
-from ..batch_utils import compress_docs
+from ..batch_utils import compress_docs, flatten_iter_path
 from ..embeddings.jina import JinaV2Small
 from ..schema import (
   EMBEDDING_KEY,
@@ -33,7 +33,7 @@ from ..signal import (
 from ..tasks import TaskId, TaskInfo, get_task_manager
 from ..utils import DebugTimer
 from .dataset import Dataset
-from .dataset_utils import get_common_ancestor, get_sibling_output_path
+from .dataset_utils import get_callable_name, get_common_ancestor, get_sibling_output_path
 
 _SHORTEN_LEN = 400
 _TOP_K_CENTRAL_DOCS = 5
@@ -164,13 +164,6 @@ def cluster(
   path: Optional[PathTuple] = None
   if not callable(input):
     path = normalize_path(input)
-    # Make sure the input path ends with a field name so we can store the cluster enrichment as a
-    # sibling.
-    if path[-1] == PATH_WILDCARD:
-      raise ValueError(
-        'Clustering an array of primitives is not yet supported. '
-        f'Path {path} must end with a field name.'
-      )
   elif not output_path:
     raise ValueError('output_path must be provided if input is a function.')
 
@@ -181,19 +174,36 @@ def cluster(
     cluster_output_path = normalize_path(output_path)
   elif path:
     # The sibling output path is the same as the input path, but with a different suffix.
-    cluster_output_path = get_sibling_output_path(path, FIELD_SUFFIX)
+    index = 0
+    for i, path_part in enumerate(path):
+      if path_part == PATH_WILDCARD:
+        break
+      else:
+        index = i
+    *parent, sibling = path[: index + 1]
+    cluster_output_path = (*parent, f'{sibling}__{FIELD_SUFFIX}')
   else:
     raise ValueError('input must be provided.')
 
-  if not path:
-    assert callable(input), 'input must be a function at this point'
-    path = (*cluster_output_path[:-1], '__temp_cluster_text__')
-    temp_path_exists = schema.has_field(path)
-    if not temp_path_exists or overwrite:
-      # Since input is a function, map over the dataset to make a temporary column with that text.
-      if task_info:
-        task_info.message = 'Extracting text from items'
-      dataset.map(input, output_path=path, overwrite=overwrite)
+  # Extract the text from the input path into a temporary column.
+  input_path = path
+  path = (*cluster_output_path[:-1], '__temp_cluster_text__')
+  temp_path_exists = schema.has_field(path)
+  if not temp_path_exists or overwrite:
+    # Since input is a function, map over the dataset to make a temporary column with that text.
+    if task_info:
+      task_info.message = 'Extracting text from items'
+
+    def flatten_input(item: Item) -> str:
+      texts = flatten_iter_path(item, cast(PathTuple, input_path))
+      # Filter out Nones
+      texts = (t for t in texts if t)
+      # Deal with enriched items.
+      texts = (t[VALUE_KEY] if VALUE_KEY in t else t for t in texts)
+      return '\n'.join(texts)
+
+    map_fn = input if callable(input) else flatten_input
+    dataset.map(map_fn, output_path=path, overwrite=overwrite)
 
   clusters_exists = schema.has_field(cluster_output_path)
   if not clusters_exists or overwrite:
@@ -255,8 +265,6 @@ def cluster(
       membership_prob = cluster_info[CLUSTER_MEMBERSHIP_PROB] or 0
       if membership_prob == 0:
         continue
-      if VALUE_KEY in text:
-        text = text[VALUE_KEY]
       cluster_locks.setdefault(cluster_id, threading.Lock())
       groups.setdefault(cluster_id, []).append((text, membership_prob))
 
@@ -298,6 +306,9 @@ def cluster(
       # Providing schema to avoid inferring.
       schema=field('string'),
     )
+
+  # Delete the temporary text column.
+  dataset.delete_column(path)
 
   if category:
     return
@@ -361,12 +372,13 @@ def cluster(
         CATEGORY_MEMBERSHIP_PROB: 'float32',
         CATEGORY_TITLE: 'string',
       },
-      cluster=ClusterInfo(min_cluster_size=min_cluster_size, remote=remote),
+      cluster=ClusterInfo(
+        min_cluster_size=min_cluster_size,
+        remote=remote,
+        input_path=(get_callable_name(input),) if callable(input) else input_path,
+      ),
     ),
   )
-  # Delete the temporary text column.
-  if callable(input):
-    dataset.delete_column(path)
   # Delete the cluster titles.
   dataset.delete_column(title_output_path)
   # Delete the caterogy clusters.

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -471,7 +471,7 @@ class Dataset(abc.ABC):
       min_cluster_size: The minimum number of docs in a cluster.
       topic_fn: A function that returns a topic summary for each cluster. It takes a list of
         (doc, membership_score) tuples and returns a single topic. This is used to compute the topic
-        for a given cluster of docs. It defaults to a function that summarizes user's instructions.
+        for a given cluster of docs. It defaults to a function that summarizes user's requests.
       overwrite: Whether to overwrite an existing output.
       remote: Whether to run the clustering remotely on Lilac Garden.
       task_id: The TaskManager `task_id` for this process run. This is used to update the progress

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -113,7 +113,7 @@ from ..utils import (
   open_file,
 )
 from . import dataset
-from .clustering import cluster, summarize_instructions
+from .clustering import cluster, summarize_request
 from .dataset import (
   BINARY_OPS,
   DELETED_LABEL_NAME,
@@ -2708,8 +2708,10 @@ class DatasetDuckDB(Dataset):
       if manifest.data_schema.has_field(output_path):
         if overwrite:
           field = manifest.data_schema.get_field(output_path)
-          if field.map is None:
-            raise ValueError(f'{output_path} is not a map column so it cannot be overwritten.')
+          if field.map is None and field.cluster is None:
+            raise ValueError(
+              f'{output_path} is not a map/cluster column and cannot be overwritten.'
+            )
         else:
           raise ValueError(
             f'Cannot map to path "{output_path}" which already exists in the dataset. '
@@ -2842,7 +2844,7 @@ class DatasetDuckDB(Dataset):
     remote: bool = False,
     task_id: Optional[TaskId] = None,
   ) -> None:
-    topic_fn = topic_fn or summarize_instructions
+    topic_fn = topic_fn or summarize_request
     return cluster(
       self, input, output_path, min_cluster_size, topic_fn, overwrite, remote, task_id=task_id
     )

--- a/lilac/schema.py
+++ b/lilac/schema.py
@@ -244,6 +244,7 @@ class ClusterInfo(BaseModel):
 
   min_cluster_size: Optional[int] = None
   remote: Optional[bool] = None
+  input_path: Optional[PathTuple] = None
 
 
 class MapType(DataType):

--- a/web/blueprint/src/lib/components/schemaView/SchemaField.svelte
+++ b/web/blueprint/src/lib/components/schemaView/SchemaField.svelte
@@ -5,6 +5,8 @@
   import {computeSignalMutation, querySelectRowsSchema} from '$lib/queries/datasetQueries';
   import {querySignals} from '$lib/queries/signalQueries';
   import {
+    CLUSTER_CATEGORY_FIELD,
+    CLUSTER_TITLE_FIELD,
     PATH_WILDCARD,
     VALUE_KEY,
     childFields,
@@ -55,9 +57,6 @@
   $: isClusterRoot = isClusterRootField(field);
   $: isLabel = isLabelField(field);
   $: isSourceField = !isSignal && !isLabel;
-
-  const CLUSTER_CATEGORY_FIELD = 'category_title';
-  const CLUSTER_TITLE_FIELD = 'cluster_title';
 
   const signalMutation = computeSignalMutation();
   const datasetViewStore = getDatasetViewContext();

--- a/web/blueprint/src/lib/stores/datasetViewStore.ts
+++ b/web/blueprint/src/lib/stores/datasetViewStore.ts
@@ -1,4 +1,9 @@
 import {
+  CATEGORY_MEMBERSHIP_PROB,
+  CLUSTER_CATEGORY_FIELD,
+  CLUSTER_MEMBERSHIP_PROB,
+  CLUSTER_PARENT_SUFFIX,
+  CLUSTER_TITLE_FIELD,
   DELETED_LABEL_KEY,
   ROWID,
   isColumn,
@@ -378,12 +383,6 @@ export function getDatasetViewContext() {
   return getContext<DatasetViewStore>(DATASET_VIEW_CONTEXT);
 }
 
-const _CLUSTER_PARENT_SUFFIX = '__cluster';
-const _CLUSTER_FIELD_NAME = 'cluster_title';
-const _CATEGORY_FIELD_NAME = 'category_title';
-const _CLUSTER_MEMBERSHIP_PROB = 'cluster_membership_prob';
-const _CATEGORY_MEMBERSHIP_PROB = 'category_membership_prob';
-
 /**
  * Get the options to pass to the selectRows API call
  * based on the current state of the dataset view store
@@ -415,13 +414,13 @@ export function getSelectRowsOptions(
     if (
       options.sort_by == null &&
       parentFieldName != null &&
-      parentFieldName.endsWith(_CLUSTER_PARENT_SUFFIX) &&
-      (fieldName == _CLUSTER_FIELD_NAME || fieldName == _CATEGORY_FIELD_NAME)
+      parentFieldName.endsWith(CLUSTER_PARENT_SUFFIX) &&
+      (fieldName == CLUSTER_TITLE_FIELD || fieldName == CLUSTER_CATEGORY_FIELD)
     ) {
       const membershipProbPath = groupByPath
         .slice(0, -1)
         .concat(
-          fieldName == _CLUSTER_FIELD_NAME ? _CLUSTER_MEMBERSHIP_PROB : _CATEGORY_MEMBERSHIP_PROB
+          fieldName == CLUSTER_TITLE_FIELD ? CLUSTER_MEMBERSHIP_PROB : CATEGORY_MEMBERSHIP_PROB
         );
       options.sort_by = [membershipProbPath];
     }

--- a/web/lib/fastapi_client/models/ClusterInfo.ts
+++ b/web/lib/fastapi_client/models/ClusterInfo.ts
@@ -9,5 +9,6 @@
 export type ClusterInfo = {
     min_cluster_size?: (number | null);
     remote?: (boolean | null);
+    input_path?: (Array<string> | null);
 };
 

--- a/web/lib/src/schema.ts
+++ b/web/lib/src/schema.ts
@@ -19,6 +19,12 @@ export const VALUE_KEY = '__value__';
 export const SPAN_KEY = '__span__';
 export const DELETED_LABEL_KEY = '__deleted__';
 
+export const CLUSTER_PARENT_SUFFIX = '__cluster';
+export const CLUSTER_TITLE_FIELD = 'cluster_title';
+export const CLUSTER_CATEGORY_FIELD = 'category_title';
+export const CLUSTER_MEMBERSHIP_PROB = 'cluster_membership_prob';
+export const CATEGORY_MEMBERSHIP_PROB = 'category_membership_prob';
+
 export const SIGNAL_INPUT_TYPE_TO_VALID_DTYPES: Record<
   Exclude<SignalInputType, 'any'>,
   DataType[]


### PR DESCRIPTION
We can now compute clusters on conversations.*.input of copybara.

Capybara demo:
https://lilacai-daniel-staging.hf.space/datasets#local/capybara&viewPivot=true&pivot=%7B%22outerPath%22%3A%5B%22conversation__cluster%22%2C%22category_title%22%5D%2C%22innerPath%22%3A%5B%22conversation__cluster%22%2C%22cluster_title%22%5D%7D

Also:
- auto sort by membership prob when grouping by a special cluster/category
- improve the prompt for the cluster titles

<img width="715" alt="CleanShot 2024-01-09 at 19 28 27@2x" src="https://github.com/lilacai/lilac/assets/2294279/c6649a3f-89a4-4336-a0cb-28de9bb22428">
