### PR TITLE
Add support for loading custom embeddings.

### DIFF
--- a/docs/datasets/dataset_concepts.md
+++ b/docs/datasets/dataset_concepts.md
@@ -5,33 +5,12 @@ to a concept.
 
 ## From the UI
 
-### Step 1: Compute an embedding index
+Before we can apply a concept to a dataset, we need to compute an embedding index. See
+[Compute embeddings](./dataset_embeddings.md) for details.
 
-Before we can use conceptual search, we first must compute an embedding index for the field of
-interest. See [Embeddings](../embeddings/embeddings.md) for details on choosing an embedding.
+### Search by concept
 
-```{important}
-Embedding indexes can be expensive to compute, however this is a one-time task and enables you to search by any concept once it's computed.
-```
-
-We can compute an embedding index with one of two approaches:
-
-#### 1a. From the search box
-
-From the search box, we can choose a column and an embedding. Then we can click the blue gear icon
-to compute the index!
-
-<img src="../_static/dataset/dataset_search_compute.png"></img>
-
-#### 1b. From the schema
-
-From the schema, we can choose the field's hamburger menu to click "Compute Embedding".
-
-<img width=360 src="../_static/dataset/dataset_schema_compute_embedding.png"></img>
-
-### Step 2: Search by concept
-
-Once the embedding index has been computed, we can now use the search box to search by a concept:
+Once an embedding index has been computed, we can now use the search box to search by a concept:
 
 <img width=240 src="../_static/dataset/dataset_search_concept.png"></img>
 
@@ -40,7 +19,7 @@ will be highlighted according to their concept score:
 
 <img src="../_static/dataset/dataset_search_concept_results.png"></img>
 
-### (Optional) Step 3: Compute the concept for the whole column
+### Compute the concept for the whole column
 
 Search by concept does not produce a score for every item in the dataset. If we want to add a score
 for every item, click the blue "compute" chip next to the preview in the schema.

--- a/docs/datasets/dataset_embeddings.md
+++ b/docs/datasets/dataset_embeddings.md
@@ -1,0 +1,162 @@
+# Compute or load embeddings
+
+Indexing data with embeddings allows us to semantically or conceptually search text data. This guide
+will show you how to compute an embedding over a dataset. For more details on chosing an embedding,
+see [Embeddings](../embeddings/embeddings.md).
+
+## From the UI
+
+```{important}
+Embedding indexes can be expensive to compute, however this is a one-time task and enables you to
+search semantically, or by concept once computed.
+```
+
+We can compute an embedding index with one of two approaches:
+
+### 1a. From the search box
+
+From the search box, we can choose a column and an embedding. Then we can click the blue gear icon
+to compute the index!
+
+<img src="../_static/dataset/dataset_search_compute.png"></img>
+
+### 1b. From the schema
+
+From the schema, we can choose the field's hamburger menu to click "Compute Embedding".
+
+<img width=360 src="../_static/dataset/dataset_schema_compute_embedding.png"></img>
+
+## From Python
+
+From Python, we can compute embedding indexes, or load from an external vector store.
+
+### Computing embeddings in Lilac
+
+We can compute embeddings with registered embeddings by using [](#Dataset.compute_embedding). For
+more details on chosing an embedding, see [Embeddings](../embeddings/embeddings.md).
+
+Let's compute `gte-small` over the `text` field:
+
+```python
+dataset = ll.get_dataset('local', 'imdb')
+dataset.compute_embedding('gte-small', path='text')
+```
+
+### Custom embeddings
+
+Lilac also allows you to register your own embedding function, and/or load your own embeddings from
+an existing vector store.
+
+We have an
+[accompanying notebook](https://github.com/lilacai/lilac/blob/main/notebooks/CustomEmbeddings.ipynb)
+for this workflow.
+
+To do this, we first must register a custom embedding function so that we can compute embeddings on
+future data.
+
+To demonstrate this, we'll load an embedding model from HuggingFace SentenceTransformers, and wrap
+it in a custom Lilac embedding class.
+
+```py
+embedding_model = SentenceTransformer('thenlper/gte-small')
+
+
+def _embed(text):
+  # Call the gte-small embedding model.
+  return np.array(embedding_model.encode(text))
+
+
+# Make an embedding class.
+class MyEmbedding(ll.TextEmbeddingSignal):
+  name = 'my_embedding'
+
+  def compute(self, data):
+    for text in data:
+      embedding = _embed(text)
+      # Yield a full chunk embedding. If you want to chunk your text, yield an array here.
+      yield [ll.chunk_embedding(0, len(text), embedding)]
+
+
+
+# Register the embedding under 'my_embedding' so it can be used by Lilac.
+ll.register_embedding(MyEmbedding, exists_ok=True)
+```
+
+Once we've registered the embedding, we can test it out.
+
+```py
+print('Testing the embedding on a single item...')
+print(next(MyEmbedding().compute(['This is some text'])))
+```
+
+Output:
+
+```py
+[{'__span__': {'start': 0, 'end': 17}, 'embedding': array([-4.39735241e-02, -9.28446930e-03,  4.57611308e-02, -3.19548771e-02,...
+```
+
+We can now compute this embedding from the UI or python, like above.
+
+#### Loading pre-computed embeddings
+
+We can also load pre-computed embeddings from an existing vector store by using the
+[](Dataset.load_embeddings) method.
+
+Let's first make a dummy vector store, just a simple dictionary.
+
+```py
+items = [
+  {'id': '0_', 'text': 'This is some fake data'},
+  {'id': '1_', 'text': 'This is some more fake data'},
+  {'id': '2_', 'text': 'This is even more fake data'},
+  {'id': '3_', 'text': 'I love plants'},
+]
+
+vector_store = {}
+for item in items:
+  vector_store[item['id']] = _embed(item['text'])
+```
+
+Now let's load the embeddings. We'll use a custom lambda function that will read the id from the
+dataset, and look it up in our vector store.
+
+```py
+ds = ll.from_dicts('local', 'load_embedding', items)
+
+# Load the embeddings into Lilac.
+def _load_embedding(item):
+  return vector_store[item['id']]
+
+# Load the embeddings into Lilac.
+ds.load_embedding(
+  load_fn=_load_embedding, index_path='text', embedding='my_embedding', overwrite=True
+)
+```
+
+Embeddings are now loaded, and can be used from the UI or from python.
+
+```py
+# Select rows using a semantic search.
+rows = ds.select_rows(
+  ['text'],
+  searches=[
+    ll.SemanticSearch(path='text', query='This is some data', embedding='my_embedding'),
+  ],
+)
+
+for row in rows:
+  print(
+    row['text'],
+    row['text.semantic_similarity(embedding=my_embedding,query=This is some data)'][0]['score'],
+  )
+```
+
+Output:
+
+```
+Computing signal "semantic_similarity" on local/load_embedding:('text',) took 0.016s.
+This is some fake data 0.9254916310310364
+This is some more fake data 0.9084776043891907
+This is even more fake data 0.8841889500617981
+I love plants 0.7808101177215576
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@
    datasets/dataset_delete_rows.md
    datasets/dataset_edit.md
    datasets/dataset_labels.md
+   datasets/dataset_embeddings.md
    datasets/dataset_concepts.md
    datasets/dataset_signals.md
    datasets/dataset_query.md

--- a/lilac/__init__.py
+++ b/lilac/__init__.py
@@ -27,6 +27,7 @@ from .schema import *  # noqa: F403
 from .schema import Field, SpanVector, chunk_embedding, span
 from .server import start_server, stop_server
 from .signals import *  # noqa: F403
+from .signals import register_embedding, register_signal
 from .source import Source
 from .sources import *  # noqa: F403
 from .splitters import *  # noqa: F403
@@ -75,4 +76,6 @@ __all__ = [
   'OpenChat',
   'download',
   'upload',
+  'register_embedding',
+  'register_signal',
 ]

--- a/lilac/__init__.py
+++ b/lilac/__init__.py
@@ -24,7 +24,7 @@ from .load_dataset import create_dataset, from_dicts, from_huggingface
 from .project import init
 from .rag import *  # noqa: F403
 from .schema import *  # noqa: F403
-from .schema import Field, SpanVector, span
+from .schema import Field, SpanVector, chunk_embedding, span
 from .server import start_server, stop_server
 from .signals import *  # noqa: F403
 from .source import Source
@@ -55,6 +55,7 @@ __all__ = [
   'list_datasets',
   'init',
   'span',
+  'chunk_embedding',
   'load',
   'set_project_dir',
   'get_project_dir',

--- a/lilac/cli.py
+++ b/lilac/cli.py
@@ -14,6 +14,7 @@ from .hf_docker_start import hf_docker_start
 from .load import load
 from .project import dir_is_project, init, project_dir_from_args
 from .server import start_server
+from .utils import log
 
 
 @click.command()
@@ -95,7 +96,7 @@ def load_command(project_dir: str, config_path: str, overwrite: bool) -> None:
 @click.command()
 def version() -> None:
   """Prints the version of Lilac."""
-  print(__version__)
+  log(__version__)
 
 
 @click.command()
@@ -301,7 +302,7 @@ def upload_command(
 @click.command()
 def concepts() -> None:
   """Lists lilac concepts."""
-  print(DISK_CONCEPT_DB.list())
+  log(DISK_CONCEPT_DB.list())
 
 
 @click.group()

--- a/lilac/concepts/db_concept_test.py
+++ b/lilac/concepts/db_concept_test.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 
 from ..data.dataset_duckdb import DatasetDuckDB
 from ..db_manager import set_default_dataset_cls
-from ..schema import Item, RichData, lilac_embedding
+from ..schema import Item, RichData, chunk_embedding
 from ..signal import TextEmbeddingSignal, clear_signal_registry, register_signal
 from .concept import (
   DRAFT_MAIN,
@@ -64,7 +64,7 @@ class TestEmbedding(TextEmbeddingSignal):
     for example in data:
       if example not in EMBEDDING_MAP:
         raise ValueError(f'Example "{str(example)}" not in embedding map')
-      yield [lilac_embedding(0, len(example), np.array(EMBEDDING_MAP[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(EMBEDDING_MAP[cast(str, example)]))]
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/data/clustering.py
+++ b/lilac/data/clustering.py
@@ -34,7 +34,7 @@ from ..signal import (
   TopicFn,
 )
 from ..tasks import TaskId, TaskInfo, get_task_manager
-from ..utils import DebugTimer, chunks
+from ..utils import DebugTimer, chunks, log
 from .dataset import Dataset
 from .dataset_utils import (
   get_callable_name,
@@ -138,8 +138,8 @@ def summarize_request(ranked_docs: list[tuple[str, float]]) -> str:
         return title.title
       except IncompleteOutputException:
         max_tokens = max_tokens * 2
-        print(f'Retrying with max_tokens={max_tokens}')
-    print(f'Could not generate a reasonable title for input:\n{input}')
+        log(f'Retrying with max_tokens={max_tokens}')
+    log(f'Could not generate a reasonable title for input:\n{input}')
     return 'FAILED_TO_GENERATE'
 
   return request_with_retries()
@@ -546,7 +546,7 @@ def _hdbscan_cluster(
       noisy_vectors.append(all_vectors[i])
   num_noisy = len(noisy_vectors)
   perc_noisy = 100 * num_noisy / len(clusterer.labels_)
-  print(f'{num_noisy} noise points ({perc_noisy:.1f}%) will be assigned to nearest cluster.')
+  log(f'{num_noisy} noise points ({perc_noisy:.1f}%) will be assigned to nearest cluster.')
 
   noisy_labels: list[np.ndarray] = []
   noisy_probs: list[np.ndarray] = []

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -576,6 +576,16 @@ class Dataset(abc.ABC):
     pass
 
   @abc.abstractmethod
+  def delete_embedding(self, embedding: str, path: Path) -> None:
+    """Delete a computed embedding from the dataset.
+
+    Args:
+      embedding: The name of the embedding.
+      path: The path of the computed embedding.
+    """
+    pass
+
+  @abc.abstractmethod
   def select_groups(
     self,
     leaf_path: Path,

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -50,7 +50,6 @@ from ..schema import (
   PathKey,
   PathTuple,
   Schema,
-  SpanVector,
   change_const_to_enum,
   normalize_path,
 )
@@ -515,7 +514,7 @@ class Dataset(abc.ABC):
   @abc.abstractmethod
   def load_embedding(
     self,
-    load_fn: Callable[[Item], Union[np.ndarray, list[SpanVector]]],
+    load_fn: Callable[[Item], Union[np.ndarray, list[Item]]],
     index_path: Path,
     embedding: str,
     overwrite: bool = False,
@@ -524,7 +523,9 @@ class Dataset(abc.ABC):
     """Loads embeddings from an external source.
 
     Args:
-      load_fn: A function that takes an item and returns an embedding.
+      load_fn: A function that takes an item and returns an embedding. `load_fn` should return
+        either a numpy array for full-document embeddings, or a list of `ll.chunk_embeddings` for
+        chunked embeddings.
       index_path: The path to the index to load the embeddings into.
       embedding: The name of the embedding to load under. This should be a registered embedding.
       overwrite: Whether to overwrite an existing embedding.

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -517,7 +517,7 @@ class Dataset(abc.ABC):
     self,
     load_fn: Callable[[Item], Union[np.ndarray, list[SpanVector]]],
     index_path: Path,
-    embedding_name: str,
+    embedding: str,
     overwrite: bool = False,
     task_id: Optional[TaskId] = None,
   ) -> None:
@@ -526,7 +526,7 @@ class Dataset(abc.ABC):
     Args:
       load_fn: A function that takes an item and returns an embedding.
       index_path: The path to the index to load the embeddings into.
-      embedding_name: The name of the embedding. This is just used for naming.
+      embedding: The name of the embedding to load under. This should be a registered embedding.
       overwrite: Whether to overwrite an existing embedding.
       task_id: The TaskManager `task_id` for this process run. This is used to update the progress
         of the task.

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Callable, Iterable, Iterator, Literal, Optional, Sequence, Union
 
+import numpy as np
 import pandas as pd
 from pydantic import (
   BaseModel,
@@ -511,6 +512,27 @@ class Dataset(abc.ABC):
     """Compute an embedding for a given field path."""
     pass
 
+  @abc.abstractmethod
+  def load_embedding(
+    self,
+    load_fn: Callable[[Item], Union[np.ndarray, list[SpanVector]]],
+    index_path: Path,
+    embedding_name: str,
+    overwrite: bool = False,
+    task_id: Optional[TaskId] = None,
+  ) -> None:
+    """Loads embeddings from an external source.
+
+    Args:
+      load_fn: A function that takes an item and returns an embedding.
+      index_path: The path to the index to load the embeddings into.
+      embedding_name: The name of the embedding. This is just used for naming.
+      overwrite: Whether to overwrite an existing embedding.
+      task_id: The TaskManager `task_id` for this process run. This is used to update the progress
+        of the task.
+    """
+    pass
+
   def compute_concept(
     self,
     namespace: str,
@@ -688,9 +710,7 @@ class Dataset(abc.ABC):
     pass
 
   @abc.abstractmethod
-  def get_embeddings(
-    self, embedding: str, rowid: str, path: Union[PathKey, str]
-  ) -> list[SpanVector]:
+  def get_embeddings(self, embedding: str, rowid: str, path: Union[PathKey, str]) -> list[Item]:
     """Returns the span-level embeddings associated with a specific row value.
 
     Args:
@@ -703,7 +723,11 @@ class Dataset(abc.ABC):
           row path would be `docs.0.text` for the 1st doc and `docs.1.text` for the 2nd doc.
 
     Returns:
-      A list of `ll.SpanVector` dicts holding the span coordinates and the embedding.
+      A list of `ll.Item` dicts holding the span coordinates and the embedding. These come from
+      ll.chunk_embedding, which looks like:
+      ```
+      {'__span__': {'start': 0, 'end': 6}, 'embedding': array([1., 0., 0.])}
+      ```
     """
     pass
 

--- a/lilac/data/dataset_compute_signal_chain_test.py
+++ b/lilac/data/dataset_compute_signal_chain_test.py
@@ -166,7 +166,9 @@ def test_missing_embedding_signal(make_test_data: TestDataMaker, mocker: MockerF
 
   # The embedding is missing for 'text'.
   embedding_sum_signal = TestEmbeddingSumSignal(embedding=TestEmbedding.name)
-  with pytest.raises(ValueError, match="No embedding found for path \\('text',\\)"):
+  with pytest.raises(
+    ValueError, match='Embedding "test_embedding" not found for path \\(\'text\',\\)'
+  ):
     dataset.compute_signal(embedding_sum_signal, 'text')
 
 

--- a/lilac/data/dataset_compute_signal_chain_test.py
+++ b/lilac/data/dataset_compute_signal_chain_test.py
@@ -15,8 +15,8 @@ from ..schema import (
   RichData,
   SignalInputType,
   SpanVector,
+  chunk_embedding,
   field,
-  lilac_embedding,
   schema,
   span,
 )
@@ -82,7 +82,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 class TestEmbeddingSumSignal(VectorSignal):

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -17,8 +17,8 @@ from ..schema import (
   Item,
   RichData,
   SignalInputType,
+  chunk_embedding,
   field,
-  lilac_embedding,
   schema,
   span,
 )
@@ -144,7 +144,7 @@ class TestEmbedding(TextEmbeddingSignal):
     """Call the embedding function."""
     for example in data:
       example = cast(str, example)
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[example]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[example]))]
 
 
 class ComputedKeySignal(TextSignal):

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -701,6 +701,56 @@ def test_embedding_signal(make_test_data: TestDataMaker, mocker: MockerFixture) 
   assert list(result) == expected_result
 
 
+def test_embedding_signal_overwrite(make_test_data: TestDataMaker, mocker: MockerFixture) -> None:
+  dataset = make_test_data([{'text': 'hello.'}, {'text': 'hello2.'}])
+
+  embedding_signal = TestEmbedding()
+  dataset.compute_signal(embedding_signal, 'text')
+
+  dataset.compute_signal(embedding_signal, 'text', overwrite=True)
+
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'text': field(
+          'string',
+          fields={
+            'test_embedding': field(
+              signal=embedding_signal.model_dump(exclude_none=True),
+              fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})],
+            )
+          },
+        )
+      }
+    ),
+    num_items=2,
+    source=TestSource(),
+  )
+
+
+def test_embedding_signal_no_overwrite_throws(
+  make_test_data: TestDataMaker, mocker: MockerFixture
+) -> None:
+  dataset = make_test_data([{'text': 'hello.'}, {'text': 'hello2.'}])
+
+  # Reduce the chunk size to 1 so we test iteratively writing to the embedding index.
+  mocker.patch(f'{dataset_utils_module.__name__}.EMBEDDINGS_WRITE_CHUNK_SIZE', 1)
+
+  embedding_signal = TestEmbedding()
+  dataset.compute_signal(embedding_signal, 'text')
+
+  with pytest.raises(
+    ValueError,
+    match=re.escape(
+      'Embedding "test_embedding" already exists at path (\'str\',). '
+      'Use overwrite=True to overwrite.'
+    ),
+  ):
+    dataset.compute_signal(embedding_signal, 'text')
+
+
 def test_compute_embedding_over_non_string(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data([{'text': 'hello. hello2.'}, {'text': 'hello world. hello world2.'}])
 

--- a/lilac/data/dataset_compute_signal_test.py
+++ b/lilac/data/dataset_compute_signal_test.py
@@ -744,7 +744,7 @@ def test_embedding_signal_no_overwrite_throws(
   with pytest.raises(
     ValueError,
     match=re.escape(
-      'Embedding "test_embedding" already exists at path (\'str\',). '
+      'Embedding "test_embedding" already exists at path (\'text\',). '
       'Use overwrite=True to overwrite.'
     ),
   ):

--- a/lilac/data/dataset_config_test.py
+++ b/lilac/data/dataset_config_test.py
@@ -153,7 +153,7 @@ def test_config_compute_embedding(make_test_data: TestDataMaker) -> None:
   )
 
   # Computing the same embedding again should not change the config.
-  dataset.compute_embedding('test_embedding', 'text')
+  dataset.compute_embedding('test_embedding', 'text', overwrite=True)
 
   assert dataset.config() == DatasetConfig(
     namespace='test_namespace',

--- a/lilac/data/dataset_config_test.py
+++ b/lilac/data/dataset_config_test.py
@@ -13,7 +13,7 @@ from ..config import (
   EmbeddingConfig,
   SignalConfig,
 )
-from ..schema import Field, Item, RichData, field, lilac_embedding
+from ..schema import Field, Item, RichData, chunk_embedding, field
 from ..signal import TextEmbeddingSignal, TextSignal, clear_signal_registry, register_signal
 from ..source import clear_source_registry, register_source
 from .dataset_test_utils import TestDataMaker, TestSource
@@ -52,7 +52,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array([1.0]))]
+      yield [chunk_embedding(0, len(example), np.array([1.0]))]
 
 
 class TestEmbedding2(TextEmbeddingSignal):
@@ -64,7 +64,7 @@ class TestEmbedding2(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array([2.0]))]
+      yield [chunk_embedding(0, len(example), np.array([2.0]))]
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1161,6 +1161,15 @@ class DatasetDuckDB(Dataset):
 
     assert signal_schema, 'Signal schema should be defined for `TextEmbeddingSignal`.'
 
+    if manifest.data_schema.has_field(output_path):
+      if overwrite:
+        self.delete_embedding(embedding, input_path)
+      else:
+        raise ValueError(
+          f'Embedding "{embedding}" already exists at path {input_path}. '
+          'Use overwrite=True to overwrite.'
+        )
+
     jsonl_cache_filepath = _jsonl_cache_filepath(
       namespace=self.namespace,
       dataset_name=self.dataset_name,

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -74,7 +74,6 @@ from ..schema import (
   PathTuple,
   RichData,
   Schema,
-  SpanVector,
   arrow_schema_to_schema,
   chunk_embedding,
   column_paths_match,
@@ -1259,7 +1258,7 @@ class DatasetDuckDB(Dataset):
   @override
   def load_embedding(
     self,
-    load_fn: Callable[[Item], Union[np.ndarray, list[SpanVector]]],
+    load_fn: Callable[[Item], Union[np.ndarray, list[Item]]],
     index_path: Path,
     embedding: str,
     overwrite: bool = False,

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1358,7 +1358,7 @@ class DatasetDuckDB(Dataset):
         batch_size=None,
         select_path=None,  # Select the entire row.
         overwrite=overwrite,
-        query_options=query_params,
+        query_options=None,
         checkpoint_progress=False,
       )
     )

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, SerializeAsAny, field_validator
 from typing_extensions import override
 
 from ..auth import UserInfo
-from ..batch_utils import flatten_iter, unflatten_iter
+from ..batch_utils import flatten_iter, flatten_path_iter, unflatten_iter
 from ..config import (
   OLD_CONFIG_FILENAME,
   DatasetConfig,
@@ -52,6 +52,7 @@ from ..project import (
 from ..schema import (
   BOOLEAN,
   EMBEDDING,
+  EMBEDDING_KEY,
   MANIFEST_FILENAME,
   PATH_WILDCARD,
   ROWID,
@@ -75,6 +76,7 @@ from ..schema import (
   Schema,
   SpanVector,
   arrow_schema_to_schema,
+  chunk_embedding,
   column_paths_match,
   is_float,
   is_integer,
@@ -90,6 +92,7 @@ from ..signal import (
   TextEmbeddingSignal,
   TopicFn,
   VectorSignal,
+  create_user_text_embedding_signal,
   get_signal_by_type,
   resolve_signal,
 )
@@ -612,10 +615,15 @@ class DatasetDuckDB(Dataset):
         and m.vector_store
         and m.signal.name == embedding
       ]
+      # Create the vector db index when it hasn't been created yet.
       if not manifests:
-        raise ValueError(f'No embedding found for path {path}.')
+        vector_index = VectorDBIndex(self.vector_store)
+        self._vector_indices[index_key] = vector_index
+        return vector_index
+
       if len(manifests) > 1:
         raise ValueError(f'Multiple embeddings found for path {path}. Got: {manifests}')
+
       manifest = manifests[0]
       if not manifest.vector_store:
         raise ValueError(
@@ -969,9 +977,7 @@ class DatasetDuckDB(Dataset):
     return get_json_query(select_str), schema, parquet_filepath
 
   @override
-  def get_embeddings(
-    self, embedding: str, rowid: str, path: Union[PathKey, str]
-  ) -> list[SpanVector]:
+  def get_embeddings(self, embedding: str, rowid: str, path: Union[PathKey, str]) -> list[Item]:
     """Returns the span-level embeddings associated with a specific row value."""
     path = normalize_path(cast(PathTuple, path))
     path = tuple([int(p) if p.isdigit() else p for p in path])
@@ -981,7 +987,12 @@ class DatasetDuckDB(Dataset):
 
     path_key: PathKey = tuple([rowid, *[p for p in path if isinstance(p, int)]])
     res = list(vector_index.get([path_key]))
-    return res[0]
+
+    # Convert the internal SpanVector to the public facing chunk_embedding.
+    return [
+      chunk_embedding(span_vector['span'][0], span_vector['span'][1], span_vector['vector'])
+      for span_vector in res[0]
+    ]
 
   @override
   def compute_signal(
@@ -1188,8 +1199,9 @@ class DatasetDuckDB(Dataset):
       )
     )
 
+    vector_index = self._get_vector_db_index(embedding, input_path)
     write_embeddings_to_disk(
-      vector_store=self.vector_store,
+      vector_index=vector_index,
       signal_items=output_items,
       output_dir=output_dir,
     )
@@ -1212,6 +1224,130 @@ class DatasetDuckDB(Dataset):
       signal=signal,
       enriched_path=input_path,
       parquet_id=make_signal_parquet_id(signal, input_path, is_computed_signal=True),
+      vector_store=self.vector_store,
+      py_version=metadata.version('lilac'),
+    )
+
+    with open_file(signal_manifest_filepath, 'w') as f:
+      f.write(signal_manifest.model_dump_json(exclude_none=True, indent=2))
+
+    log(f'Wrote embedding index to {output_dir}')
+
+  @override
+  def load_embedding(
+    self,
+    load_fn: Callable[[Item], Union[np.ndarray, list[SpanVector]]],
+    index_path: Path,
+    embedding_name: str,
+    overwrite: bool = False,
+    task_id: Optional[TaskId] = None,
+  ) -> None:
+    index_path = normalize_path(index_path)
+    # Make sure there are no PATH_WILDCARDS in index_path.
+    if any(p == PATH_WILDCARD for p in index_path):
+      raise ValueError(
+        '`index_path` cannot contain repeated values for `load_embedding`. '
+        'If you require this, please file an issue: https://github.com/lilacai/lilac/issues/new'
+      )
+
+    manifest = self.manifest()
+    index_field = manifest.data_schema.get_field(index_path)
+    if index_field.dtype != STRING:
+      raise ValueError('`index_path` "{index_path}" must be a string field.')
+
+    # We create an implicit embedding signal for user-loaded embeddings.
+    signal = create_user_text_embedding_signal(embedding_name)
+    signal.setup()
+
+    signal_col = Column(path=index_path, alias='value', signal_udf=signal)
+
+    output_path = _col_destination_path(signal_col, is_computed_signal=True)
+    output_dir = os.path.join(self.dataset_path, _signal_dir(output_path))
+    signal_schema = create_signal_schema(signal, index_path, manifest.data_schema)
+
+    assert signal_schema, 'Signal schema should be defined for `TextEmbeddingSignal`.'
+    if manifest.data_schema.has_field(output_path) and not overwrite:
+      raise ValueError('Embedding already exists. Use overwrite=True to overwrite.')
+
+    query_params = DuckDBQueryParams()
+    estimated_len = self.count(query_params)
+
+    if task_id is not None:
+      progress_bar = get_progress_bar(estimated_len=estimated_len, task_id=task_id)
+    else:
+      progress_bar = get_progress_bar(
+        estimated_len=estimated_len,
+        task_description=f'Load embedding {embedding_name} on {self.dataset_name}:{index_path}',
+      )
+
+    jsonl_cache_filepath = _jsonl_cache_filepath(
+      namespace=self.namespace,
+      dataset_name=self.dataset_name,
+      key=output_path,
+      project_dir=self.project_dir,
+    )
+
+    def _validated_load_fn(item: Item) -> Union[np.ndarray, list[Item]]:
+      res = load_fn(item)
+
+      print('validating', res)
+      if isinstance(res, np.ndarray):
+        texts = list(flatten_path_iter(item, path=index_path))
+        # We currently only support non-repeated texts.
+        text = texts[0]
+        return [chunk_embedding(0, len(text), res)]
+      elif isinstance(res, list):
+        for chunk in res:
+          assert EMBEDDING_KEY in chunk and SPAN_KEY in chunk, (
+            f'load_fn must return a list of `ll.chunk_embedding()` or a single numpy array. '
+            f'Got: {type(res)}'
+          )
+        return res
+      else:
+        raise ValueError(
+          f'load_fn must return a list of `ll.chunk_embedding()` or a numpy array. Got: {type(res)}'
+        )
+
+    output_items = progress_bar(
+      self._dispatch_workers(
+        joblib.Parallel(n_jobs=1, prefer='threads', return_as='generator'),
+        _validated_load_fn,
+        output_path,
+        jsonl_cache_filepath,
+        batch_size=None,
+        select_path=None,  # Select the entire row.
+        overwrite=overwrite,
+        query_options=query_params,
+        checkpoint_progress=False,
+      )
+    )
+
+    output_items = list(output_items)
+    print('oi', output_items)
+
+    vector_index = self._get_vector_db_index(embedding_name, index_path)
+    write_embeddings_to_disk(
+      vector_index=vector_index,
+      signal_items=output_items,
+      output_dir=output_dir,
+    )
+    gc.collect()
+
+    signal_manifest_filepath = os.path.join(output_dir, SIGNAL_MANIFEST_FILENAME)
+    # If the signal manifest already exists, delete it as it will be rewritten after the new signal
+    # outputs are run.
+    if os.path.exists(signal_manifest_filepath):
+      os.remove(signal_manifest_filepath)
+      # Call manifest() to recreate all the views, otherwise this could be stale and point to a non
+      # existent file.
+      self.manifest()
+
+    signal_manifest = SignalManifest(
+      files=[],
+      data_schema=signal_schema,
+      signal=signal,
+      enriched_path=index_path,
+      parquet_id=make_signal_parquet_id(signal, index_path, is_computed_signal=True),
       vector_store=self.vector_store,
       py_version=metadata.version('lilac'),
     )

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -587,7 +587,7 @@ class DatasetDuckDB(Dataset):
       latest_mtime_micro_sec = int(latest_mtime * 1e6)
       return self._recompute_joint_table(latest_mtime_micro_sec)
 
-  def count(self, query_options: Optional[DuckDBQueryParams]) -> int:
+  def count(self, query_options: Optional[DuckDBQueryParams] = None) -> int:
     """Count the number of rows."""
     if query_options is None:
       option_sql = ''
@@ -1312,8 +1312,7 @@ class DatasetDuckDB(Dataset):
           'Use overwrite=True to overwrite.'
         )
 
-    query_params = DuckDBQueryParams()
-    estimated_len = self.count(query_params)
+    estimated_len = self.count()
 
     if task_id is not None:
       progress_bar = get_progress_bar(estimated_len=estimated_len, task_id=task_id)

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1224,9 +1224,8 @@ class DatasetDuckDB(Dataset):
     # outputs are run.
     if os.path.exists(signal_manifest_filepath):
       os.remove(signal_manifest_filepath)
-      # Call manifest() to recreate all the views, otherwise this could be stale and point to a non
-      # existent file.
-      self.manifest()
+      # Recreate all the views, otherwise this could be stale and point to a non existent file.
+      self._clear_joint_table_cache()
 
     signal_manifest = SignalManifest(
       files=[],
@@ -1260,9 +1259,8 @@ class DatasetDuckDB(Dataset):
     # outputs are run.
     if os.path.exists(signal_manifest_filepath):
       os.remove(signal_manifest_filepath)
-      # Call manifest() to recreate all the views, otherwise this could be stale and point to a non
-      # existent file.
-      self.manifest()
+      # Recreate all the views, otherwise this could be stale and point to a non existent file.
+      self._clear_joint_table_cache()
 
   @override
   def load_embedding(
@@ -1379,9 +1377,8 @@ class DatasetDuckDB(Dataset):
     # outputs are run.
     if os.path.exists(signal_manifest_filepath):
       os.remove(signal_manifest_filepath)
-      # Call manifest() to recreate all the views, otherwise this could be stale and point to a non
-      # existent file.
-      self.manifest()
+      # Recreate all the views, otherwise this could be stale and point to a non existent file.
+      self._clear_joint_table_cache()
 
     signal_manifest = SignalManifest(
       files=[],

--- a/lilac/data/dataset_load_embedding_test.py
+++ b/lilac/data/dataset_load_embedding_test.py
@@ -1,0 +1,190 @@
+"""Tests for dataset.load_embedding()."""
+
+from typing import Iterable
+
+import numpy as np
+import pytest
+
+from ..schema import (
+  EMBEDDING_KEY,
+  ROWID,
+  SPAN_KEY,
+  Item,
+  chunk_embedding,
+  field,
+  schema,
+  span,
+)
+from ..signal import clear_signal_registry, create_user_text_embedding_signal
+from ..source import clear_source_registry, register_source
+from .dataset import DatasetManifest
+from .dataset_test_utils import (
+  TEST_DATASET_NAME,
+  TEST_NAMESPACE,
+  TestDataMaker,
+  TestSource,
+)
+
+EMBEDDINGS: dict[str, list[float]] = {
+  '1': [1.0, 0.0, 0.0],
+  '2': [1.0, 1.0, 0.0],
+  '3': [0.0, 0.0, 1.0],
+}
+
+
+ITEMS: list[Item] = [
+  {'id': '1', 'str': 'hello.'},
+  {'id': '2', 'str': 'hello2.'},
+  {'id': '3', 'str': 'hello3.'},
+]
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_teardown() -> Iterable[None]:
+  # Setup.
+  clear_signal_registry()
+  register_source(TestSource)
+
+  # Unit test runs.
+  yield
+
+  # Teardown.
+  clear_source_registry()
+  clear_signal_registry()
+
+
+def test_load_embedding_full_doc(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(ITEMS)
+
+  def _load_embedding(item: Item) -> np.ndarray:
+    # Return a full-doc np.array embedding.
+    return np.array(EMBEDDINGS[item['id']])
+
+  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+
+  embedding_signal = create_user_text_embedding_signal('test_embedding')
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'id': 'string',
+        'str': field(
+          'string',
+          fields={
+            'test_embedding': field(
+              signal=embedding_signal.model_dump(exclude_none=True),
+              fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})],
+            )
+          },
+        ),
+      }
+    ),
+    num_items=3,
+    source=TestSource(),
+  )
+
+  rows = dataset.select_rows(combine_columns=True)
+  assert list(rows) == ITEMS
+
+  # Make sure the row-level embeddings match the embeddings we explicitly passed.
+  rows = list(dataset.select_rows(['*', ROWID]))
+  assert len(rows) == 3
+  for row in rows:
+    embeddings = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
+    assert len(embeddings) == 1
+    embedding = embeddings[0]
+
+    np.testing.assert_array_almost_equal(embedding[EMBEDDING_KEY], EMBEDDINGS[row['id']])
+    assert embedding[SPAN_KEY] == span(0, len(row['str']))[SPAN_KEY]
+
+
+def test_load_embedding_chunks(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(ITEMS)
+
+  def _load_embedding(item: Item) -> list[Item]:
+    return [
+      chunk_embedding(0, 1, np.array(EMBEDDINGS[item['id']])),
+      chunk_embedding(1, 2, 2 * np.array(EMBEDDINGS[item['id']])),
+    ]
+
+  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+
+  embedding_signal = create_user_text_embedding_signal('test_embedding')
+  assert dataset.manifest() == DatasetManifest(
+    namespace=TEST_NAMESPACE,
+    dataset_name=TEST_DATASET_NAME,
+    data_schema=schema(
+      {
+        'id': 'string',
+        'str': field(
+          'string',
+          fields={
+            'test_embedding': field(
+              signal=embedding_signal.model_dump(exclude_none=True),
+              fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})],
+            )
+          },
+        ),
+      }
+    ),
+    num_items=3,
+    source=TestSource(),
+  )
+
+  rows = dataset.select_rows(combine_columns=True)
+  assert list(rows) == ITEMS
+
+  # Make sure the row-level embeddings match the embeddings we explicitly passed.
+  rows = list(dataset.select_rows(['*', ROWID]))
+  assert len(rows) == 3
+  for row in rows:
+    embeddings = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
+    assert len(embeddings) == 2
+
+    np.testing.assert_array_almost_equal(embeddings[0][EMBEDDING_KEY], EMBEDDINGS[row['id']])
+    assert embeddings[0][SPAN_KEY] == span(0, 1)[SPAN_KEY]
+
+    np.testing.assert_array_almost_equal(
+      embeddings[1][EMBEDDING_KEY], [2 * x for x in EMBEDDINGS[row['id']]]
+    )
+    assert embeddings[1][SPAN_KEY] == span(1, 2)[SPAN_KEY]
+
+
+def test_load_embedding_overwrite(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(ITEMS)
+
+  multiplier = 1.0
+
+  def _load_embedding(item: Item) -> np.ndarray:
+    # Return a full-doc np.array embedding.
+    return multiplier * np.array(EMBEDDINGS[item['id']])
+
+  # Call load_embedding once.
+  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+
+  # Make sure the row-level embeddings match the embeddings we explicitly passed.
+  rows = list(dataset.select_rows(['*', ROWID]))
+  assert len(rows) == 3
+  for row in rows:
+    [embedding] = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
+
+    np.testing.assert_array_almost_equal(embedding[EMBEDDING_KEY], EMBEDDINGS[row['id']])
+
+  multiplier = 2.0
+
+  # Call load_embedding again with overwrite=True.
+  dataset.load_embedding(
+    _load_embedding, index_path='str', embedding_name='test_embedding', overwrite=True
+  )
+
+  # Make sure the row-level embeddings match the embeddings we explicitly passed, times 2.
+  rows = list(dataset.select_rows(['*', ROWID]))
+  assert len(rows) == 3
+  for row in rows:
+    [embedding] = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
+    print('get_embeddings=', embedding)
+
+    np.testing.assert_array_almost_equal(
+      embedding[EMBEDDING_KEY], [multiplier * x for x in EMBEDDINGS[row['id']]]
+    )

--- a/lilac/data/dataset_load_embedding_test.py
+++ b/lilac/data/dataset_load_embedding_test.py
@@ -1,5 +1,6 @@
 """Tests for dataset.load_embedding()."""
 
+import re
 from typing import Iterable
 
 import numpy as np
@@ -211,5 +212,11 @@ def test_load_embedding_throws_twice_no_overwrite(make_test_data: TestDataMaker)
     np.testing.assert_array_almost_equal(embedding[EMBEDDING_KEY], EMBEDDINGS[row['id']])
 
   # Calling load_embedding again with the same embedding name throws.
-  with pytest.raises(ValueError, match='blah blah'):
+  with pytest.raises(
+    ValueError,
+    match=re.escape(
+      'Embedding "test_embedding" already exists at path (\'str\',). '
+      'Use overwrite=True to overwrite.'
+    ),
+  ):
     dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')

--- a/lilac/data/dataset_load_embedding_test.py
+++ b/lilac/data/dataset_load_embedding_test.py
@@ -1,22 +1,24 @@
 """Tests for dataset.load_embedding()."""
 
 import re
-from typing import Iterable
+from typing import ClassVar, Iterable, Iterator, Union, cast
 
 import numpy as np
 import pytest
+from typing_extensions import override
 
 from ..schema import (
   EMBEDDING_KEY,
   ROWID,
   SPAN_KEY,
   Item,
+  RichData,
   chunk_embedding,
   field,
   schema,
   span,
 )
-from ..signal import clear_signal_registry, create_user_text_embedding_signal
+from ..signal import TextEmbeddingSignal, clear_signal_registry, register_embedding
 from ..source import clear_source_registry, register_source
 from .dataset import DatasetManifest
 from .dataset_test_utils import (
@@ -26,12 +28,22 @@ from .dataset_test_utils import (
   TestSource,
 )
 
-EMBEDDINGS: dict[str, list[float]] = {
+ID_EMBEDDINGS: dict[str, list[float]] = {
   '1': [1.0, 0.0, 0.0],
+  # This embedding has an outer dimension of 1.
   '2': [1.0, 1.0, 0.0],
   '3': [0.0, 0.0, 1.0],
 }
 
+EMBEDDINGS: list[tuple[str, Union[list[float], list[list[float]]]]] = [
+  ('hello.', ID_EMBEDDINGS['1']),
+  ('hello2.', ID_EMBEDDINGS['2']),
+  ('hello3.', ID_EMBEDDINGS['3']),
+]
+
+STR_EMBEDDINGS: dict[str, Union[list[float], list[list[float]]]] = {
+  text: embedding for text, embedding in EMBEDDINGS
+}
 
 ITEMS: list[Item] = [
   {'id': '1', 'str': 'hello.'},
@@ -40,11 +52,25 @@ ITEMS: list[Item] = [
 ]
 
 
+class TestEmbedding(TextEmbeddingSignal):
+  """A test embed function."""
+
+  name: ClassVar[str] = 'test_embedding'
+
+  @override
+  def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
+    """Call the embedding function."""
+    for example in data:
+      example = cast(str, example)
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[example]))]
+
+
 @pytest.fixture(scope='module', autouse=True)
 def setup_teardown() -> Iterable[None]:
   # Setup.
   clear_signal_registry()
   register_source(TestSource)
+  register_embedding(TestEmbedding)
 
   # Unit test runs.
   yield
@@ -59,11 +85,11 @@ def test_load_embedding_full_doc(make_test_data: TestDataMaker) -> None:
 
   def _load_embedding(item: Item) -> np.ndarray:
     # Return a full-doc np.array embedding.
-    return np.array(EMBEDDINGS[item['id']])
+    return np.array(ID_EMBEDDINGS[item['id']])
 
-  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+  dataset.load_embedding(_load_embedding, index_path='str', embedding='test_embedding')
 
-  embedding_signal = create_user_text_embedding_signal('test_embedding')
+  embedding_signal = TestEmbedding()
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
     dataset_name=TEST_DATASET_NAME,
@@ -96,7 +122,9 @@ def test_load_embedding_full_doc(make_test_data: TestDataMaker) -> None:
     assert len(embeddings) == 1
     embedding = embeddings[0]
 
-    np.testing.assert_array_almost_equal(embedding[EMBEDDING_KEY], EMBEDDINGS[row['id']])
+    np.testing.assert_array_almost_equal(
+      embedding[EMBEDDING_KEY], np.array(ID_EMBEDDINGS[row['id']], dtype=np.float32)
+    )
     assert embedding[SPAN_KEY] == span(0, len(row['str']))[SPAN_KEY]
 
 
@@ -105,13 +133,13 @@ def test_load_embedding_chunks(make_test_data: TestDataMaker) -> None:
 
   def _load_embedding(item: Item) -> list[Item]:
     return [
-      chunk_embedding(0, 1, np.array(EMBEDDINGS[item['id']])),
-      chunk_embedding(1, 2, 2 * np.array(EMBEDDINGS[item['id']])),
+      chunk_embedding(0, 1, np.array(ID_EMBEDDINGS[item['id']])),
+      chunk_embedding(1, 2, 2 * np.array(ID_EMBEDDINGS[item['id']])),
     ]
 
-  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+  dataset.load_embedding(_load_embedding, index_path='str', embedding='test_embedding')
 
-  embedding_signal = create_user_text_embedding_signal('test_embedding')
+  embedding_signal = TestEmbedding()
   assert dataset.manifest() == DatasetManifest(
     namespace=TEST_NAMESPACE,
     dataset_name=TEST_DATASET_NAME,
@@ -143,12 +171,16 @@ def test_load_embedding_chunks(make_test_data: TestDataMaker) -> None:
     embeddings = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
     assert len(embeddings) == 2
 
-    np.testing.assert_array_almost_equal(embeddings[0][EMBEDDING_KEY], EMBEDDINGS[row['id']])
+    np.testing.assert_array_almost_equal(
+      embeddings[0][EMBEDDING_KEY], np.array(ID_EMBEDDINGS[row['id']], dtype=np.float32)
+    )
     assert embeddings[0][SPAN_KEY] == span(0, 1)[SPAN_KEY]
 
     np.testing.assert_array_almost_equal(
-      embeddings[1][EMBEDDING_KEY], [2 * x for x in EMBEDDINGS[row['id']]]
+      embeddings[1][EMBEDDING_KEY],
+      np.array([2 * x for x in ID_EMBEDDINGS[row['id']]], dtype=np.float32),
     )
+
     assert embeddings[1][SPAN_KEY] == span(1, 2)[SPAN_KEY]
 
 
@@ -159,10 +191,10 @@ def test_load_embedding_overwrite(make_test_data: TestDataMaker) -> None:
 
   def _load_embedding(item: Item) -> np.ndarray:
     # Return a full-doc np.array embedding.
-    return multiplier * np.array(EMBEDDINGS[item['id']])
+    return multiplier * np.array(ID_EMBEDDINGS[item['id']])
 
   # Call load_embedding once.
-  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+  dataset.load_embedding(_load_embedding, index_path='str', embedding='test_embedding')
 
   # Make sure the row-level embeddings match the embeddings we explicitly passed.
   rows = list(dataset.select_rows(['*', ROWID]))
@@ -170,13 +202,15 @@ def test_load_embedding_overwrite(make_test_data: TestDataMaker) -> None:
   for row in rows:
     [embedding] = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
 
-    np.testing.assert_array_almost_equal(embedding[EMBEDDING_KEY], EMBEDDINGS[row['id']])
+    np.testing.assert_array_almost_equal(
+      embedding[EMBEDDING_KEY], np.array(ID_EMBEDDINGS[row['id']], dtype=np.float32)
+    )
 
   multiplier = 2.0
 
   # Call load_embedding again with overwrite=True.
   dataset.load_embedding(
-    _load_embedding, index_path='str', embedding_name='test_embedding', overwrite=True
+    _load_embedding, index_path='str', embedding='test_embedding', overwrite=True
   )
 
   # Make sure the row-level embeddings match the embeddings we explicitly passed, times 2.
@@ -184,10 +218,9 @@ def test_load_embedding_overwrite(make_test_data: TestDataMaker) -> None:
   assert len(rows) == 3
   for row in rows:
     [embedding] = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
-    print('get_embeddings=', embedding)
 
     np.testing.assert_array_almost_equal(
-      embedding[EMBEDDING_KEY], [multiplier * x for x in EMBEDDINGS[row['id']]]
+      embedding[EMBEDDING_KEY], [multiplier * x for x in ID_EMBEDDINGS[row['id']]]
     )
 
 
@@ -198,10 +231,10 @@ def test_load_embedding_throws_twice_no_overwrite(make_test_data: TestDataMaker)
 
   def _load_embedding(item: Item) -> np.ndarray:
     # Return a full-doc np.array embedding.
-    return multiplier * np.array(EMBEDDINGS[item['id']])
+    return multiplier * np.array(ID_EMBEDDINGS[item['id']])
 
   # Call load_embedding once.
-  dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+  dataset.load_embedding(_load_embedding, index_path='str', embedding='test_embedding')
 
   # Make sure the row-level embeddings match the embeddings we explicitly passed.
   rows = list(dataset.select_rows(['*', ROWID]))
@@ -209,7 +242,9 @@ def test_load_embedding_throws_twice_no_overwrite(make_test_data: TestDataMaker)
   for row in rows:
     [embedding] = dataset.get_embeddings('test_embedding', row[ROWID], 'str')
 
-    np.testing.assert_array_almost_equal(embedding[EMBEDDING_KEY], EMBEDDINGS[row['id']])
+    np.testing.assert_array_almost_equal(
+      embedding[EMBEDDING_KEY], np.array(ID_EMBEDDINGS[row['id']], dtype=np.float32)
+    )
 
   # Calling load_embedding again with the same embedding name throws.
   with pytest.raises(
@@ -219,4 +254,19 @@ def test_load_embedding_throws_twice_no_overwrite(make_test_data: TestDataMaker)
       'Use overwrite=True to overwrite.'
     ),
   ):
-    dataset.load_embedding(_load_embedding, index_path='str', embedding_name='test_embedding')
+    dataset.load_embedding(_load_embedding, index_path='str', embedding='test_embedding')
+
+
+def test_load_embedding_no_registered_embed(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data(ITEMS)
+
+  def _load_embedding(item: Item) -> np.ndarray:
+    # Return a full-doc np.array embedding.
+    return np.array(ID_EMBEDDINGS[item['id']])
+
+  # Call load_embedding once.
+  with pytest.raises(
+    ValueError,
+    match=re.escape('Embedding "other_embedding" not found. You must register an embedding'),
+  ):
+    dataset.load_embedding(_load_embedding, index_path='str', embedding='other_embedding')

--- a/lilac/data/dataset_load_embedding_test.py
+++ b/lilac/data/dataset_load_embedding_test.py
@@ -111,8 +111,8 @@ def test_load_embedding_full_doc(make_test_data: TestDataMaker) -> None:
     source=TestSource(),
   )
 
-  rows = dataset.select_rows(combine_columns=True)
-  assert list(rows) == ITEMS
+  rows = list(dataset.select_rows(combine_columns=True))
+  assert rows == ITEMS
 
   # Make sure the row-level embeddings match the embeddings we explicitly passed.
   rows = list(dataset.select_rows(['*', ROWID]))
@@ -161,8 +161,8 @@ def test_load_embedding_chunks(make_test_data: TestDataMaker) -> None:
     source=TestSource(),
   )
 
-  rows = dataset.select_rows(combine_columns=True)
-  assert list(rows) == ITEMS
+  rows = list(dataset.select_rows(combine_columns=True))
+  assert rows == ITEMS
 
   # Make sure the row-level embeddings match the embeddings we explicitly passed.
   rows = list(dataset.select_rows(['*', ROWID]))

--- a/lilac/data/dataset_project_test.py
+++ b/lilac/data/dataset_project_test.py
@@ -19,7 +19,7 @@ from ..db_manager import get_dataset
 from ..env import get_project_dir
 from ..load_dataset import create_dataset
 from ..project import create_project_and_set_env, read_project_config
-from ..schema import Field, Item, RichData, field, lilac_embedding
+from ..schema import Field, Item, RichData, chunk_embedding, field
 from ..signal import TextEmbeddingSignal, TextSignal, clear_signal_registry, register_signal
 from ..source import Source, SourceSchema, clear_source_registry, register_source
 
@@ -71,7 +71,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 class TestSignal(TextSignal):

--- a/lilac/data/dataset_select_rows_schema_test.py
+++ b/lilac/data/dataset_select_rows_schema_test.py
@@ -14,8 +14,8 @@ from ..schema import (
   RichData,
   SignalInputType,
   SpanVector,
+  chunk_embedding,
   field,
-  lilac_embedding,
   schema,
   span,
 )
@@ -107,7 +107,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 class TestEmbeddingSumSignal(VectorSignal):

--- a/lilac/data/dataset_select_rows_search_test.py
+++ b/lilac/data/dataset_select_rows_search_test.py
@@ -11,7 +11,7 @@ from typing_extensions import override
 from ..concepts.concept import ExampleIn, LogisticEmbeddingModel
 from ..concepts.db_concept import ConceptUpdate, DiskConceptDB
 from ..db_manager import set_default_dataset_cls
-from ..schema import ROWID, Item, RichData, SignalInputType, lilac_embedding, span
+from ..schema import ROWID, Item, RichData, SignalInputType, chunk_embedding, span
 from ..signal import TextEmbeddingSignal, clear_signal_registry, register_signal
 from ..signals.concept_scorer import ConceptSignal
 from ..signals.semantic_similarity import SemanticSimilaritySignal
@@ -170,7 +170,7 @@ class TestEmbedding(TextEmbeddingSignal):
     """Call the embedding function."""
     for example in data:
       embedding = np.array(STR_EMBEDDINGS[cast(str, example)])
-      yield [lilac_embedding(0, len(example), embedding)]
+      yield [chunk_embedding(0, len(example), embedding)]
 
 
 def test_semantic_search(make_test_data: TestDataMaker) -> None:

--- a/lilac/data/dataset_select_rows_sort_test.py
+++ b/lilac/data/dataset_select_rows_sort_test.py
@@ -15,8 +15,8 @@ from ..schema import (
   SignalInputType,
   SpanVector,
   VectorKey,
+  chunk_embedding,
   field,
-  lilac_embedding,
   span,
 )
 from ..signal import (
@@ -379,7 +379,7 @@ def test_sort_by_complex_signal_udf_alias_called_on_repeated(make_test_data: Tes
 
 
 def test_sort_by_primitive_signal_udf_alias_called_on_repeated(
-  make_test_data: TestDataMaker
+  make_test_data: TestDataMaker,
 ) -> None:
   dataset = make_test_data(
     [
@@ -453,7 +453,7 @@ class TopKEmbedding(TextEmbeddingSignal):
       for i, score in enumerate(example.split('_')):
         start, end = i * 2, i * 2 + 1
         vector = np.array([int(score)])
-        emb_spans.append(lilac_embedding(start, end, vector))
+        emb_spans.append(chunk_embedding(start, end, vector))
       yield emb_spans
 
 

--- a/lilac/data/dataset_select_rows_udf_test.py
+++ b/lilac/data/dataset_select_rows_udf_test.py
@@ -17,8 +17,8 @@ from ..schema import (
   RichData,
   SignalInputType,
   SpanVector,
+  chunk_embedding,
   field,
-  lilac_embedding,
   span,
 )
 from ..signal import (
@@ -54,7 +54,7 @@ class TestEmbedding(TextEmbeddingSignal):
       if example == '':
         yield None
         continue
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 class LengthSignal(TextSignal):

--- a/lilac/data/dataset_select_rows_udf_test.py
+++ b/lilac/data/dataset_select_rows_udf_test.py
@@ -265,7 +265,9 @@ def test_udf_throws_without_precomputing(make_test_data: TestDataMaker) -> None:
 
   signal_col = Column('text', signal_udf=TestEmbeddingSumSignal(embedding='test_embedding'))
 
-  with pytest.raises(ValueError, match="No embedding found for path \\('text',\\)"):
+  with pytest.raises(
+    ValueError, match='Embedding "test_embedding" not found for path \\(\'text\',\\)'
+  ):
     dataset.select_rows(['text', signal_col])
 
 

--- a/lilac/data/dataset_storage_utils.py
+++ b/lilac/data/dataset_storage_utils.py
@@ -59,7 +59,7 @@ def download(
   cache_dir = get_lilac_cache_dir(project_dir)
   os.makedirs(datasets_dir, exist_ok=True)
 
-  print(f'Downloading "{repo_id}" from HuggingFace to {datasets_dir}')
+  log(f'Downloading "{repo_id}" from HuggingFace to {datasets_dir}')
   repo_subdir = os.path.join(cache_dir, 'hf_download', repo_id)
   snapshot_download(
     repo_id=repo_id,
@@ -90,7 +90,7 @@ def download(
           'Use --overwrite to overwrite it.'
         )
       else:
-        print(f'Overwriting existing dataset {dataset_namespace}/{dataset_name}')
+        log(f'Overwriting existing dataset {dataset_namespace}/{dataset_name}')
         shutil.rmtree(os.path.join(datasets_dir, dataset_namespace, dataset_name))
 
   dataset_dir = os.path.join(datasets_dir, dataset_namespace, dataset_name)
@@ -107,7 +107,7 @@ def download(
 
   add_project_dataset_config(dataset_config, project_dir, overwrite=True)
 
-  print('Wrote dataset to', dataset_dir)
+  log('Wrote dataset to', dataset_dir)
 
 
 def upload(
@@ -154,7 +154,7 @@ def upload(
     repo_id = _dataset_repo_id(dataset)
 
   dataset_link = f'https://huggingface.co/datasets/{repo_id}'
-  print(f'Uploading "{dataset}" to HuggingFace dataset repo ' f'{dataset_link}')
+  log(f'Uploading "{dataset}" to HuggingFace dataset repo ' f'{dataset_link}')
 
   hf_api.create_repo(
     repo_id,

--- a/lilac/data/dataset_test.py
+++ b/lilac/data/dataset_test.py
@@ -16,13 +16,15 @@ from ..config import (
 from ..schema import (
   EMBEDDING_KEY,
   ROWID,
+  SPAN_KEY,
   Field,
   Item,
   MapType,
   RichData,
+  chunk_embedding,
   field,
-  lilac_embedding,
   schema,
+  span,
 )
 from ..signal import TextEmbeddingSignal, TextSignal, clear_signal_registry, register_signal
 from ..source import clear_source_registry, register_source
@@ -60,7 +62,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 class LengthSignal(TextSignal):
@@ -668,16 +670,16 @@ def test_get_embeddings(make_test_data: TestDataMaker) -> None:
 
   rows = list(dataset.select_rows([ROWID]))
 
-  span_vectors = dataset.get_embeddings('test_embedding', rows[0][ROWID], 'text')
-  assert len(span_vectors) == 1
-  assert span_vectors[0]['span'] == (0, 6)
+  chunk_embeddings = dataset.get_embeddings('test_embedding', rows[0][ROWID], 'text')
+  assert len(chunk_embeddings) == 1
+  assert chunk_embeddings[0][SPAN_KEY] == span(0, 6)[SPAN_KEY]
   np.testing.assert_array_equal(
-    span_vectors[0]['vector'], np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    chunk_embeddings[0][EMBEDDING_KEY], np.array([1.0, 0.0, 0.0], dtype=np.float32)
   )
 
-  span_vectors = dataset.get_embeddings('test_embedding', rows[1][ROWID], 'text')
-  assert len(span_vectors) == 1
-  assert span_vectors[0]['span'] == (0, 12)
+  chunk_embeddings = dataset.get_embeddings('test_embedding', rows[1][ROWID], 'text')
+  assert len(chunk_embeddings) == 1
+  assert chunk_embeddings[0][SPAN_KEY] == span(0, 12)[SPAN_KEY]
   np.testing.assert_array_equal(
-    span_vectors[0]['vector'], np.array([1.0, 1.0, 1.0], dtype=np.float32)
+    chunk_embeddings[0][EMBEDDING_KEY], np.array([1.0, 1.0, 1.0], dtype=np.float32)
   )

--- a/lilac/data/dataset_utils.py
+++ b/lilac/data/dataset_utils.py
@@ -185,7 +185,7 @@ def _flat_embeddings(
 
 
 def write_embeddings_to_disk(
-  vector_store: str, signal_items: Iterable[Item], output_dir: str
+  vector_index: VectorDBIndex, signal_items: Iterable[Item], output_dir: str
 ) -> None:
   """Write a set of embeddings to disk."""
   path_embedding_items = (
@@ -213,7 +213,6 @@ def write_embeddings_to_disk(
 
   span_vectors = _get_span_vectors()
 
-  vector_index = VectorDBIndex(vector_store)
   for span_vectors_chunk in chunks(span_vectors, EMBEDDINGS_WRITE_CHUNK_SIZE):
     chunk_spans: list[tuple[PathKey, list[tuple[int, int]]]] = []
     chunk_embedding_vectors: list[np.ndarray] = []
@@ -228,9 +227,6 @@ def write_embeddings_to_disk(
 
     del embedding_matrix, chunk_embedding_vectors, chunk_spans
     gc.collect()
-
-  del vector_index
-  gc.collect()
 
 
 def write_items_to_parquet(

--- a/lilac/embeddings/embedding.py
+++ b/lilac/embeddings/embedding.py
@@ -13,7 +13,7 @@ from ..schema import (
   Item,
   RichData,
   SpanVector,
-  lilac_embedding,
+  chunk_embedding,
 )
 from ..signal import TextEmbeddingSignal, get_signal_by_type
 from ..splitters.chunk_splitter import TextChunk
@@ -82,6 +82,6 @@ def chunked_compute_embedding(
     batch_texts = [text for _, (text, _) in batch]
     batch_embeddings = embed_fn(batch_texts)
     for (i, (_, (start, end))), embedding in zip(batch, batch_embeddings):
-      output[i].append(lilac_embedding(start, end, embedding))
+      output[i].append(chunk_embedding(start, end, embedding))
 
   return [lis or None for lis in output]

--- a/lilac/embeddings/embedding_test.py
+++ b/lilac/embeddings/embedding_test.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from ..schema import lilac_embedding
+from ..schema import chunk_embedding
 from ..splitters.chunk_splitter import TextChunk
 from .embedding import chunked_compute_embedding
 
@@ -28,18 +28,18 @@ def test_split_and_combine_text_embeddings_batch_across_two_docs() -> None:
 
   assert result == [
     [
-      lilac_embedding(0, 1, np.array(1)),  # T
-      lilac_embedding(1, 2, np.array(1)),  # h
-      lilac_embedding(2, 3, np.array(1)),  # i
-      lilac_embedding(3, 4, np.array(1)),  # s
-      lilac_embedding(4, 5, np.array(1)),  # ' '
-      lilac_embedding(5, 6, np.array(1)),  # i
-      lilac_embedding(6, 7, np.array(1)),  # s
+      chunk_embedding(0, 1, np.array(1)),  # T
+      chunk_embedding(1, 2, np.array(1)),  # h
+      chunk_embedding(2, 3, np.array(1)),  # i
+      chunk_embedding(3, 4, np.array(1)),  # s
+      chunk_embedding(4, 5, np.array(1)),  # ' '
+      chunk_embedding(5, 6, np.array(1)),  # i
+      chunk_embedding(6, 7, np.array(1)),  # s
     ],
     [
-      lilac_embedding(0, 1, np.array(1)),  # 1
-      lilac_embedding(1, 2, np.array(1)),  # 2
-      lilac_embedding(2, 3, np.array(1)),  # 3
+      chunk_embedding(0, 1, np.array(1)),  # 1
+      chunk_embedding(1, 2, np.array(1)),  # 2
+      chunk_embedding(2, 3, np.array(1)),  # 3
     ],
   ]
 
@@ -76,9 +76,9 @@ def test_split_and_combine_text_embeddings_empty_docs() -> None:
     None,
     None,
     [
-      lilac_embedding(0, 1, np.array(1)),  # 1
-      lilac_embedding(1, 2, np.array(1)),  # 2
-      lilac_embedding(2, 3, np.array(1)),  # 3
+      chunk_embedding(0, 1, np.array(1)),  # 1
+      chunk_embedding(1, 2, np.array(1)),  # 2
+      chunk_embedding(2, 3, np.array(1)),  # 3
     ],
   ]
 
@@ -98,9 +98,9 @@ def test_split_and_combine_text_embeddings_empty_docs_at_end() -> None:
 
   assert result == [
     [
-      lilac_embedding(0, 1, np.array(1)),  # 1
-      lilac_embedding(1, 2, np.array(1)),  # 2
-      lilac_embedding(2, 3, np.array(1)),  # 3
+      chunk_embedding(0, 1, np.array(1)),  # 1
+      chunk_embedding(1, 2, np.array(1)),  # 2
+      chunk_embedding(2, 3, np.array(1)),  # 3
     ],
     None,
     None,

--- a/lilac/embeddings/gte.py
+++ b/lilac/embeddings/gte.py
@@ -13,7 +13,7 @@ from ..utils import DebugTimer, chunks
 if TYPE_CHECKING:
   from sentence_transformers import SentenceTransformer
 
-from ..schema import Item, lilac_embedding
+from ..schema import Item, chunk_embedding
 from ..signal import TextEmbeddingSignal
 from ..splitters.spacy_splitter import clustering_spacy_chunker
 from ..tasks import TaskExecutionType
@@ -92,7 +92,7 @@ class GTESmall(TextEmbeddingSignal):
             yield doc_embeddings
             doc_embeddings = []
             last_index = i
-          doc_embeddings.append(lilac_embedding(start, end, vector))
+          doc_embeddings.append(chunk_embedding(start, end, vector))
       yield doc_embeddings
 
   @override

--- a/lilac/embeddings/jina.py
+++ b/lilac/embeddings/jina.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.linalg import norm
 from typing_extensions import override
 
-from ..schema import Item, lilac_embedding
+from ..schema import Item, chunk_embedding
 from ..signal import TextEmbeddingSignal
 
 # See readme in https://huggingface.co/jinaai/jina-embeddings-v2-small-en
@@ -117,7 +117,7 @@ class JinaV2Small(TextEmbeddingSignal):
     for batch in jina_batch.remote_gen({'gzipped_docs': gzipped_docs}):
       batch /= norm(batch, axis=1, keepdims=True)
       for vector in batch:
-        yield [lilac_embedding(start=0, end=doc_lengths[index], embedding=vector)]
+        yield [chunk_embedding(start=0, end=doc_lengths[index], embedding=vector)]
         index += 1
 
 

--- a/lilac/embeddings/vector_store.py
+++ b/lilac/embeddings/vector_store.py
@@ -85,6 +85,7 @@ class VectorDBIndex:
   """
 
   def __init__(self, vector_store: str) -> None:
+    print('~~~~~~~~~~~~~~~~~~~CREATING VECTOR DB INDEX')
     self._vector_store: VectorStore = get_vector_store_cls(vector_store)()
     # Map a path key to spans for that path.
     self._id_to_spans: dict[PathKey, list[tuple[int, int]]] = {}

--- a/lilac/embeddings/vector_store.py
+++ b/lilac/embeddings/vector_store.py
@@ -33,6 +33,11 @@ class VectorStore(abc.ABC):
     pass
 
   @abc.abstractmethod
+  def delete(self, base_path: str) -> None:
+    """Delete the vector store."""
+    pass
+
+  @abc.abstractmethod
   def add(self, keys: list[VectorKey], embeddings: np.ndarray) -> None:
     """Add or edit the given keyed embeddings to the store.
 
@@ -85,11 +90,15 @@ class VectorDBIndex:
   """
 
   def __init__(self, vector_store: str) -> None:
-    print('~~~~~~~~~~~~~~~~~~~CREATING VECTOR DB INDEX')
     self._vector_store: VectorStore = get_vector_store_cls(vector_store)()
     # Map a path key to spans for that path.
     self._id_to_spans: dict[PathKey, list[tuple[int, int]]] = {}
     self._rowid_to_path_keys: dict[str, list[PathKey]] = {}
+
+  def delete(self, base_path: str) -> None:
+    """Delete the vector store."""
+    self._vector_store.delete(os.path.join(base_path, self._vector_store.name))
+    os.remove(os.path.join(base_path, _SPANS_PICKLE_NAME))
 
   def load(self, base_path: str) -> None:
     """Load the vector index from disk."""

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -1,6 +1,7 @@
 """HNSW vector store."""
 
 import multiprocessing
+import os
 import threading
 from typing import Iterable, Optional, Set, cast
 
@@ -33,6 +34,11 @@ class HNSWVectorStore(VectorStore):
     self._key_to_label: Optional[pd.Series] = None
     self._index: Optional[hnswlib.Index] = None
     self._lock = threading.Lock()
+
+  @override
+  def delete(self, base_path: str) -> None:
+    os.remove(base_path + _HNSW_SUFFIX)
+    os.remove(base_path + _LOOKUP_SUFFIX)
 
   @override
   def save(self, base_path: str) -> None:

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -103,9 +103,6 @@ class HNSWVectorStore(VectorStore):
         self._key_to_label.name = str(dim)
         self._index.add_items(embeddings, row_indices)
         self._index.set_ef(min(QUERY_EF, self.size()))
-        print('key to labels writing...', self._key_to_label)
-        print('row indices:', row_indices, self.size(), embeddings)
-        print('get=', self._index.get_items(row_indices))
 
   @override
   def get(self, keys: Optional[Iterable[VectorKey]] = None) -> np.ndarray:
@@ -113,12 +110,9 @@ class HNSWVectorStore(VectorStore):
       self._index is not None and self._key_to_label is not None
     ), 'No embeddings exist in this store.'
     with self._lock:
-      print('getting with keys=', keys)
       if not keys:
         return np.array(self._index.get_items(self._key_to_label.values), dtype=np.float32)
       locs = self._key_to_label.loc[cast(list[str], keys)].values
-      print('returning...', np.array(self._index.get_items(locs), dtype=np.float32))
-      print('key to labels:', self._key_to_label)
       return np.array(self._index.get_items(locs), dtype=np.float32)
 
   @override

--- a/lilac/embeddings/vector_store_hnsw.py
+++ b/lilac/embeddings/vector_store_hnsw.py
@@ -97,6 +97,9 @@ class HNSWVectorStore(VectorStore):
         self._key_to_label.name = str(dim)
         self._index.add_items(embeddings, row_indices)
         self._index.set_ef(min(QUERY_EF, self.size()))
+        print('key to labels writing...', self._key_to_label)
+        print('row indices:', row_indices, self.size(), embeddings)
+        print('get=', self._index.get_items(row_indices))
 
   @override
   def get(self, keys: Optional[Iterable[VectorKey]] = None) -> np.ndarray:
@@ -104,9 +107,12 @@ class HNSWVectorStore(VectorStore):
       self._index is not None and self._key_to_label is not None
     ), 'No embeddings exist in this store.'
     with self._lock:
+      print('getting with keys=', keys)
       if not keys:
         return np.array(self._index.get_items(self._key_to_label.values), dtype=np.float32)
       locs = self._key_to_label.loc[cast(list[str], keys)].values
+      print('returning...', np.array(self._index.get_items(locs), dtype=np.float32))
+      print('key to labels:', self._key_to_label)
       return np.array(self._index.get_items(locs), dtype=np.float32)
 
   @override

--- a/lilac/embeddings/vector_store_numpy.py
+++ b/lilac/embeddings/vector_store_numpy.py
@@ -1,5 +1,6 @@
 """NumpyVectorStore class for storing vectors in numpy arrays."""
 
+import os
 from typing import Iterable, Optional, cast
 
 import numpy as np
@@ -22,6 +23,11 @@ class NumpyVectorStore(VectorStore):
     self._embeddings: Optional[np.ndarray] = None
     # Maps a `VectorKey` to a row index in `_embeddings`.
     self._key_to_index: Optional[pd.Series] = None
+
+  @override
+  def delete(self, base_path: str) -> None:
+    os.remove(base_path + _EMBEDDINGS_SUFFIX)
+    os.remove(base_path + _LOOKUP_SUFFIX)
 
   @override
   def size(self) -> int:

--- a/lilac/hf_docker_start.py
+++ b/lilac/hf_docker_start.py
@@ -94,7 +94,7 @@ def _hf_docker_start() -> None:
   datasets_dir = get_datasets_dir(get_project_dir())
   os.makedirs(datasets_dir, exist_ok=True)
   for lilac_hf_dataset in hf_config.get('datasets', []):
-    print('Downloading dataset from HuggingFace: ', lilac_hf_dataset)
+    log('Downloading dataset from HuggingFace: ', lilac_hf_dataset)
     snapshot_download(
       repo_id=lilac_hf_dataset,
       repo_type='dataset',

--- a/lilac/load_test.py
+++ b/lilac/load_test.py
@@ -24,7 +24,7 @@ from .db_manager import get_dataset
 from .env import set_project_dir
 from .load import load
 from .project import PROJECT_CONFIG_FILENAME, init
-from .schema import EMBEDDING_KEY, Field, Item, RichData, field, lilac_embedding, schema
+from .schema import EMBEDDING_KEY, Field, Item, RichData, chunk_embedding, field, schema
 from .signal import TextEmbeddingSignal, TextSignal, clear_signal_registry, register_signal
 from .source import Source, SourceSchema, clear_source_registry, register_source
 from .utils import to_yaml
@@ -77,7 +77,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 class TestSignal(TextSignal):

--- a/lilac/load_test.py
+++ b/lilac/load_test.py
@@ -25,7 +25,13 @@ from .env import set_project_dir
 from .load import load
 from .project import PROJECT_CONFIG_FILENAME, init
 from .schema import EMBEDDING_KEY, Field, Item, RichData, chunk_embedding, field, schema
-from .signal import TextEmbeddingSignal, TextSignal, clear_signal_registry, register_signal
+from .signal import (
+  TextEmbeddingSignal,
+  TextSignal,
+  clear_signal_registry,
+  register_embedding,
+  register_signal,
+)
 from .source import Source, SourceSchema, clear_source_registry, register_source
 from .utils import to_yaml
 
@@ -99,7 +105,7 @@ def setup_teardown() -> Iterable[None]:
   # Setup.
   register_source(TestSource)
   register_signal(TestSignal)
-  register_signal(TestEmbedding)
+  register_embedding(TestEmbedding)
 
   # Unit test runs.
   yield

--- a/lilac/router_utils.py
+++ b/lilac/router_utils.py
@@ -10,6 +10,7 @@ from .auth import UserInfo
 from .concepts.db_concept import DISK_CONCEPT_DB, DISK_CONCEPT_MODEL_DB
 from .schema import Item, RichData
 from .signals.concept_scorer import ConceptSignal
+from .utils import log
 
 
 class RouteErrorHandler(APIRoute):
@@ -26,8 +27,8 @@ class RouteErrorHandler(APIRoute):
         if isinstance(ex, HTTPException):
           raise ex
 
-        print('Route error:', request.url)
-        print(traceback.format_exc())
+        log('Route error:', request.url)
+        log(traceback.format_exc())
 
         # wrap error into pretty 500 exception
         detail = ''.join(traceback.format_exception_only(type(ex), ex))

--- a/lilac/schema.py
+++ b/lilac/schema.py
@@ -481,8 +481,14 @@ def span(start: int, end: int, metadata: dict[str, Any] = {}) -> Item:
   return {SPAN_KEY: {TEXT_SPAN_START_FEATURE: start, TEXT_SPAN_END_FEATURE: end}, **metadata}
 
 
-def lilac_embedding(start: int, end: int, embedding: Optional[np.ndarray]) -> Item:
-  """Creates a lilac embedding item, representing a vector with a pointer to a slice of text."""
+def chunk_embedding(start: int, end: int, embedding: Optional[np.ndarray]) -> Item:
+  """Creates a lilac chunk embedding: a vector with a pointer to a chunk of text.
+
+  Args:
+    start: The start character of of the chunk with respect to the original text.
+    end: The end character of the chunk with respect to the original text.
+    embedding: The embedding vector for the chunk.
+  """
   # Cast to int; we've had issues where start/end were np.int64, which caused downstream sadness.
   return span(int(start), int(end), {EMBEDDING_KEY: embedding})
 

--- a/lilac/server_concept_test.py
+++ b/lilac/server_concept_test.py
@@ -31,7 +31,7 @@ from .router_concept import (
 )
 from .schema import Item, RichData, chunk_embedding, span
 from .server import app
-from .signal import TextEmbeddingSignal, clear_signal_registry, register_signal
+from .signal import TextEmbeddingSignal, clear_signal_registry, register_embedding
 from .test_utils import fake_uuid
 
 client = TestClient(app)
@@ -61,7 +61,7 @@ class TestEmbedding(TextEmbeddingSignal):
 @pytest.fixture(scope='module', autouse=True)
 def setup_teardown() -> Iterable[None]:
   # Setup.
-  register_signal(TestEmbedding)
+  register_embedding(TestEmbedding)
   # Unit test runs.
   yield
   # Teardown.

--- a/lilac/server_concept_test.py
+++ b/lilac/server_concept_test.py
@@ -29,7 +29,7 @@ from .router_concept import (
   ScoreBody,
   ScoreExample,
 )
-from .schema import Item, RichData, lilac_embedding, span
+from .schema import Item, RichData, chunk_embedding, span
 from .server import app
 from .signal import TextEmbeddingSignal, clear_signal_registry, register_signal
 from .test_utils import fake_uuid
@@ -55,7 +55,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Call the embedding function."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -219,6 +219,25 @@ class TextEmbeddingSignal(TextSignal):
     return field(fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})])
 
 
+def create_user_text_embedding_signal(embedding_name: str) -> TextEmbeddingSignal:
+  """Create a user text embedding signal."""
+
+  class UserTextEmbeddingSignal(TextEmbeddingSignal):
+    """This class is a shim for user-provided text embeddings.
+
+    The entire app assumes that when embeddings are computed, they are from an embedding signal, so
+    we create this dummy user text embedding signal just to make sure that the app doesn't break.
+    """
+
+    name: ClassVar[str] = embedding_name
+
+    @override
+    def compute(self, docs: list[str]) -> list[Optional[Item]]:
+      raise ValueError('User text embeddings cannot be computed.')
+
+  return UserTextEmbeddingSignal()
+
+
 def _vector_signal_schema_extra(schema: dict[str, Any], signal: Type['Signal']) -> None:
   """Add the enum values for embeddings."""
   embeddings: list[str] = []

--- a/lilac/signals/__init__.py
+++ b/lilac/signals/__init__.py
@@ -1,12 +1,20 @@
 """Signals enrich a document with additional metadata."""
 
-from ..signal import Signal, SignalInputType, TextEmbeddingSignal, TextSignal, register_signal
+from ..signal import (
+  Signal,
+  SignalInputType,
+  TextEmbeddingSignal,
+  TextSignal,
+  register_embedding,
+  register_signal,
+)
 from .concept_scorer import ConceptSignal
 from .default_signals import register_default_signals
 from .lang_detection import LangDetectionSignal
 from .near_dup import NearDuplicateSignal
 from .ner import SpacyNER
 from .pii import PIISignal
+from .semantic_similarity import SemanticSimilaritySignal
 from .text_statistics import TextStatisticsSignal
 
 register_default_signals()
@@ -15,8 +23,10 @@ __all__ = [
   'Signal',
   'TextEmbeddingSignal',
   'TextStatisticsSignal',
+  'SemanticSimilaritySignal',
   'TextSignal',
   'register_signal',
+  'register_embedding',
   'SignalInputType',
   'LangDetectionSignal',
   'NearDuplicateSignal',

--- a/lilac/signals/concept_scorer_test.py
+++ b/lilac/signals/concept_scorer_test.py
@@ -20,7 +20,7 @@ from ..concepts.db_concept import (
 from ..data.dataset_duckdb import DatasetDuckDB
 from ..data.dataset_test_utils import make_vector_index
 from ..db_manager import set_default_dataset_cls
-from ..schema import Item, RichData, SignalInputType, lilac_embedding
+from ..schema import Item, RichData, SignalInputType, chunk_embedding
 from ..signal import TextEmbeddingSignal, clear_signal_registry, register_signal
 from .concept_scorer import ConceptSignal
 
@@ -54,7 +54,7 @@ class TestEmbedding(TextEmbeddingSignal):
     for example in data:
       if example not in EMBEDDING_MAP:
         raise ValueError(f'Example "{str(example)}" not in embedding map')
-      yield [lilac_embedding(0, len(example), np.array(EMBEDDING_MAP[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(EMBEDDING_MAP[cast(str, example)]))]
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/lilac/signals/default_signals.py
+++ b/lilac/signals/default_signals.py
@@ -20,29 +20,29 @@ from .text_statistics import TextStatisticsSignal
 def register_default_signals() -> None:
   """Register all the default signals."""
   # Concepts.
-  register_signal(ConceptSignal)
-  register_signal(ConceptLabelsSignal)
+  register_signal(ConceptSignal, exists_ok=True)
+  register_signal(ConceptLabelsSignal, exists_ok=True)
 
   # Text.
-  register_signal(PIISignal)
-  register_signal(TextStatisticsSignal)
-  register_signal(SpacyNER)
-  register_signal(NearDuplicateSignal)
-  register_signal(LangDetectionSignal)
-  register_signal(MarkdownCodeBlockSignal)
+  register_signal(PIISignal, exists_ok=True)
+  register_signal(TextStatisticsSignal, exists_ok=True)
+  register_signal(SpacyNER, exists_ok=True)
+  register_signal(NearDuplicateSignal, exists_ok=True)
+  register_signal(LangDetectionSignal, exists_ok=True)
+  register_signal(MarkdownCodeBlockSignal, exists_ok=True)
 
   # Embeddings.
-  register_signal(Cohere)
+  register_signal(Cohere, exists_ok=True)
 
-  register_signal(SBERT)
+  register_signal(SBERT, exists_ok=True)
 
-  register_signal(OpenAIEmbedding)
+  register_signal(OpenAIEmbedding, exists_ok=True)
 
-  register_signal(PaLM)
+  register_signal(PaLM, exists_ok=True)
 
-  register_signal(GTETiny)
-  register_signal(GTESmall)
-  register_signal(GTEBase)
+  register_signal(GTETiny, exists_ok=True)
+  register_signal(GTESmall, exists_ok=True)
+  register_signal(GTEBase, exists_ok=True)
 
-  register_signal(JinaV2Small)
-  register_signal(JinaV2Base)
+  register_signal(JinaV2Small, exists_ok=True)
+  register_signal(JinaV2Base, exists_ok=True)

--- a/lilac/signals/semantic_similarity_test.py
+++ b/lilac/signals/semantic_similarity_test.py
@@ -53,6 +53,10 @@ class TestVectorStore(VectorStore):
     keys = keys or []
     return np.array([EMBEDDINGS[tuple(path_key)][cast(int, index)] for *path_key, index in keys])
 
+  @override
+  def delete(self, base_path: str) -> None:
+    raise NotImplementedError
+
 
 class TestEmbedding(TextEmbeddingSignal):
   """A test embed function."""

--- a/lilac/signals/semantic_similarity_test.py
+++ b/lilac/signals/semantic_similarity_test.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 
 from ..data.dataset_test_utils import make_vector_index
 from ..embeddings.vector_store import VectorStore, register_vector_store
-from ..schema import Item, RichData, VectorKey, lilac_embedding, span
+from ..schema import Item, RichData, VectorKey, chunk_embedding, span
 from ..signal import TextEmbeddingSignal, clear_signal_registry, register_signal
 from .semantic_similarity import SemanticSimilaritySignal
 
@@ -63,7 +63,7 @@ class TestEmbedding(TextEmbeddingSignal):
   def compute(self, data: Iterable[RichData]) -> Iterator[Item]:
     """Embed the examples, use a hashmap to the vector for simplicity."""
     for example in data:
-      yield [lilac_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
+      yield [chunk_embedding(0, len(example), np.array(STR_EMBEDDINGS[cast(str, example)]))]
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/notebooks/CustomEmbeddings.ipynb
+++ b/notebooks/CustomEmbeddings.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Custom embeddings\n",
+    "\n",
+    "This notebook will show to use custom embeddings in Lilac.\n",
+    "\n",
+    "When making a custom embedding, you have to register an embedding function with Lilac, but you do not have to compute embeddings for the entire dataset in Lilac. Embeddings from an existing vector store can be loaded with [`Dataset.load_embeddings`](https://docs.lilacml.com/api_reference/data.html#lilac.data.Dataset.load_embeddings)\n",
+    "\n",
+    "For more information on embeddings, see our [Embeddings](https://docs.lilacml.com/datasets/dataset_embeddings.html) guide.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "import lilac as ll\n",
+    "\n",
+    "ll.set_project_dir('./data')\n",
+    "\n",
+    "items = [\n",
+    "  {'id': '0_', 'text': 'This is some fake data'},\n",
+    "  {'id': '1_', 'text': 'This is some more fake data'},\n",
+    "  {'id': '2_', 'text': 'This is even more fake data'},\n",
+    "  {'id': '3_', 'text': 'I love plants'},\n",
+    "]\n",
+    "# Load a fake dataset from dictionaries.\n",
+    "try:\n",
+    "  ds = ll.get_dataset('local', 'load_embedding')\n",
+    "except Exception as e:\n",
+    "  ds = ll.from_dicts('local', 'load_embedding', items)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Register an embedding function\n",
+    "\n",
+    "For embeddings to be useful in Lilac, we must be able to compute new embeddings\n",
+    "\n",
+    "This means we have to register an embedding function under a name so that we can call it from semantic searches (embedding the query) or from concept search (embedding concept data).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Testing the embedding on a single item...\n",
+      "[{'__span__': {'start': 0, 'end': 17}, 'embedding': array([-4.39735241e-02, -9.28446930e-03,  4.57611308e-02, -3.19548771e-02,\n",
+      "        8.43660533e-03,  9.48431529e-03,  5.90084903e-02,  5.59187271e-02,\n",
+      "       -1.78449824e-02, -5.01370244e-02,  8.36663414e-03, -5.73770069e-02,\n",
+      "        9.36811697e-03,  1.31201018e-02, -1.38591407e-02, -2.79680942e-03,\n",
+      "        1.27376560e-02, -2.13926788e-02, -5.75558171e-02,  3.24781537e-02,\n",
+      "        7.07704574e-02,  2.67298613e-02, -2.15108655e-02, -1.52723445e-02,\n",
+      "        5.37770353e-02,  2.32838802e-02, -1.45876221e-02, -3.92815508e-02,\n",
+      "       -8.67534149e-03, -1.66421592e-01, -7.23247370e-03,  2.60695047e-03,\n",
+      "        4.72562760e-02, -5.58551177e-02, -1.39868818e-03, -8.96183029e-03,\n",
+      "       -5.59775271e-02,  6.02203384e-02, -2.89687067e-02,  3.60556208e-02,\n",
+      "        3.68024521e-02, -3.64479795e-02, -5.02835214e-03, -4.53025363e-02,\n",
+      "       -2.61498820e-02, -7.03798011e-02, -5.70576228e-02, -3.78287770e-02,\n",
+      "        1.76253114e-02, -4.91252914e-02,  2.62264106e-02,  9.68559354e-04,\n",
+      "       -4.24263300e-03, -7.24040298e-03,  1.87096968e-02,  4.51337509e-02,\n",
+      "        5.70538789e-02,  4.94649746e-02,  3.54286842e-02,  1.33729139e-02,\n",
+      "        3.20986249e-02,  3.85782048e-02, -2.25227967e-01,  1.25819832e-01,\n",
+      "        2.57874522e-02,  3.28232744e-03, -3.83680612e-02, -2.30490186e-04,\n",
+      "        5.14140092e-02,  3.93648520e-02, -3.75990160e-02,  2.29944550e-02,\n",
+      "        1.89062431e-02,  6.84182495e-02, -7.92450085e-03, -2.69938596e-02,\n",
+      "       -3.01054977e-02, -4.91223559e-02,  8.13283399e-03,  2.19072197e-02,\n",
+      "        3.33208754e-03, -2.19486319e-02,  1.44597339e-02, -3.38134170e-03,\n",
+      "       -5.36277071e-02, -5.32854572e-02, -9.22775827e-03, -2.93167438e-02,\n",
+      "        4.00652848e-02, -1.89703761e-03, -2.98962276e-02, -7.73666147e-03,\n",
+      "        2.39082146e-02,  8.84186197e-03, -4.58775237e-02, -1.93526261e-02,\n",
+      "        3.40101533e-02, -6.99519133e-03,  1.11258728e-02,  2.32716054e-01,\n",
+      "       -6.28979802e-02,  2.47108098e-02,  4.64564413e-02, -9.61099006e-03,\n",
+      "        1.02606900e-02, -2.15526689e-02,  1.26665747e-02, -4.23083417e-02,\n",
+      "       -3.75740528e-02,  1.82393268e-02, -3.29855038e-03, -1.52005898e-02,\n",
+      "        9.17492993e-03, -2.25046780e-02,  4.73027304e-02, -1.30696893e-02,\n",
+      "        6.55562282e-02,  3.80051993e-02, -9.58174816e-04,  1.14183538e-02,\n",
+      "       -1.91028118e-02,  1.60282142e-02,  1.43870199e-02, -1.42485043e-02,\n",
+      "        6.50884211e-02, -7.10930154e-02,  6.00317754e-02,  1.02917612e-01,\n",
+      "        5.39738908e-02,  1.84119977e-02,  4.23884019e-02,  9.11878515e-03,\n",
+      "       -3.11106928e-02, -3.48473899e-02, -3.50664258e-02,  1.51163395e-02,\n",
+      "       -1.38842324e-02,  2.60395231e-03,  2.15508882e-02, -6.76768646e-02,\n",
+      "       -2.39691865e-02, -1.36866286e-01, -2.43556332e-02, -1.19492628e-01,\n",
+      "       -6.14276789e-02,  6.34225756e-02,  3.73305473e-03,  5.43350615e-02,\n",
+      "       -5.55165932e-02, -1.34935156e-02, -1.31179951e-02,  5.41530959e-02,\n",
+      "       -2.14719921e-02, -1.21977832e-02,  2.52397116e-02, -2.74596009e-02,\n",
+      "        3.97148393e-02,  3.62676233e-02, -6.06627017e-02,  3.13008167e-02,\n",
+      "        2.00557169e-02, -3.79323550e-02, -3.25453877e-02,  1.27246231e-01,\n",
+      "        3.04672904e-02, -1.11378610e-01, -4.22729589e-02, -1.62340216e-02,\n",
+      "        8.47518910e-03, -2.65603680e-02,  2.88859941e-02,  2.67571006e-02,\n",
+      "       -4.13879007e-02,  6.14852756e-02,  6.53700083e-02,  1.51177403e-02,\n",
+      "       -2.98494697e-02,  4.26297355e-03, -5.43835294e-03,  3.34546305e-02,\n",
+      "        4.01177481e-02, -4.11894284e-02, -3.45960706e-02,  5.58982305e-02,\n",
+      "        2.79217456e-02, -3.21064591e-02, -1.62213482e-02, -6.21478632e-02,\n",
+      "        2.12123916e-02,  2.06543114e-02, -2.30661631e-02,  7.18063042e-02,\n",
+      "       -2.45512538e-02, -3.26925442e-02, -6.34562224e-02, -2.92757712e-03,\n",
+      "       -2.57320851e-02, -3.79187465e-02, -2.07359642e-02, -3.02065611e-02,\n",
+      "        4.48752083e-02,  2.00069454e-02, -4.80789989e-02,  2.60105990e-02,\n",
+      "        7.46281678e-03,  1.74651816e-02,  1.13370372e-02,  5.61753463e-04,\n",
+      "        1.12274289e-02, -3.03209145e-02, -3.99290211e-02,  5.21994308e-02,\n",
+      "        1.87836625e-02, -1.57606194e-03, -1.87910497e-02, -1.62748285e-02,\n",
+      "        1.14851594e-02,  4.17079479e-02, -1.86803006e-02,  1.55243818e-02,\n",
+      "       -1.01187732e-02, -8.63769054e-02, -4.49596941e-02, -2.31446773e-01,\n",
+      "        1.43295275e-02,  1.12035060e-02, -4.86242212e-02,  3.97708677e-02,\n",
+      "       -1.69103984e-02,  3.39829512e-02, -2.23324727e-02,  5.07147647e-02,\n",
+      "        7.55643025e-02,  7.00387731e-02, -2.80953906e-02, -2.14203279e-02,\n",
+      "       -4.23438818e-04,  1.53467804e-02,  5.40248156e-02,  7.39449682e-03,\n",
+      "        1.60025600e-02,  2.21551885e-03,  2.02767253e-02, -1.84773915e-02,\n",
+      "       -1.01584112e-02, -2.82454230e-02, -4.33561541e-02,  4.88963164e-02,\n",
+      "       -1.18346820e-02,  2.21260265e-01,  1.15226172e-01,  2.93488204e-02,\n",
+      "       -5.76255023e-02,  5.14890254e-02,  2.13495232e-02,  4.32722270e-03,\n",
+      "       -7.80859962e-02,  4.26553674e-02,  3.94582897e-02,  1.01066483e-02,\n",
+      "       -1.70017518e-02, -4.47423160e-02, -3.73657886e-03, -9.89677198e-03,\n",
+      "        6.46085218e-02,  2.89389980e-03, -5.78800850e-02, -4.39192243e-02,\n",
+      "       -5.09524234e-02, -3.47328335e-02, -1.45356432e-02, -6.81961998e-02,\n",
+      "        3.99697945e-02,  3.05952039e-02, -4.30575125e-02,  2.90555712e-02,\n",
+      "        4.61442769e-02,  2.96799801e-02, -1.31074646e-02, -1.21429950e-01,\n",
+      "        9.44986660e-03, -3.08850221e-02,  2.88082231e-02,  2.59405328e-03,\n",
+      "       -1.68599263e-02,  1.58408340e-02, -4.99515124e-02,  3.71913016e-02,\n",
+      "        3.20708752e-02, -1.60497464e-02, -5.91248572e-02,  2.48909499e-02,\n",
+      "       -1.07513927e-02, -5.60467271e-03,  3.16081978e-02, -3.61951180e-02,\n",
+      "       -4.27424312e-02,  3.86971235e-02,  5.90188541e-02,  4.91246320e-02,\n",
+      "        1.42127704e-02, -4.47982103e-02, -3.10373083e-02,  1.02228113e-02,\n",
+      "        8.65050778e-03,  1.59131363e-02,  5.04547879e-02, -9.12769232e-03,\n",
+      "        9.22143832e-03,  3.87291238e-02, -5.03061414e-02,  5.30913286e-02,\n",
+      "       -3.43675725e-02,  6.50202483e-03,  5.21517619e-02, -2.89056897e-02,\n",
+      "       -4.51964997e-02,  7.40819331e-03, -3.08206566e-02, -3.00171822e-01,\n",
+      "        3.75145711e-02, -4.50131157e-03, -2.01970781e-03, -4.40680832e-02,\n",
+      "        3.91510874e-02,  5.92548065e-02,  5.69307730e-02, -1.05794609e-01,\n",
+      "        1.10388212e-02, -9.41633899e-03,  4.97216210e-02,  1.24368528e-02,\n",
+      "       -1.68958362e-02, -1.18479291e-02,  4.82368506e-02,  8.50489512e-02,\n",
+      "       -8.80272165e-02, -8.02026480e-04, -7.85567537e-02,  8.76908936e-03,\n",
+      "        7.00512994e-03,  1.91530406e-01, -2.53157225e-02,  4.18267306e-03,\n",
+      "        3.29622924e-02, -9.14285332e-03,  1.53724607e-02,  6.52871057e-02,\n",
+      "       -2.34898105e-02,  5.69275431e-02,  1.43813901e-02,  9.45839882e-02,\n",
+      "       -2.04234049e-02,  6.41784072e-02,  5.14972780e-04, -2.62881890e-02,\n",
+      "        4.79228534e-02,  1.62316358e-03,  2.92370096e-02, -2.18462534e-02,\n",
+      "        5.08508906e-02, -1.07988857e-01, -1.55504746e-02,  1.15721837e-01,\n",
+      "        1.38980998e-02, -7.17592798e-03, -4.22822312e-02,  8.29605479e-03,\n",
+      "        3.38608921e-02, -6.07384667e-02,  4.37516794e-02, -2.34813225e-02,\n",
+      "       -1.69972684e-02,  3.54364067e-02,  5.95175140e-02, -4.48691398e-02,\n",
+      "       -5.69155253e-02, -3.76485959e-02, -9.80093703e-03,  3.81507422e-03,\n",
+      "       -3.69908325e-02, -3.02194487e-02,  7.84944370e-02,  6.18109666e-02],\n",
+      "      dtype=float32)}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "try:\n",
+    "  from sentence_transformers import SentenceTransformer\n",
+    "except ImportError:\n",
+    "  raise ImportError(\n",
+    "    'Could not import the \"sentence_transformers\" python package. '\n",
+    "    'Please install it with `pip install \"sentence_transformers\".'\n",
+    "  )\n",
+    "\n",
+    "embedding_model = SentenceTransformer('thenlper/gte-small')\n",
+    "\n",
+    "\n",
+    "def _embed(text):\n",
+    "  # Call the gte-small embedding model.\n",
+    "  return np.array(embedding_model.encode(text))\n",
+    "\n",
+    "\n",
+    "# Make an embedding class.\n",
+    "class MyEmbedding(ll.TextEmbeddingSignal):\n",
+    "  name = 'my_embedding'\n",
+    "\n",
+    "  def compute(self, data):\n",
+    "    for text in data:\n",
+    "      embedding = _embed(text)\n",
+    "      # Yield a full chunk embedding. If you want to chunk your text, yield an array here.\n",
+    "      yield [ll.chunk_embedding(0, len(text), embedding)]\n",
+    "\n",
+    "\n",
+    "print('Testing the embedding on a single item...')\n",
+    "print(next(MyEmbedding().compute(['This is some text'])))\n",
+    "\n",
+    "# Register the embedding under 'my_embedding' so it can be used by Lilac.\n",
+    "ll.register_embedding(MyEmbedding, exists_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load full-document embeddings from our vector store\n",
+    "\n",
+    "First, let's compute full-document embeddings manually with gte-small, from the sentence_transformers library.\n",
+    "\n",
+    "Our vector store is just a dictionary in this example.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Load embedding my_embedding on load_embedding:('text',): 100%|██████████| 4/4 [00:00<00:00, 2032.62it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hnswlib index creation took 0.001s.\n",
+      "hnswlib add items took 0.000s.\n",
+      "Wrote embedding index to ./data/datasets/local/load_embedding/text/my_embedding\n"
+     ]
+    }
+   ],
+   "source": [
+    "vector_store = {}\n",
+    "for item in items:\n",
+    "  vector_store[item['id']] = _embed(item['text'])\n",
+    "\n",
+    "\n",
+    "# Load the embeddings into Lilac.\n",
+    "def _load_embedding(item):\n",
+    "  return vector_store[item['id']]\n",
+    "\n",
+    "\n",
+    "# Load the embeddings into Lilac.\n",
+    "ds.load_embedding(\n",
+    "  load_fn=_load_embedding, index_path='text', embedding='my_embedding', overwrite=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Semantic search with our custom embedding\n",
+    "\n",
+    "Now we can rank documents with our custom embedding.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing signal \"semantic_similarity\" on local/load_embedding:('text',) took 0.016s.\n",
+      "This is some fake data 0.9254916310310364\n",
+      "This is some more fake data 0.9084776043891907\n",
+      "This is even more fake data 0.8841889500617981\n",
+      "I love plants 0.7808101177215576\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Select rows using a semantic search.\n",
+    "rows = ds.select_rows(\n",
+    "  ['text'],\n",
+    "  searches=[\n",
+    "    ll.SemanticSearch(path='text', query='This is some data', embedding='my_embedding'),\n",
+    "  ],\n",
+    ")\n",
+    "\n",
+    "for row in rows:\n",
+    "  print(\n",
+    "    row['text'],\n",
+    "    row['text.semantic_similarity(embedding=my_embedding,query=This is some data)'][0]['score'],\n",
+    "  )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/deploy_demo.py
+++ b/scripts/deploy_demo.py
@@ -35,7 +35,7 @@ from lilac.db_manager import list_datasets
 from lilac.deploy import deploy_project
 from lilac.env import env
 from lilac.load import load
-from lilac.utils import get_datasets_dir, get_hf_dataset_repo_id
+from lilac.utils import get_datasets_dir, get_hf_dataset_repo_id, log
 
 
 @click.command()
@@ -105,7 +105,7 @@ def deploy_demo(
       if repo_id not in hf_dataset_repos:
         continue
 
-      print(f'Downloading dataset from HuggingFace "{repo_id}": ', dataset)
+      log(f'Downloading dataset from HuggingFace "{repo_id}": ', dataset)
       snapshot_download(
         repo_id=repo_id,
         repo_type='dataset',


### PR DESCRIPTION
- Add `Dataset.load_embeddings`, which takes a lambda, an index_path (the text field) and loads embeddings into our vector store.
- Add `ll.register_embedding` which wraps `ll.register_signal`
- Rename `ll.lilac_embedding` => `ll.chunk_embedding` which is now public API.
- Add `Dataset.delete_embedding` which deletes an embedding and its index.

Fixes https://github.com/lilacai/lilac/issues/1080 and https://github.com/lilacai/lilac/issues/1087

Documentation:
- Ad of docs for compute custom embeddings, and loading embeddings.
- Add an accompanying notebook for loading custom embeddings.

Other fixes:
- Centralize the get_vector_index since it was used in two places
- Add exists_ok to register_signal in case of double registration