### PR TITLE
Add an upload dataset script. Some other cleanups.

### DIFF
--- a/lilac/__init__.py
+++ b/lilac/__init__.py
@@ -11,7 +11,7 @@ from .config import (
 )
 from .data import *  # noqa: F403
 from .data.dataset_duckdb import DatasetDuckDB
-from .db_manager import get_dataset, set_default_dataset_cls
+from .db_manager import get_dataset, list_datasets, set_default_dataset_cls
 from .deploy import deploy_config, deploy_project
 from .embeddings import *  # noqa: F403
 from .env import *  # noqa: F403
@@ -49,6 +49,7 @@ __all__ = [
   'from_dicts',
   'from_huggingface',
   'get_dataset',
+  'list_datasets',
   'init',
   'span',
   'load',

--- a/lilac/cli.py
+++ b/lilac/cli.py
@@ -7,7 +7,7 @@ import click
 
 from . import __version__
 from .concepts.db_concept import DISK_CONCEPT_DB
-from .data.dataset_storage_utils import download
+from .data.dataset_storage_utils import download, upload
 from .deploy import deploy_project
 from .env import env, get_project_dir
 from .hf_docker_start import hf_docker_start
@@ -236,15 +236,66 @@ def deploy_project_command(
   'This can also be set via the `HF_ACCESS_TOKEN` environment flag.',
   type=str,
 )
+@click.option(
+  '--overwrite',
+  help='When true, overwrites any existing datasets with the same name.',
+  is_flag=True,
+  default=False,
+)
 def download_command(
   url_or_repo: str,
   project_dir: Optional[str],
   dataset_namespace: Optional[str],
   dataset_name: Optional[str],
   hf_token: Optional[str],
+  overwrite: Optional[bool] = False,
 ) -> None:
   """Download a Lilac dataset from HuggingFace."""
-  download(url_or_repo, project_dir, dataset_namespace, dataset_name)
+  download(url_or_repo, project_dir, dataset_namespace, dataset_name, hf_token, overwrite)
+
+
+@click.command()
+@click.argument(
+  'dataset',
+  required=True,
+)
+@click.option(
+  '--project_dir',
+  help='The project directory to use for the demo. Defaults to `env.LILAC_PROJECT_DIR`.',
+  type=str,
+)
+@click.option(
+  '--url_or_repo',
+  help='The repo id, or full dataset URL, to use for uploading. For example: lilacai/my-dataset.',
+  type=str,
+)
+@click.option(
+  '--public',
+  help='When true, makes the dataset public.',
+  is_flag=True,
+  default=False,
+)
+@click.option(
+  '--readme_suffix',
+  help='A suffix string for the readme file.',
+  type=str,
+)
+@click.option(
+  '--hf_token',
+  help='The HuggingFace access token to use when writing private datasets. '
+  'This can also be set via the `HF_ACCESS_TOKEN` environment flag.',
+  type=str,
+)
+def upload_command(
+  dataset: str,
+  project_dir: Optional[str],
+  url_or_repo: Optional[str] = None,
+  public: Optional[bool] = False,
+  readme_suffix: Optional[str] = None,
+  hf_token: Optional[str] = None,
+) -> None:
+  """Upload a Lilac dataset to HuggingFace."""
+  upload(dataset, project_dir, url_or_repo, public, readme_suffix, hf_token)
 
 
 @click.command()
@@ -268,6 +319,7 @@ cli.add_command(start)
 cli.add_command(deploy_project_command, name='deploy-project')
 cli.add_command(hf_docker_start_command, name='hf-docker-start')
 cli.add_command(download_command, name='download')
+cli.add_command(upload_command, name='upload')
 cli.add_command(concepts)
 
 if __name__ == '__main__':

--- a/lilac/data/__init__.py
+++ b/lilac/data/__init__.py
@@ -7,6 +7,7 @@ from .dataset import (
   Filter,
   FilterLike,
   FilterOp,
+  GroupsSortBy,
   KeywordSearch,
   ListOp,
   MetadataSearch,
@@ -14,6 +15,7 @@ from .dataset import (
   SelectGroupsResult,
   SelectRowsResult,
   SemanticSearch,
+  SortOrder,
   UnaryOp,
 )
 
@@ -34,4 +36,6 @@ __all__ = [
   'SelectRowsResult',
   'SelectGroupsResult',
   'FilterLike',
+  'SortOrder',
+  'GroupsSortBy',
 ]

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -627,6 +627,10 @@ class Dataset(abc.ABC):
     row_ids: Optional[Sequence[str]] = None,
     searches: Optional[Sequence[Search]] = None,
     filters: Optional[Sequence[FilterLike]] = None,
+    sort_by: Optional[Sequence[Path]] = None,
+    sort_order: Optional[SortOrder] = SortOrder.DESC,
+    limit: Optional[int] = None,
+    offset: Optional[int] = 0,
     include_deleted: bool = False,
     value: Optional[str] = 'true',
   ) -> int:
@@ -668,6 +672,10 @@ class Dataset(abc.ABC):
     row_ids: Optional[Sequence[str]] = None,
     searches: Optional[Sequence[Search]] = None,
     filters: Optional[Sequence[FilterLike]] = None,
+    sort_by: Optional[Sequence[Path]] = None,
+    sort_order: Optional[SortOrder] = SortOrder.DESC,
+    limit: Optional[int] = None,
+    offset: Optional[int] = 0,
     include_deleted: bool = False,
   ) -> int:
     """Removes labels from a row, or a set of rows defined by searches and filters.
@@ -681,24 +689,51 @@ class Dataset(abc.ABC):
     row_ids: Optional[Sequence[str]] = None,
     searches: Optional[Sequence[Search]] = None,
     filters: Optional[Sequence[FilterLike]] = None,
+    sort_by: Optional[Sequence[Path]] = None,
+    sort_order: Optional[SortOrder] = SortOrder.DESC,
+    limit: Optional[int] = None,
+    offset: Optional[int] = 0,
   ) -> int:
     """Deletes rows from the dataset.
 
     Returns the number of deleted rows.
     """
-    return self.add_labels(DELETED_LABEL_NAME, row_ids, searches, filters)
+    return self.add_labels(
+      name=DELETED_LABEL_NAME,
+      row_ids=row_ids,
+      searches=searches,
+      filters=filters,
+      sort_by=sort_by,
+      sort_order=sort_order,
+      limit=limit,
+      offset=offset,
+    )
 
   def restore_rows(
     self,
     row_ids: Optional[Sequence[str]] = None,
     searches: Optional[Sequence[Search]] = None,
     filters: Optional[Sequence[FilterLike]] = None,
+    sort_by: Optional[Sequence[Path]] = None,
+    sort_order: Optional[SortOrder] = SortOrder.DESC,
+    limit: Optional[int] = None,
+    offset: Optional[int] = 0,
   ) -> int:
     """Undeletes rows from the dataset.
 
     Returns the number of restored rows.
     """
-    return self.remove_labels(DELETED_LABEL_NAME, row_ids, searches, filters, include_deleted=True)
+    return self.remove_labels(
+      DELETED_LABEL_NAME,
+      row_ids=row_ids,
+      searches=searches,
+      filters=filters,
+      sort_by=sort_by,
+      sort_order=sort_order,
+      limit=limit,
+      offset=offset,
+      include_deleted=True,
+    )
 
   @abc.abstractmethod
   def stats(self, leaf_path: Path, include_deleted: bool = False) -> StatsResult:

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -2140,6 +2140,10 @@ class DatasetDuckDB(Dataset):
     row_ids: Optional[Sequence[str]] = None,
     searches: Optional[Sequence[Search]] = None,
     filters: Optional[Sequence[FilterLike]] = None,
+    sort_by: Optional[Sequence[Path]] = None,
+    sort_order: Optional[SortOrder] = SortOrder.DESC,
+    limit: Optional[int] = None,
+    offset: Optional[int] = 0,
     include_deleted: bool = False,
     value: Optional[str] = 'true',
   ) -> int:
@@ -2152,7 +2156,14 @@ class DatasetDuckDB(Dataset):
     insert_row_ids = (
       row[ROWID]
       for row in self.select_rows(
-        columns=[ROWID], searches=searches, filters=filters, include_deleted=include_deleted
+        columns=[ROWID],
+        searches=searches,
+        filters=filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        offset=offset,
+        include_deleted=include_deleted,
       )
     )
 
@@ -2206,6 +2217,10 @@ class DatasetDuckDB(Dataset):
     row_ids: Optional[Sequence[str]] = None,
     searches: Optional[Sequence[Search]] = None,
     filters: Optional[Sequence[FilterLike]] = None,
+    sort_by: Optional[Sequence[Path]] = None,
+    sort_order: Optional[SortOrder] = SortOrder.DESC,
+    limit: Optional[int] = None,
+    offset: Optional[int] = 0,
     include_deleted: bool = False,
   ) -> int:
     # Check if the label file exists.
@@ -2222,7 +2237,14 @@ class DatasetDuckDB(Dataset):
     remove_row_ids = [
       row[ROWID]
       for row in self.select_rows(
-        columns=[ROWID], searches=searches, filters=filters, include_deleted=include_deleted
+        columns=[ROWID],
+        searches=searches,
+        filters=filters,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        limit=limit,
+        offset=offset,
+        include_deleted=include_deleted,
       )
     ]
 

--- a/lilac/data/dataset_storage_utils.py
+++ b/lilac/data/dataset_storage_utils.py
@@ -28,7 +28,7 @@ def download(
   dataset_namespace: Optional[str] = 'local',
   dataset_name: Optional[str] = None,
   hf_token: Optional[str] = None,
-  overwrite: bool = False,
+  overwrite: Optional[bool] = False,
 ) -> None:
   """Download a Lilac dataset from HuggingFace.
 

--- a/lilac/data/dataset_storage_utils.py
+++ b/lilac/data/dataset_storage_utils.py
@@ -5,12 +5,21 @@ import os
 import shutil
 from typing import Optional
 
-from ..config import DatasetConfig
-from ..db_manager import get_dataset
+from ..config import DatasetConfig, get_dataset_config
+from ..db_manager import get_dataset, list_datasets
 from ..env import env, get_project_dir
-from ..project import add_project_dataset_config
-from ..utils import get_datasets_dir, get_lilac_cache_dir, read_yaml
+from ..project import add_project_dataset_config, read_project_config
+from ..sources.huggingface_source import HuggingFaceSource
+from ..utils import (
+  get_dataset_output_dir,
+  get_datasets_dir,
+  get_lilac_cache_dir,
+  log,
+  read_yaml,
+  to_yaml,
+)
 from .dataset import config_from_dataset
+from .dataset_duckdb import DUCKDB_CACHE_FILE
 
 
 def download(
@@ -19,6 +28,7 @@ def download(
   dataset_namespace: Optional[str] = 'local',
   dataset_name: Optional[str] = None,
   hf_token: Optional[str] = None,
+  overwrite: bool = False,
 ) -> None:
   """Download a Lilac dataset from HuggingFace.
 
@@ -32,6 +42,7 @@ def download(
     dataset_name: The local dataset name to use. Defaults to the name of the HuggingFace dataset.
     hf_token: The HuggingFace access token to use when making datasets private. This can also be set
       via the `HF_ACCESS_TOKEN` environment flag.
+    overwrite: Whether to overwrite the dataset if it already exists.
   """
   try:
     from huggingface_hub import snapshot_download
@@ -69,6 +80,19 @@ def download(
   dataset_namespace = dataset_namespace or remote_namespace
   dataset_name = dataset_name or remote_name
 
+  # Check the dataset doesn't already exist.
+  datasets = list_datasets(project_dir)
+  for dataset in datasets:
+    if dataset.namespace == dataset_namespace and dataset.dataset_name == dataset_name:
+      if not overwrite:
+        raise ValueError(
+          f'Dataset {dataset_namespace}/{dataset_name} already exists. '
+          'Use --overwrite to overwrite it.'
+        )
+      else:
+        print(f'Overwriting existing dataset {dataset_namespace}/{dataset_name}')
+        shutil.rmtree(os.path.join(datasets_dir, dataset_namespace, dataset_name))
+
   dataset_dir = os.path.join(datasets_dir, dataset_namespace, dataset_name)
   os.makedirs(dataset_dir, exist_ok=True)
 
@@ -84,3 +108,131 @@ def download(
   add_project_dataset_config(dataset_config, project_dir, overwrite=True)
 
   print('Wrote dataset to', dataset_dir)
+
+
+def upload(
+  dataset: str,
+  project_dir: Optional[str] = None,
+  url_or_repo: Optional[str] = None,
+  public: Optional[bool] = False,
+  readme_suffix: Optional[str] = None,
+  hf_token: Optional[str] = None,
+) -> None:
+  """Uploads local datasets to HuggingFace datasets.
+
+  Args:
+    project_dir: The project directory to use for the demo. Defaults to `env.LILAC_PROJECT_DIR`
+      which can be set with `ll.set_project_dir()`.
+    dataset: The dataset to upload. Can be a local dataset name, or a namespace/dataset name.
+    url_or_repo: The HuggingFace dataset repo ID to use. If not specified, will be automatically
+      generated.
+    public: Whether to make the dataset public. Defaults to False.
+    readme_suffix: A suffix to add to the README.md file. Defaults to None.
+    hf_token: The HuggingFace access token to use when making datasets private. This can also be set
+      via the `HF_ACCESS_TOKEN` environment flag.
+  """
+  if not public:
+    public = False
+  project_dir = project_dir or get_project_dir()
+
+  try:
+    from huggingface_hub import HfApi
+
+  except ImportError:
+    raise ImportError(
+      'Could not import the "huggingface_hub" python package. '
+      'Please install it with `pip install "huggingface_hub".'
+    )
+  hf_api = HfApi(token=env('HF_ACCESS_TOKEN', hf_token))
+
+  log('Uploading dataset: ', dataset)
+
+  namespace, name = dataset.split('/')
+  if url_or_repo:
+    repo_id = url_or_repo.removeprefix('https://huggingface.co/datasets/')
+  else:
+    repo_id = _dataset_repo_id(dataset)
+
+  dataset_link = f'https://huggingface.co/datasets/{repo_id}'
+  print(f'Uploading "{dataset}" to HuggingFace dataset repo ' f'{dataset_link}')
+
+  hf_api.create_repo(
+    repo_id,
+    repo_type='dataset',
+    private=not public,
+    exist_ok=True,
+  )
+  dataset_output_dir = get_dataset_output_dir(project_dir, namespace, name)
+  hf_api.upload_folder(
+    folder_path=dataset_output_dir,
+    # The path in the remote doesn't os.path.join as it is specific to Linux.
+    path_in_repo=f'{namespace}/{name}',
+    repo_id=repo_id,
+    repo_type='dataset',
+    # Delete all data on the server.
+    delete_patterns='*',
+    ignore_patterns=[DUCKDB_CACHE_FILE + '*'],
+  )
+
+  config = read_project_config(project_dir)
+  dataset_config = get_dataset_config(config, namespace, name)
+  if dataset_config is None:
+    raise ValueError(f'Dataset {namespace}/{name} not found in project config.')
+
+  original_dataset_link = ''
+  if isinstance(dataset_config.source, HuggingFaceSource):
+    original_dataset_link = f'https://huggingface.co/datasets/{dataset_config.source.dataset_name}'
+
+  dataset_config_yaml = to_yaml(
+    dataset_config.model_dump(exclude_defaults=True, exclude_none=True, exclude_unset=True)
+  )
+  hf_api.upload_file(
+    path_or_fileobj=dataset_config_yaml.encode(),
+    path_in_repo='dataset_config.yml',
+    repo_id=repo_id,
+    repo_type='dataset',
+  )
+
+  readme = (
+    '---\n'
+    'tags:\n'
+    '- Lilac\n'
+    '---\n'
+    f'# {dataset}\n'
+    'This dataset is a [Lilac](http://lilacml.com) processed dataset. '
+    + (
+      f'Original dataset: [{original_dataset_link}]({original_dataset_link})\n\n'
+      if original_dataset_link != ''
+      else ''
+    )
+    + 'To download the dataset to a local directory:\n\n'
+    '```bash\n'
+    f'lilac download {repo_id}\n'
+    '```\n\n'
+    'or from python with:\n\n'
+    '```py\n'
+    f'll.download("{url_or_repo}")\n'
+    '```\n\n' + (readme_suffix or '')
+  ).encode()
+  hf_api.upload_file(
+    path_or_fileobj=readme,
+    path_in_repo='README.md',
+    repo_id=repo_id,
+    repo_type='dataset',
+  )
+
+  log(
+    f'\nDataset "{dataset}" uploaded to {dataset_link}\n\n'
+    'Download the dataset with: \n\n'
+    f'$: lilac download {repo_id}\n\n'
+    'or from python with: \n\n'
+    '```py\n'
+    f'll.download("{url_or_repo}")\n'
+    '```'
+  )
+
+
+def _dataset_repo_id(dataset: str) -> str:
+  """Returns the dataset repo ID from a dataset."""
+  namespace, dataset_name = dataset.split('/')
+  return f'lilac-{namespace}-{dataset_name}'

--- a/lilac/deploy.py
+++ b/lilac/deploy.py
@@ -11,12 +11,11 @@ from importlib import resources
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from .concepts.db_concept import CONCEPTS_DIR, DiskConceptDB, get_concept_output_dir
-from .config import Config, get_dataset_config
-from .data.dataset_duckdb import DUCKDB_CACHE_FILE
+from .config import Config
+from .data.dataset_storage_utils import upload
 from .env import get_project_dir
 from .project import PROJECT_CONFIG_FILENAME, read_project_config, write_project_config
-from .sources.huggingface_source import HuggingFaceSource
-from .utils import get_dataset_output_dir, get_hf_dataset_repo_id, get_lilac_cache_dir, log, to_yaml
+from .utils import get_hf_dataset_repo_id, get_lilac_cache_dir, log, to_yaml
 
 HF_SPACE_DIR = '.hf_spaces'
 PY_DIST_DIR = 'dist'
@@ -449,68 +448,12 @@ def _upload_datasets(
     namespace, name = d.split('/')
     dataset_repo_id = get_hf_dataset_repo_id(hf_space_org, hf_space_name, namespace, name)
 
-    print(
-      f'Uploading "{d}" to HuggingFace dataset repo '
-      f'https://huggingface.co/datasets/{dataset_repo_id}\n'
-    )
-
-    hf_api.create_repo(
-      dataset_repo_id,
-      repo_type='dataset',
-      private=not make_datasets_public,
-      exist_ok=True,
-    )
-    dataset_output_dir = get_dataset_output_dir(project_dir, namespace, name)
-    hf_api.upload_folder(
-      folder_path=dataset_output_dir,
-      # The path in the remote doesn't os.path.join as it is specific to Linux.
-      path_in_repo=f'{namespace}/{name}',
-      repo_id=dataset_repo_id,
-      repo_type='dataset',
-      # Delete all data on the server.
-      delete_patterns='*',
-      ignore_patterns=[DUCKDB_CACHE_FILE + '*'],
-    )
-
-    config = read_project_config(project_dir)
-    dataset_config = get_dataset_config(config, namespace, name)
-    if dataset_config is None:
-      raise ValueError(f'Dataset {namespace}/{name} not found in project config.')
-
-    dataset_link = ''
-    if isinstance(dataset_config.source, HuggingFaceSource):
-      dataset_link = f'https://huggingface.co/datasets/{dataset_config.source.dataset_name}'
-
-    dataset_config_yaml = to_yaml(
-      dataset_config.model_dump(exclude_defaults=True, exclude_none=True, exclude_unset=True)
-    )
-    hf_api.upload_file(
-      path_or_fileobj=dataset_config_yaml.encode(),
-      path_in_repo='dataset_config.yml',
-      repo_id=dataset_repo_id,
-      repo_type='dataset',
-    )
-
-    readme = (
-      '---\n'
-      'tags:\n'
-      '- Lilac\n'
-      '---\n'
-      f'# {config}\n'
-      'This dataset is a [Lilac](http://lilacml.com) processed dataset.'
-      # TODO: add this as extra
-      f'[huggingface.co/spaces/{hf_space_org}/{hf_space_name}]'
-      f'(https://huggingface.co/spaces/{hf_space_org}/{hf_space_name}).\n\n'
-      f'You can download the dataset locally with `lilac download {namespace}/{name}`.\n\n'
-      + (f'Original dataset: [{dataset_link}]({dataset_link})\n\n' if dataset_link != '' else '')
-      + 'Lilac dataset config:\n'
-      f'```{dataset_config_yaml}```\n\n'
-    ).encode()
-    hf_api.upload_file(
-      path_or_fileobj=readme,
-      path_in_repo='README.md',
-      repo_id=dataset_repo_id,
-      repo_type='dataset',
+    upload(
+      dataset=d,
+      project_dir=project_dir,
+      url_or_repo=dataset_repo_id,
+      public=make_datasets_public,
+      hf_token=hf_api.token,
     )
 
     lilac_hf_datasets.append(dataset_repo_id)

--- a/lilac/deploy.py
+++ b/lilac/deploy.py
@@ -496,7 +496,9 @@ def _upload_datasets(
       'tags:\n'
       '- Lilac\n'
       '---\n'
-      'This dataset is a [Lilac](http://lilacml.com) processed dataset for a HuggingFace Space: '
+      f'# {config}\n'
+      'This dataset is a [Lilac](http://lilacml.com) processed dataset.'
+      # TODO: add this as extra
       f'[huggingface.co/spaces/{hf_space_org}/{hf_space_name}]'
       f'(https://huggingface.co/spaces/{hf_space_org}/{hf_space_name}).\n\n'
       f'You can download the dataset locally with `lilac download {namespace}/{name}`.\n\n'

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,9 @@ filterwarnings =
     ignore::DeprecationWarning:pkg_resources.*:
     ignore::DeprecationWarning:google.rpc.*:
     ignore::DeprecationWarning:scipy.*:
-    ignore:`FieldValidationInfo` is deprecated:DeprecationWarning
+    ignore::DeprecationWarning:huggingface_hub.*:
+    ignore::DeprecationWarning:pydantic_core.*:
+    ignore:PydanticDeprecatedSince20:DeprecationWarning
 markers =
     largedownload: Marks a test as having a large download. Wont run on github. (deselect with '-m "not largedownload"')
 asyncio_mode = auto

--- a/web/blueprint/src/lib/components/datasetView/DatasetPivotViewer.svelte
+++ b/web/blueprint/src/lib/components/datasetView/DatasetPivotViewer.svelte
@@ -234,7 +234,7 @@
                   {:else}<span>{highlight.text}</span>{/if}
                 {/each}
               </div>
-              <div class="flex flex-col font-light">
+              <div class="flex w-full flex-col items-center font-light">
                 <span class="ml-2 text-xl text-neutral-800">
                   {group.percentage}%
                 </span>
@@ -243,7 +243,7 @@
                 </span>
               </div>
               <div class="">
-                <a class="flex flex-row" href={groupLink}>
+                <a class="flex flex-row" href={groupLink} target="_blank">
                   Explore
                   <svg
                     class="ms-2 h-3 w-3 rtl:rotate-[270deg]"

--- a/web/blueprint/src/lib/stores/datasetViewStore.ts
+++ b/web/blueprint/src/lib/stores/datasetViewStore.ts
@@ -362,6 +362,9 @@ export function createDatasetViewStore(
     openPivotViewer(outerPath: Path, innerPath: Path) {
       update(state => {
         state.viewPivot = true;
+        state.query.filters = undefined;
+        state.query.searches = undefined;
+        state.groupBy = undefined;
         state.pivot = {outerPath: outerPath, innerPath: innerPath};
         return state;
       });


### PR DESCRIPTION
Python:
- Add limit, offset, filter to labels & deleting. This allows us to filter by a cluster group, sort by membership prob, limit=N, and add a label to it
- Export useful methods to lilac public API.

UI:
- Remove filters, searches, group by when clicking the cluster button in the UI

Example dataset: https://huggingface.co/datasets/lilacai/hermes-cluster-sample

<img width="1203" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/162f32e8-bc50-42d2-8dbf-72d8275245d6">
