### PR TITLE
Fix a few small bugs by testing prod mode

### DIFF
--- a/lilac/cli.py
+++ b/lilac/cli.py
@@ -42,9 +42,7 @@ def start(project_dir: str, host: str, port: int, load: bool) -> None:
     if value == 'n':
       exit()
 
-  server = start_server(host=host, port=port, open=True, project_dir=project_dir, load=load)
-  # Block the server.
-  server.thread.join()
+  start_server(host=host, port=port, open=True, project_dir=project_dir, load=load)
 
 
 @click.command()

--- a/poetry.lock
+++ b/poetry.lock
@@ -2682,13 +2682,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
-    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]
@@ -8122,4 +8122,4 @@ text-stats = ["textacy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "f7ef7198cf872356e03b8d40e065e1ae0f67d7daeab117851b6f51ecb4a23499"
+content-hash = "3bba3fdb0ea5d7e2efdbaa63bae5d52245f761a8e65b13d55d679e5c0c68a4b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tiktoken = "^0.5.1"
 loky = "^3.4.1"
 cloudpickle = "^2.0.0"
 modal = "^0.56.4396"
+jinja2 = "^3.1.3"                                        # Used for directory listing via /_data
 
 ### Optional dependencies. ###
 

--- a/web/blueprint/src/lib/components/NavigationExpandable.svelte
+++ b/web/blueprint/src/lib/components/NavigationExpandable.svelte
@@ -63,6 +63,11 @@
         <slot name="below" />
         {#if linkItems.length > 0}
           {#each linkItems as linkItem}
+            {@const link = urlHashContext.getPageIdentifierLink(
+              linkItem.page,
+              linkItem.identifier,
+              $navigationStore
+            )}
             <div
               class={`flex w-full rounded ${!linkItem.isSelected ? 'hover:bg-gray-100' : ''}
           `}
@@ -70,11 +75,8 @@
               class:bg-neutral-100={linkItem.isSelected}
             >
               <a
-                href={urlHashContext.getPageIdentifierLink(
-                  linkItem.page,
-                  linkItem.identifier,
-                  $navigationStore
-                )}
+                data-sveltekit-reload
+                href={link}
                 class:text-black={linkItem.isSelected}
                 class:font-semibold={linkItem.isSelected}
                 class="w-full truncate px-1 py-1 text-xs text-black"


### PR DESCRIPTION
In prod mode (pip install lilac), we had a few bugs:

- jinja2 not installed (fastapi needs it since we have one page with jinja templates "_data")
- fix an error that happens after you kill the server
- fix links pointing to invalid URL using https://kit.svelte.dev/docs/link-options#data-sveltekit-reload