### PR TITLE
Fixed cache busting behavior

### DIFF
--- a/lilac/hf_docker_start.py
+++ b/lilac/hf_docker_start.py
@@ -100,6 +100,7 @@ def _hf_docker_start() -> None:
       repo_type='dataset',
       token=env('HF_ACCESS_TOKEN'),
       local_dir=datasets_dir,
+      local_dir_use_symlinks=True,
       ignore_patterns=['.gitattributes', 'README.md'],
     )
 


### PR DESCRIPTION
the stupid bug that took hours to find: small files didn't use symlinks and their mtimes kept on getting bumped even with no changes, causing startups to always bust cache and recompute indices.