### PR TITLE
Optimize the cluster view page to reduce number of requests

### DIFF
--- a/web/blueprint/src/lib/components/datasetView/SingleItemSelectRows.svelte
+++ b/web/blueprint/src/lib/components/datasetView/SingleItemSelectRows.svelte
@@ -7,6 +7,7 @@
   } from '$lib/stores/datasetViewStore';
   import {ROWID, type SelectRowsResponse} from '$lilac';
   export let limit: number;
+  export let offset: number | undefined = undefined;
   export let rowsResponse: SelectRowsResponse | undefined = undefined;
 
   const store = getDatasetViewContext();
@@ -24,6 +25,7 @@
       ...selectOptions,
       columns: [ROWID],
       limit,
+      offset,
       // Sort by ROWID on top of any other sort_by option to ensure that the result order is stable.
       sort_by: [...(selectOptions.sort_by || []), ROWID]
     },

--- a/web/blueprint/src/lib/stores/datasetViewStore.ts
+++ b/web/blueprint/src/lib/stores/datasetViewStore.ts
@@ -365,6 +365,7 @@ export function createDatasetViewStore(
         state.query.filters = undefined;
         state.query.searches = undefined;
         state.groupBy = undefined;
+        state.rowId = undefined;
         state.pivot = {outerPath: outerPath, innerPath: innerPath};
         return state;
       });

--- a/web/lib/fastapi_client/models/DatasetFormat.ts
+++ b/web/lib/fastapi_client/models/DatasetFormat.ts
@@ -3,14 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { Schema } from './Schema';
-
 /**
  * A dataset format.
  */
-export type DatasetFormat = {
-    name: string;
-    data_schema: Schema;
-    title_slots?: Array<any[]>;
-};
-
+export type DatasetFormat = Record<string, any>;


### PR DESCRIPTION
Fetch only the next 1 row, instead of the next 10/20. Also most requests are now where rowid in (single_id) , which brian will rewrite into an equals query server-side.