### PR TITLE
Fix some small UI bugs.

### DIFF
--- a/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ItemMediaTextContent.svelte
@@ -135,7 +135,8 @@
     editor = monaco.editor.create(editorContainer, {
       ...MONACO_OPTIONS,
       lineNumbers: 'on',
-      glyphMargin: true,
+      // GlyphMargins are off because they cause an issue where the minimap overlaps the text.
+      glyphMargin: false,
       lineNumbersMinChars: 3,
       renderLineHighlight: 'none',
       minimap: {
@@ -642,12 +643,12 @@
 </script>
 
 <!-- For reasons unknown to me, the -ml-6 is required to make the autolayout of monaco react. -->
-<div class="relative -ml-6 flex h-fit w-full flex-col gap-x-4">
+<div class="relative left-16 -ml-10 flex h-fit w-full flex-col gap-x-4">
   {#if !editorReady}
-    <div class="ml-6 w-full"><SkeletonText class="ml-6 w-full " lines={3} /></div>
+    <div class="w-full"><SkeletonText class="ml-4 w-full " lines={3} /></div>
   {/if}
   <div
-    class="editor-container ml-6 h-64"
+    class="editor-container h-64"
     class:hidden
     bind:this={editorContainer}
     class:invisible={!editorReady}


### PR DESCRIPTION
- Turn glyph margins off for monaco which causes the minimap to overlap the text.
- Fix an issue with negative margin overlapping the expand button.
- Speed up the expand metadata button (somehow this is related to the margin... literally do not understand why)

https://huggingface.co/spaces/lilacai/nikhil_staging