### PR TITLE
Rename USE_TABLE_INDEX => LILAC_USE_TABLE_INDEX. Add LILAC_PROD_MODE.

### DIFF
--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -335,7 +335,7 @@ class DatasetDuckDB(Dataset):
     self._signal_manifests: list[SignalManifest] = []
     self._map_manifests: list[MapManifest] = []
     self._label_schemas: dict[str, Schema] = {}
-    if env('USE_TABLE_INDEX', default=False):
+    if env('LILAC_USE_TABLE_INDEX', default=False):
       self.con = duckdb.connect(database=os.path.join(self.dataset_path, DUCKDB_CACHE_FILE))
     else:
       self.con = duckdb.connect(database=':memory:')
@@ -521,7 +521,7 @@ class DatasetDuckDB(Dataset):
       [SOURCE_VIEW_NAME]
       + [f'LEFT JOIN {escape_col_name(parquet_id)} USING ({ROWID})' for parquet_id in parquet_ids]
     )
-    if env('USE_TABLE_INDEX', default=False):
+    if env('LILAC_USE_TABLE_INDEX', default=False):
       self.con.execute(
         """CREATE TABLE IF NOT EXISTS mtime_cache AS
          (SELECT CAST(0 AS bigint) AS mtime);"""
@@ -572,7 +572,7 @@ class DatasetDuckDB(Dataset):
     """Clears the cache for the joint table."""
     self._recompute_joint_table.cache_clear()
     self._pivot_cache.clear()
-    if env('USE_TABLE_INDEX', default=False):
+    if env('LILAC_USE_TABLE_INDEX', default=False):
       self.con.execute('DROP TABLE IF EXISTS mtime_cache')
 
   def _add_map_keys_to_schema(self, path: PathTuple, field: Field, merged_schema: Schema) -> None:
@@ -2901,7 +2901,7 @@ class DatasetDuckDB(Dataset):
             # So, we insert a range clause to limit the extent of the index scan. This optimization
             # works well because nearly all of our queries are sorted by rowid, meaning that min/max
             # will narrow down the index scan to a small range.
-            if env('USE_TABLE_INDEX', default=False) and ROWID in select_str:
+            if env('LILAC_USE_TABLE_INDEX', default=False) and ROWID in select_str:
               min_row, max_row = min(filter_list_val), max(filter_list_val)
               filter_query += f' AND {ROWID} BETWEEN {min_row} AND {max_row}'
               # wrap in parens to isolate from other filters, just in case?

--- a/lilac/env.py
+++ b/lilac/env.py
@@ -44,7 +44,7 @@ class LilacEnvironment(BaseModel):
   LILAC_USE_TABLE_INDEX: str = PydanticField(
     description='Use persistent tables with rowid indexes.'
   )
-  LILAC_PROD_MODE: str = PydanticField(
+  LILAC_DISABLE_ERROR_NOTIFICATIONS: str = PydanticField(
     description='Set lilac in production mode. This will disable error messages in the UI.'
   )
 

--- a/lilac/env.py
+++ b/lilac/env.py
@@ -37,7 +37,16 @@ class LilacEnvironment(BaseModel):
     description='Turn on Lilac debug mode to log queries and timing information.'
   )
   DISABLE_LOGS: str = PydanticField(description='Disable log() statements to the console.')
-  USE_TABLE_INDEX: str = PydanticField(description='Use persistent tables with rowid indexes.')
+  USE_TABLE_INDEX: str = PydanticField(
+    description='Use persistent tables with rowid indexes.'
+    ' NOTE: This is deprecated in favor of USE_TABLE_INDEX.'
+  )
+  LILAC_USE_TABLE_INDEX: str = PydanticField(
+    description='Use persistent tables with rowid indexes.'
+  )
+  LILAC_PROD_MODE: str = PydanticField(
+    description='Set lilac in production mode. This will disable error messages in the UI.'
+  )
 
   # API Keys.
   OPENAI_API_KEY: str = PydanticField(
@@ -140,6 +149,9 @@ def _init_env() -> None:
 
 def env(key: str, default: Optional[Any] = None) -> Any:
   """Return the value of an environment variable."""
+  # For backwards compatibility, shim USE_TABLE_INDEX to LILAC_USE_TABLE_INDEX.
+  if key == 'USE_TABLE_INDEX':
+    key = 'LILAC_USE_TABLE_INDEX'
   return os.environ.get(key, default)
 
 

--- a/lilac/server.py
+++ b/lilac/server.py
@@ -134,7 +134,7 @@ class ServerStatus(BaseModel):
 
   version: str
   google_analytics_enabled: bool
-  prod_mode: bool
+  disable_error_notifications: bool
 
 
 @app.get('/status')
@@ -143,7 +143,7 @@ def status() -> ServerStatus:
   return ServerStatus(
     version=metadata.version('lilac'),
     google_analytics_enabled=env('GOOGLE_ANALYTICS_ENABLED', False),
-    prod_mode=env('LILAC_PROD_MODE', False),
+    disable_error_notifications=env('LILAC_DISABLE_ERROR_NOTIFICATIONS', False),
   )
 
 

--- a/lilac/server.py
+++ b/lilac/server.py
@@ -134,6 +134,7 @@ class ServerStatus(BaseModel):
 
   version: str
   google_analytics_enabled: bool
+  prod_mode: bool
 
 
 @app.get('/status')
@@ -142,6 +143,7 @@ def status() -> ServerStatus:
   return ServerStatus(
     version=metadata.version('lilac'),
     google_analytics_enabled=env('GOOGLE_ANALYTICS_ENABLED', False),
+    prod_mode=env('LILAC_PROD_MODE', False),
   )
 
 

--- a/lilac_hf_space.yml
+++ b/lilac_hf_space.yml
@@ -134,6 +134,12 @@ datasets:
           - - conversations
             - '*'
             - value
+    embeddings:
+      - embedding: gte-small
+        path:
+          - conversations
+          - '*'
+          - value
 
   - namespace: lilac
     name: UltraChat-200k
@@ -158,6 +164,13 @@ datasets:
       ui:
         media_paths:
           - prompt
+          - completion
+    embeddings:
+      - embedding: gte-small
+        path:
+          - prompt
+      - embedding: gte-small
+        path:
           - completion
 
   ## Eval datasets
@@ -385,7 +398,10 @@ datasets:
           - instruction
           - input
           - output
-
+    embeddings:
+      - embedding: gte-small
+        path:
+          - instruction
 signals:
   - signal_name: text_statistics
   - signal_name: lang_detection

--- a/web/blueprint/src/lib/components/ErrorNotifications.svelte
+++ b/web/blueprint/src/lib/components/ErrorNotifications.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import {apiErrors} from '$lib/queries/queryClient';
+  import {ToastNotification} from 'carbon-components-svelte';
+
+  import {queryServerStatus} from '$lib/queries/serverQueries';
+  import type {ApiError} from '$lilac';
+  import ApiErrorModal from './ApiErrorModal.svelte';
+
+  let showError: ApiError | undefined = undefined;
+
+  $: serverStatus = queryServerStatus();
+  $: isProdMode = $serverStatus.data?.prod_mode;
+</script>
+
+{#if !isProdMode}
+  {#each $apiErrors as error}
+    <ToastNotification
+      lowContrast
+      title={error.name || 'Error'}
+      subtitle={error.body.message || error.message}
+      on:close={() => {
+        $apiErrors = $apiErrors.filter(e => e !== error);
+      }}
+    >
+      <div slot="caption">
+        <button class="underline" on:click={() => (showError = error)}>Show error</button>
+      </div>
+    </ToastNotification>
+  {/each}
+  {#if showError}
+    <ApiErrorModal error={showError} />
+  {/if}
+{/if}

--- a/web/blueprint/src/lib/components/ErrorNotifications.svelte
+++ b/web/blueprint/src/lib/components/ErrorNotifications.svelte
@@ -9,10 +9,10 @@
   let showError: ApiError | undefined = undefined;
 
   $: serverStatus = queryServerStatus();
-  $: isProdMode = $serverStatus.data?.prod_mode;
+  $: disableErrorNotifications = $serverStatus.data?.disable_error_notifications;
 </script>
 
-{#if !isProdMode}
+{#if !disableErrorNotifications}
   {#each $apiErrors as error}
     <ToastNotification
       lowContrast

--- a/web/blueprint/src/routes/+layout.svelte
+++ b/web/blueprint/src/routes/+layout.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-  import ApiErrorModal from '$lib/components/ApiErrorModal.svelte';
-  import {apiErrors, queryClient} from '$lib/queries/queryClient';
+  import {queryClient} from '$lib/queries/queryClient';
   import TaskMonitor from '$lib/stores/TaskMonitor.svelte';
-  import {OpenAPI, type ApiError} from '$lilac';
+  import {OpenAPI} from '$lilac';
   import {QueryClientProvider} from '@tanstack/svelte-query';
   import {Theme, ToastNotification} from 'carbon-components-svelte';
   import {onMount} from 'svelte';
@@ -21,11 +20,10 @@
   import {slide} from 'svelte/transition';
 
   import {base} from '$app/paths';
+  import ErrorNotifications from '$lib/components/ErrorNotifications.svelte';
   import GoogleAnalytics from '$lib/components/GoogleAnalytics.svelte';
   import {SIDEBAR_TRANSITION_TIME_MS} from '$lib/view_utils';
   import '../app.css';
-
-  let showError: ApiError | undefined = undefined;
 
   // Set the base URL for the OpenAPI requests when the app is served from a subdir.
   OpenAPI.BASE = base;
@@ -138,24 +136,7 @@
     {/each}
   </div>
   <div class="absolute bottom-4 right-4" style="z-index: 1000">
-    {#each $apiErrors as error}
-      <ToastNotification
-        lowContrast
-        title={error.name || 'Error'}
-        subtitle={error.body.message || error.message}
-        on:close={() => {
-          $apiErrors = $apiErrors.filter(e => e !== error);
-        }}
-      >
-        <div slot="caption">
-          <button class="underline" on:click={() => (showError = error)}>Show error</button>
-        </div>
-      </ToastNotification>
-    {/each}
-
-    {#if showError}
-      <ApiErrorModal error={showError} />
-    {/if}
+    <ErrorNotifications />
   </div>
 
   <TaskMonitor />

--- a/web/lib/fastapi_client/models/ServerStatus.ts
+++ b/web/lib/fastapi_client/models/ServerStatus.ts
@@ -9,6 +9,6 @@
 export type ServerStatus = {
     version: string;
     google_analytics_enabled: boolean;
-    prod_mode: boolean;
+    disable_error_notifications: boolean;
 };
 

--- a/web/lib/fastapi_client/models/ServerStatus.ts
+++ b/web/lib/fastapi_client/models/ServerStatus.ts
@@ -9,5 +9,6 @@
 export type ServerStatus = {
     version: string;
     google_analytics_enabled: boolean;
+    prod_mode: boolean;
 };
 


### PR DESCRIPTION
Renames USE_TABLE_INDEX to LILAC_USE_TABLE_INDEX, and then makes sure it's backwards compat.

Add LILAC_PROD_MODE, which disables toast notification errors for the public demo, which makes it just look janky and broken.

Also add embeddings to missing datasets.