### PR TITLE
Fix a bug where we drop source fields that have embeddings computed on them

### DIFF
--- a/web/blueprint/src/lib/components/datasetView/ExportModal.svelte
+++ b/web/blueprint/src/lib/components/datasetView/ExportModal.svelte
@@ -6,6 +6,7 @@
     DELETED_LABEL_KEY,
     childFields,
     isClusterField,
+    isEmbeddingField,
     isLabelField,
     isLabelRootField,
     isMapField,
@@ -83,9 +84,7 @@
 
   function getFields(schema: LilacSchema) {
     const allFields = childFields(schema);
-    const petalFields = petals(schema).filter(
-      f => !childFields(f).some(f => f.dtype?.type === 'embedding')
-    );
+    const petalFields = petals(schema).filter(f => !isEmbeddingField(f));
 
     const labelFields = allFields.filter(f => isLabelRootField(f));
     const enrichedFields = allFields

--- a/web/lib/src/lilac.ts
+++ b/web/lib/src/lilac.ts
@@ -307,6 +307,26 @@ export function isLabelField(field: LilacField): boolean {
   return getLabel(field) != null;
 }
 
+/** Determine if a field is produced by a embedding. */
+export function isEmbeddingField(field: LilacField): boolean {
+  return hasSignalParent(field) && hasEmbeddingChild(field);
+}
+
+function hasSignalParent(field: LilacField): boolean {
+  const parentHasSignal = field.parent != null && field.parent.signal != null;
+  if (parentHasSignal) {
+    return true;
+  }
+  if (field.parent) {
+    return hasSignalParent(field.parent);
+  }
+  return false;
+}
+
+function hasEmbeddingChild(field: LilacField): boolean {
+  return childFields(field).some(f => f.dtype?.type === 'embedding');
+}
+
 export function getSchemaLabels(schema: LilacSchema | LilacField): string[] {
   return childFields(schema)
     .map(f => f.label)


### PR DESCRIPTION
<img width="905" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/a7c70d97-9545-4905-85df-91d5c4b979f3">


https://lilacai-nikhil-staging.hf.space/datasets#local/Capybara