### PR TITLE
Fix concept labeler when we index a repeated string (capybara)

### DIFF
--- a/web/blueprint/src/lib/components/concepts/ConceptMetrics.svelte
+++ b/web/blueprint/src/lib/components/concepts/ConceptMetrics.svelte
@@ -17,6 +17,7 @@
 
 <div
   class="flex w-36 flex-col items-center gap-y-2 rounded-md border border-b-0 border-gray-200 p-4 shadow-md"
+  style="height: 103px"
 >
   <div class="text-gray-500">{embedding}</div>
   {#if $model.isFetching}

--- a/web/blueprint/src/lib/components/concepts/ConceptMetrics.svelte
+++ b/web/blueprint/src/lib/components/concepts/ConceptMetrics.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import {conceptModelMutation, queryConceptModel} from '$lib/queries/conceptQueries';
-  import type {Concept} from '$lilac';
+  import {conceptModelMutation} from '$lib/queries/conceptQueries';
+  import type {Concept, ConceptModelInfo} from '$lilac';
   import {Button, InlineLoading} from 'carbon-components-svelte';
   import {Chip} from 'carbon-icons-svelte';
   import {hoverTooltip} from '../common/HoverTooltip';
@@ -10,7 +10,8 @@
   export let concept: Concept;
   export let embedding: string;
 
-  $: model = queryConceptModel(concept.namespace, concept.concept_name, embedding);
+  export let model: ConceptModelInfo | undefined;
+  export let isFetching: boolean;
 
   const modelMutation = conceptModelMutation();
 </script>
@@ -20,21 +21,21 @@
   style="height: 103px"
 >
   <div class="text-gray-500">{embedding}</div>
-  {#if $model.isFetching}
+  {#if isFetching}
     <div class="flex flex-col items-center">
       <InlineLoading />
     </div>
-  {:else if $model?.data?.metrics}
+  {:else if model?.metrics}
     <div
       class="concept-score-pill cursor-default text-2xl font-light {scoreToColor[
-        $model.data.metrics.overall
+        model.metrics.overall
       ]}"
       use:hoverTooltip={{
         component: ConceptHoverPill,
-        props: {metrics: $model.data.metrics}
+        props: {metrics: model.metrics}
       }}
     >
-      {scoreToText[$model.data.metrics.overall]}
+      {scoreToText[model.metrics.overall]}
     </div>
   {:else}
     {@const createModelIfNotExists = true}

--- a/web/blueprint/src/lib/components/concepts/ConceptView.svelte
+++ b/web/blueprint/src/lib/components/concepts/ConceptView.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import {goto} from '$app/navigation';
-  import {editConceptMutation, queryConcepts} from '$lib/queries/conceptQueries';
+  import {
+    editConceptMutation,
+    queryConceptModels,
+    queryConcepts
+  } from '$lib/queries/conceptQueries';
   import {queryAuthInfo} from '$lib/queries/serverQueries';
   import {queryEmbeddings} from '$lib/queries/signalQueries';
   import {createDatasetViewStore} from '$lib/stores/datasetViewStore';
@@ -68,6 +72,8 @@
     if (!concept.namespace || !concept.concept_name) return;
     $conceptMutation.mutate([concept.namespace, concept.concept_name, {insert: [{text, label}]}]);
   }
+
+  $: conceptModels = queryConceptModels(concept.namespace, concept.concept_name);
 </script>
 
 <div class="flex h-full w-full flex-col gap-y-8 px-10">
@@ -141,7 +147,13 @@
       <div slot="above" class="text-md font-semibold">Metrics</div>
       <div slot="below" class="model-metrics flex flex-wrap gap-x-4 gap-y-4">
         {#each $embeddings.data as embedding}
-          <ConceptMetrics {concept} embedding={embedding.name} />
+          {@const model = $conceptModels.data?.find(m => m.embedding_name == embedding.name)}
+          <ConceptMetrics
+            {concept}
+            embedding={embedding.name}
+            {model}
+            isFetching={$conceptModels.isFetching}
+          />
         {/each}
       </div>
     </Expandable>

--- a/web/lib/src/lilac.ts
+++ b/web/lib/src/lilac.ts
@@ -88,6 +88,24 @@ export function valueAtPath(item: LilacValueNode, path: Path): LilacValueNode | 
   return valueAtPath(item[key], rest);
 }
 
+export function valuesAtPath(
+  item: LilacValueNode | LilacValueNode[],
+  path: Path
+): LilacValueNode[] {
+  if (item == null) {
+    return [];
+  }
+  const [key, ...rest] = path;
+  if (key == PATH_WILDCARD) {
+    return (item as LilacValueNode[]).flatMap(v => valuesAtPath(v, rest));
+  }
+  item = item as LilacValueNode;
+  if (rest.length === 0) {
+    return [item[key]];
+  }
+  return valuesAtPath(item[key], rest);
+}
+
 /**
  * Cast a value node to an internal value node
  */


### PR DESCRIPTION
- Fix concept labeler for repeateds
- Make labeler fast again by caching the embedding models locally
- Make concept metrics fast by issuing 1 request instead of 7-8 requests (for each registered embedding)

https://huggingface.co/spaces/lilacai/daniel_staging