### PR TITLE
Move use_garden outside of a Signal.

### DIFF
--- a/lilac/config.py
+++ b/lilac/config.py
@@ -62,9 +62,6 @@ class EmbeddingConfig(BaseModel):
 
   path: PathTuple
   embedding: str
-  use_garden: bool = PydanticField(
-    default=False, description='Accelerate computation by running remotely on Lilac Garden.'
-  )
 
   model_config = ConfigDict(extra='forbid')
 
@@ -153,9 +150,6 @@ class ClusterConfig(BaseModel):
   input_selector: Optional[ClusterInputSelectorConfig] = None
   output_path: Optional[PathTuple] = None
   min_cluster_size: int = 5
-  use_garden: bool = PydanticField(
-    default=False, description='Accelerate computation by running remotely on Lilac Garden.'
-  )
 
   @field_validator('input_selector')
   def check_inputs(
@@ -212,6 +206,12 @@ class Config(BaseModel):
 
   datasets: list[DatasetConfig] = PydanticField(
     description='The configurations for the datasets in the project.', default=[]
+  )
+
+  use_garden: bool = PydanticField(
+    default=False,
+    description='Accelerate computation by running remotely on Lilac Garden. '
+    'Signals, embeddings, and clusters will be run remotely if they support Lilac Garden.',
   )
 
   # When defined, uses this list of signals to run over every dataset, over all media paths, unless

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -238,6 +238,9 @@ class SignalManifest(BaseModel):
   # The lilac python version that produced this signal.
   py_version: Optional[str] = None
 
+  # True when the signal was computed on Lilac Garden.
+  use_garden: bool = False
+
   @field_validator('signal', mode='before')
   @classmethod
   def parse_signal(cls, signal: dict) -> Signal:
@@ -1119,6 +1122,7 @@ class DatasetDuckDB(Dataset):
       enriched_path=input_path,
       parquet_id=make_signal_parquet_id(signal, input_path, is_computed_signal=True),
       py_version=metadata.version('lilac'),
+      use_garden=use_garden,
     )
     with open_file(signal_manifest_filepath, 'w') as f:
       f.write(signal_manifest.model_dump_json(exclude_none=True, indent=2))
@@ -1238,6 +1242,7 @@ class DatasetDuckDB(Dataset):
       parquet_id=make_signal_parquet_id(signal, input_path, is_computed_signal=True),
       vector_store=self.vector_store,
       py_version=metadata.version('lilac'),
+      use_garden=use_garden,
     )
 
     with open_file(signal_manifest_filepath, 'w') as f:
@@ -1390,6 +1395,7 @@ class DatasetDuckDB(Dataset):
       parquet_id=make_signal_parquet_id(signal, index_path, is_computed_signal=True),
       vector_store=self.vector_store,
       py_version=metadata.version('lilac'),
+      use_garden=False,
     )
 
     with open_file(signal_manifest_filepath, 'w') as f:

--- a/lilac/load.py
+++ b/lilac/load.py
@@ -15,6 +15,7 @@ from .env import get_project_dir
 from .load_dataset import process_source
 from .project import PROJECT_CONFIG_FILENAME
 from .schema import PathTuple
+from .signal import TextEmbeddingSignal, get_signal_by_type, get_signal_cls
 from .utils import DebugTimer, get_datasets_dir, log
 
 
@@ -107,12 +108,7 @@ def load(
         field = manifest.data_schema.get_field(e.path)
         embedding_field = (field.fields or {}).get(e.embedding)
         if embedding_field is None or overwrite:
-          _compute_embedding(
-            d.namespace,
-            d.name,
-            e,
-            project_dir,
-          )
+          _compute_embedding(d.namespace, d.name, e, project_dir, config.use_garden)
         else:
           log(f'Embedding {e.embedding} already exists for {d.name}:{e.path}. Skipping.')
 
@@ -151,6 +147,7 @@ def load(
               d.name,
               s,
               project_dir,
+              config.use_garden,
               overwrite,
             )
           else:
@@ -210,7 +207,7 @@ def load(
           cluster_input,
           output_path=c.output_path,
           min_cluster_size=c.min_cluster_size,
-          use_garden=c.use_garden,
+          use_garden=config.use_garden,
         )
 
   log()
@@ -235,6 +232,7 @@ def _compute_signal(
   name: str,
   signal_config: SignalConfig,
   project_dir: Union[str, pathlib.Path],
+  use_garden: bool,
   overwrite: bool = False,
 ) -> None:
   # Turn off debug logging.
@@ -242,10 +240,13 @@ def _compute_signal(
     del os.environ['DEBUG']
 
   dataset = get_dataset(namespace, name, project_dir)
+  signal = get_signal_cls(signal_config.signal.name)
+
   dataset.compute_signal(
     signal=signal_config.signal,
     path=signal_config.path,
     overwrite=overwrite,
+    use_garden=use_garden and signal.supports_garden,
   )
 
   # Free up RAM.
@@ -259,17 +260,20 @@ def _compute_embedding(
   name: str,
   embedding_config: EmbeddingConfig,
   project_dir: Union[str, pathlib.Path],
+  use_garden: bool,
 ) -> None:
   # Turn off debug logging.
   if 'DEBUG' in os.environ:
     del os.environ['DEBUG']
 
   dataset = get_dataset(namespace, name, project_dir)
+
+  embedding = get_signal_by_type(embedding_config.embedding, TextEmbeddingSignal)
   dataset.compute_embedding(
     embedding=embedding_config.embedding,
     path=embedding_config.path,
     overwrite=True,
-    use_garden=embedding_config.use_garden,
+    use_garden=use_garden and embedding.supports_garden,
   )
   remove_dataset_from_cache(namespace, name)
   del dataset

--- a/lilac/load.py
+++ b/lilac/load.py
@@ -241,6 +241,7 @@ def _compute_signal(
 
   dataset = get_dataset(namespace, name, project_dir)
   signal = get_signal_cls(signal_config.signal.name)
+  assert signal is not None
 
   dataset.compute_signal(
     signal=signal_config.signal,

--- a/lilac/load_test.py
+++ b/lilac/load_test.py
@@ -254,7 +254,7 @@ def test_load_embeddings(tmp_path: pathlib.Path) -> None:
         namespace='namespace',
         name='test',
         source=TestSource(),
-        embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding', use_garden=False)],
+        embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding')],
       )
     ]
   )
@@ -302,7 +302,7 @@ def test_load_twice_no_overwrite(tmp_path: pathlib.Path, capsys: pytest.CaptureF
         name='test',
         source=TestSource(),
         signals=[SignalConfig(path=('str',), signal=test_signal)],
-        embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding', use_garden=False)],
+        embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding')],
       )
     ]
   )
@@ -336,7 +336,7 @@ def test_load_twice_overwrite(tmp_path: pathlib.Path, capsys: pytest.CaptureFixt
         name='test',
         source=TestSource(),
         signals=[SignalConfig(path=('str',), signal=test_signal)],
-        embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding', use_garden=False)],
+        embeddings=[EmbeddingConfig(path=('str',), embedding='test_embedding')],
       )
     ]
   )
@@ -375,9 +375,7 @@ def test_load_clusters(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture) ->
       )
     ],
     clusters=[
-      ClusterConfig(
-        dataset_namespace='namespace', dataset_name='test', input_path=('str',), use_garden=False
-      )
+      ClusterConfig(dataset_namespace='namespace', dataset_name='test', input_path=('str',))
     ],
   )
 
@@ -484,7 +482,6 @@ def test_load_clusters_format_selector(
         ),
         output_path=('cluster',),
         min_cluster_size=2,
-        use_garden=False,
       )
     ],
   )

--- a/lilac/router_dataset_signals.py
+++ b/lilac/router_dataset_signals.py
@@ -26,6 +26,7 @@ class ComputeSignalOptions(BaseModel):
   leaf_path: Path
 
   overwrite: bool = False
+  use_garden: bool = False
 
   @field_validator('signal', mode='before')
   @classmethod
@@ -71,7 +72,7 @@ def compute_signal(
       options.leaf_path,
       overwrite=options.overwrite,
       task_id=task_id,
-      use_garden=signal.use_garden,
+      use_garden=options.use_garden,
     )
 
   launch_task(task_id, run)

--- a/lilac/signal.py
+++ b/lilac/signal.py
@@ -41,15 +41,17 @@ def _signal_schema_extra(schema: dict[str, Any], signal: Type['Signal']) -> None
   """
   if hasattr(signal, 'display_name'):
     schema['title'] = signal.display_name
-  if not signal.supports_garden and 'use_garden' in schema['properties']:
-    del schema['properties']['use_garden']
 
   signal_prop: dict[str, Any]
   if hasattr(signal, 'name'):
     signal_prop = {'enum': [signal.name]}
   else:
     signal_prop = {'type': 'string'}
-  schema['properties'] = {'signal_name': signal_prop, **schema['properties']}
+  schema['properties'] = {
+    'signal_name': signal_prop,
+    'supports_garden': signal.supports_garden,
+    **schema['properties'],
+  }
   if 'required' not in schema:
     schema['required'] = []
   schema['required'].append('signal_name')
@@ -81,10 +83,6 @@ class Signal(BaseModel):
 
   # True when the signal supports accelerated computation remotely on Lilac Garden.
   supports_garden: ClassVar[bool] = False
-
-  use_garden: bool = PydanticField(
-    default=False, description='Accelerate computation by running remotely on Lilac Garden.'
-  )
 
   @model_serializer(mode='wrap', when_used='always')
   def serialize_model(self, serializer: Callable[..., dict[str, Any]]) -> dict[str, Any]:

--- a/lilac/signal_test.py
+++ b/lilac/signal_test.py
@@ -64,11 +64,7 @@ def test_signal_serialization() -> None:
   signal = TestSignal(query='test')
 
   # The class variables should not be included.
-  assert signal.model_dump(exclude_none=True) == {
-    'signal_name': 'test_signal',
-    'query': 'test',
-    'use_garden': False,
-  }
+  assert signal.model_dump(exclude_none=True) == {'signal_name': 'test_signal', 'query': 'test'}
 
 
 def test_get_signal_cls() -> None:

--- a/lilac/signals/pii.py
+++ b/lilac/signals/pii.py
@@ -34,6 +34,8 @@ class PIISignal(TextSignal):
   local_parallelism: ClassVar[int] = -1
   local_strategy: ClassVar[TaskExecutionType] = 'processes'
 
+  supports_garden: ClassVar[bool] = True
+
   @override
   def fields(self) -> Field:
     return field(

--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -1,3 +1,6 @@
+# Accelerate signals, embeddings, and clustering on Lilac Garden.
+use_garden: true
+
 datasets:
   - namespace: lilac
     name: Capybara
@@ -14,20 +17,18 @@ datasets:
             - '*'
             - output
         markdown_paths: []
-      tags: [dataset]
+      tags: [datasets]
     embeddings:
       - embedding: gte-small
         path:
           - conversation
           - '*'
           - input
-        use_garden: true
       - embedding: gte-small
         path:
           - conversation
           - '*'
           - output
-        use_garden: true
 
   - namespace: lilac
     name: glaive
@@ -163,29 +164,23 @@ clusters:
       - conversation
       - '*'
       - input
-    use_garden: true
   - dataset_namespace: lilac
     dataset_name: glaive
     input_path:
       - question
-    use_garden: true
   - dataset_namespace: lilac
     dataset_name: open-asssistant-conversations
     input_path:
       - text
-    use_garden: true
   - dataset_namespace: lilac
     dataset_name: databricks-dolly-15k-curated-en
     input_path:
       - original-instruction
-    use_garden: true
   - dataset_namespace: lilac
     dataset_name: OpenOrca-100k
     input_path:
       - question
-    use_garden: true
   - dataset_namespace: lilac
     dataset_name: dolphin
     input_path:
       - input
-    use_garden: true

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -40,6 +40,7 @@
   import SvelteMarkdown from 'svelte-markdown';
   import {writable, type Readable} from 'svelte/store';
   import JsonSchemaForm from '../JSONSchema/JSONSchemaForm.svelte';
+  import {hoverTooltip} from '../common/HoverTooltip';
   import {
     Command,
     type ComputeEmbeddingCommand,
@@ -66,10 +67,15 @@
   let errors: JSONError[] = [];
 
   let overwrite = false;
+  let useGarden = false;
+
+  $: supportsGarden = signalInfo?.json_schema?.properties?.['supports_garden'];
+  $: console.log('supports_garden', supportsGarden);
 
   const HIDDEN_PROPERTIES = [
     // Hide the signal name as it's just used for type coersion.
     '/signal_name',
+    '/supports_garden',
     // Hide the embedding input type from the compute embedding menu as we're always computing
     // document level embeddings.
     '/embed_input_type'
@@ -135,7 +141,8 @@
         {
           leaf_path: path || [],
           signal,
-          overwrite
+          overwrite,
+          use_garden: useGarden
         }
       ]);
     } else if (command.command === Command.PreviewConcept) {
@@ -205,6 +212,21 @@
             <div class="mt-8">
               <div class="label text-s mb-2 font-medium text-gray-700">Overwrite</div>
               <Toggle labelA={'False'} labelB={'True'} bind:toggled={overwrite} hideLabel />
+            </div>
+            <div
+              class="mt-8"
+              use:hoverTooltip={{
+                text: !supportsGarden ? 'Signal does not support Lilac Garden.' : ''
+              }}
+            >
+              <div class="label text-s mb-2 font-medium text-gray-700">Run on Lilac Garden</div>
+              <Toggle
+                disabled={!supportsGarden}
+                labelA={'False'}
+                labelB={'True'}
+                bind:toggled={useGarden}
+                hideLabel
+              />
             </div>
           {/key}
         {:else}

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -70,7 +70,6 @@
   let useGarden = false;
 
   $: supportsGarden = signalInfo?.json_schema?.properties?.['supports_garden'];
-  $: console.log('supports_garden', supportsGarden);
 
   const HIDDEN_PROPERTIES = [
     // Hide the signal name as it's just used for type coersion.

--- a/web/blueprint/src/lib/components/commands/CommandSignals.svelte
+++ b/web/blueprint/src/lib/components/commands/CommandSignals.svelte
@@ -218,7 +218,10 @@
                 text: !supportsGarden ? 'Signal does not support Lilac Garden.' : ''
               }}
             >
-              <div class="label text-s mb-2 font-medium text-gray-700">Run on Lilac Garden</div>
+              <div class="label mb-2 font-medium text-gray-700">Use Garden</div>
+              <div class="label mb-2 text-sm text-gray-700">
+                Accelerate computation by running remotely on Lilac Garden
+              </div>
               <Toggle
                 disabled={!supportsGarden}
                 labelA={'False'}

--- a/web/lib/fastapi_client/models/ComputeSignalOptions.ts
+++ b/web/lib/fastapi_client/models/ComputeSignalOptions.ts
@@ -12,5 +12,6 @@ export type ComputeSignalOptions = {
     signal: Signal;
     leaf_path: (Array<string> | string);
     overwrite?: boolean;
+    use_garden?: boolean;
 };
 

--- a/web/lib/fastapi_client/models/ConceptLabelsSignal.ts
+++ b/web/lib/fastapi_client/models/ConceptLabelsSignal.ts
@@ -8,6 +8,7 @@
  */
 export type ConceptLabelsSignal = {
     signal_name: 'concept_labels';
+    supports_garden?: any;
     namespace: string;
     concept_name: string;
     version?: (number | null);

--- a/web/lib/fastapi_client/models/ConceptSignal.ts
+++ b/web/lib/fastapi_client/models/ConceptSignal.ts
@@ -9,10 +9,6 @@
 export type ConceptSignal = {
     signal_name: 'concept_score';
     /**
-     * Accelerate computation by running remotely on Lilac Garden.
-     */
-    use_garden?: boolean;
-    /**
      * The name of the pre-computed embedding.
      */
     embedding: 'cohere' | 'sbert' | 'openai' | 'palm' | 'gte-tiny' | 'gte-small' | 'gte-base' | 'jina-v2-small' | 'jina-v2-base';

--- a/web/lib/fastapi_client/models/SemanticSimilaritySignal.ts
+++ b/web/lib/fastapi_client/models/SemanticSimilaritySignal.ts
@@ -12,10 +12,6 @@
 export type SemanticSimilaritySignal = {
     signal_name: 'semantic_similarity';
     /**
-     * Accelerate computation by running remotely on Lilac Garden.
-     */
-    use_garden?: boolean;
-    /**
      * The name of the pre-computed embedding.
      */
     embedding: 'cohere' | 'sbert' | 'openai' | 'palm' | 'gte-tiny' | 'gte-small' | 'gte-base' | 'jina-v2-small' | 'jina-v2-base';

--- a/web/lib/fastapi_client/models/Signal.ts
+++ b/web/lib/fastapi_client/models/Signal.ts
@@ -8,5 +8,6 @@
  */
 export type Signal = {
     signal_name: string;
+    supports_garden?: any;
 };
 

--- a/web/lib/fastapi_client/models/SubstringSignal.ts
+++ b/web/lib/fastapi_client/models/SubstringSignal.ts
@@ -8,6 +8,7 @@
  */
 export type SubstringSignal = {
     signal_name: 'substring_search';
+    supports_garden?: any;
     query: string;
 };
 

--- a/web/lib/fastapi_client/models/TextEmbeddingSignal.ts
+++ b/web/lib/fastapi_client/models/TextEmbeddingSignal.ts
@@ -8,6 +8,7 @@
  */
 export type TextEmbeddingSignal = {
     signal_name: string;
+    supports_garden?: any;
     /**
      * The input type to the embedding.
      */

--- a/web/lib/fastapi_client/models/TextSignal.ts
+++ b/web/lib/fastapi_client/models/TextSignal.ts
@@ -8,5 +8,6 @@
  */
 export type TextSignal = {
     signal_name: string;
+    supports_garden?: any;
 };
 


### PR DESCRIPTION
`use_garden` is now defined in configs, and manifests.

Details:
- Move `use_garden` in configs to the top-level so we don't define it everywhere. Now we only run on garden if a signal supports it, when the bit is true.
- Add UI for use_garden when a signal supports it, disabling it otherwise.

Demo: https://huggingface.co/spaces/lilacai/nikhil_staging

<img width="746" alt="image" src="https://github.com/lilacai/lilac/assets/1100749/bf4cd28f-55b4-4ca4-bf10-12b8e0bdc343">
