### PR TITLE
Bug fixes: overwrite, task errors, embedding keys.

### DIFF
--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -389,7 +389,7 @@ class Dataset(abc.ABC):
   def config(self) -> DatasetConfig:
     """Return the dataset config for this dataset."""
     manifest = self.manifest()
-    project_config = read_project_config(get_project_dir())
+    project_config = read_project_config(self.project_dir)
     dataset_config = get_dataset_config(project_config, self.namespace, self.dataset_name)
     if not dataset_config:
       raise ValueError(

--- a/lilac/router_dataset_signals.py
+++ b/lilac/router_dataset_signals.py
@@ -11,7 +11,7 @@ from .auth import UserInfo, get_session_user, get_user_access
 from .db_manager import get_dataset
 from .router_utils import RouteErrorHandler
 from .schema import Path
-from .signal import Signal, TextEmbeddingSignal, resolve_signal
+from .signal import Signal, resolve_signal
 from .tasks import TaskId, get_task_manager, launch_task
 
 router = APIRouter(route_class=RouteErrorHandler)
@@ -24,6 +24,8 @@ class ComputeSignalOptions(BaseModel):
 
   # The leaf path to compute the signal on.
   leaf_path: Path
+
+  overwrite: bool = False
 
   @field_validator('signal', mode='before')
   @classmethod
@@ -67,8 +69,7 @@ def compute_signal(
     dataset.compute_signal(
       signal,
       options.leaf_path,
-      # Overwrite for text embeddings since we don't have UI to control deleting embeddings.
-      overwrite=isinstance(options.signal, TextEmbeddingSignal),
+      overwrite=options.overwrite,
       task_id=task_id,
       use_garden=signal.use_garden,
     )

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -224,6 +224,11 @@ class TextEmbeddingSignal(TextSignal):
     """
     return field(fields=[field('string_span', fields={EMBEDDING_KEY: 'embedding'})])
 
+  @override
+  def key(self, is_computed_signal: Optional[bool] = False) -> str:
+    """Get the key for an embedding. This is exactly the embedding name, regardless of garden."""
+    return self.name
+
 
 def _vector_signal_schema_extra(schema: dict[str, Any], signal: Type['Signal']) -> None:
   """Add the enum values for embeddings."""

--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -160,9 +160,9 @@ clusters:
   - dataset_namespace: lilac
     dataset_name: Capybara
     input_path:
-      - - conversation
-        - '*'
-        - input
+      - conversation
+      - '*'
+      - input
     use_garden: true
   - dataset_namespace: lilac
     dataset_name: glaive

--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -21,6 +21,12 @@ datasets:
           - '*'
           - input
         use_garden: true
+      - embedding: gte-small
+        path:
+          - conversation
+          - '*'
+          - output
+        use_garden: true
 
   - namespace: lilac
     name: glaive

--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -14,6 +14,7 @@ datasets:
             - '*'
             - output
         markdown_paths: []
+      tags: [dataset]
     embeddings:
       - embedding: gte-small
         path:
@@ -156,6 +157,13 @@ concept_model_cache_embeddings:
   # - palm
 
 clusters:
+  - dataset_namespace: lilac
+    dataset_name: Capybara
+    input_path:
+      - - conversation
+        - '*'
+        - input
+    use_garden: true
   - dataset_namespace: lilac
     dataset_name: glaive
     input_path:

--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -7,7 +7,6 @@ datasets:
     settings:
       ui:
         media_paths:
-          - input
           - - conversation
             - '*'
             - input

--- a/web/blueprint/src/lib/components/TaskStatus.svelte
+++ b/web/blueprint/src/lib/components/TaskStatus.svelte
@@ -78,13 +78,14 @@
               task.total_progress != null && task.total_len != null
                 ? task.total_progress / task.total_len
                 : undefined}
+            {@const message = task.error ?? task.message}
             <div class="relative border-b-2 border-slate-200 p-4 text-left last:border-b-0">
               <div class="text-s flex flex-row">
                 <div class="mr-2">{task.name}</div>
               </div>
               <div class="progress-container mt-3">
                 <ProgressBar
-                  labelText={task.message || ''}
+                  labelText={message || ''}
                   helperText={task.status != 'completed' ? task.details || undefined : ''}
                   value={task.status === 'completed' ? 1.0 : progressValue}
                   max={1.0}

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -27,7 +27,13 @@
     type Signal,
     type SignalInfoWithTypedSchema
   } from '$lilac';
-  import {ComposedModal, ModalBody, ModalFooter, ModalHeader} from 'carbon-components-svelte';
+  import {
+    ComposedModal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Toggle
+  } from 'carbon-components-svelte';
   import type {JSONSchema4Type, JSONSchema7} from 'json-schema';
   import type {JSONError} from 'json-schema-library';
   import {SvelteComponent, createEventDispatcher, getContext, setContext} from 'svelte';
@@ -58,6 +64,8 @@
   let signalInfo: SignalInfoWithTypedSchema | undefined;
   let signalPropertyValues: Record<string, Record<string, JSONSchema4Type>> = {};
   let errors: JSONError[] = [];
+
+  let overwrite = false;
 
   const HIDDEN_PROPERTIES = [
     // Hide the signal name as it's just used for type coersion.
@@ -193,6 +201,10 @@
               hiddenProperties={HIDDEN_PROPERTIES}
               customComponents={customComponents[signalInfo?.name]}
             />
+            <div class="mt-8">
+              <div class="label text-s mb-2 font-medium text-gray-700">Overwrite</div>
+              <Toggle labelA={'False'} labelB={'True'} bind:toggled={overwrite} hideLabel />
+            </div>
           {/key}
         {:else}
           No signal selected

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -134,7 +134,8 @@
         command.datasetName,
         {
           leaf_path: path || [],
-          signal
+          signal,
+          overwrite
         }
       ]);
     } else if (command.command === Command.PreviewConcept) {

--- a/web/lib/fastapi_client/models/ComputeSignalOptions.ts
+++ b/web/lib/fastapi_client/models/ComputeSignalOptions.ts
@@ -11,5 +11,6 @@ import type { Signal } from './Signal';
 export type ComputeSignalOptions = {
     signal: Signal;
     leaf_path: (Array<string> | string);
+    overwrite?: boolean;
 };
 


### PR DESCRIPTION
- Fix issue with embedding keys being long when using use_garden=True.
- Add overwrite=True to the UI.
- Fix issue with task errors not propagating to the UI.

<img width="459" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/229c4dd9-97d9-4acb-8232-ee7655242920">
