### PR TITLE
Add exclude_signals to select_rows, and include_signals to export methods.

### DIFF
--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -670,6 +670,7 @@ class Dataset(abc.ABC):
     resolve_span: bool = False,
     combine_columns: bool = False,
     include_deleted: bool = False,
+    exclude_signals: bool = False,
     user: Optional[UserInfo] = None,
   ) -> SelectRowsResult:
     """Select a set of rows that match the provided filters, analogous to SQL SELECT.
@@ -694,6 +695,7 @@ class Dataset(abc.ABC):
       combine_columns: Whether to combine columns into a single object. The object will be pruned
         to only include sub-fields that correspond to the requested columns.
       include_deleted: Whether to include deleted rows in the query.
+      exclude_signals: Whether to exclude fields produced by signals.
       user: The authenticated user, if auth is enabled and the user is logged in. This is used to
         apply ACL to the query, especially for concepts.
 
@@ -987,6 +989,7 @@ class Dataset(abc.ABC):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> HuggingFaceDataset:
     """Export the dataset to a huggingface dataset.
 
@@ -996,6 +999,7 @@ class Dataset(abc.ABC):
       include_labels: The labels to include in the export.
       exclude_labels: The labels to exclude in the export.
       include_deleted: Whether to include deleted rows in the export.
+      include_signals: Whether to include fields produced by signals.
     """
     pass
 
@@ -1009,6 +1013,7 @@ class Dataset(abc.ABC):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> None:
     """Export the dataset to a JSON file.
 
@@ -1020,6 +1025,7 @@ class Dataset(abc.ABC):
       include_labels: The labels to include in the export.
       exclude_labels: The labels to exclude in the export.
       include_deleted: Whether to include deleted rows in the export.
+      include_signals: Whether to include fields produced by signals.
     """
     pass
 
@@ -1031,6 +1037,7 @@ class Dataset(abc.ABC):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> pd.DataFrame:
     """Export the dataset to a pandas DataFrame.
 
@@ -1040,6 +1047,7 @@ class Dataset(abc.ABC):
       include_labels: The labels to include in the export.
       exclude_labels: The labels to exclude in the export.
       include_deleted: Whether to include deleted rows in the export.
+      include_signals: Whether to include fields produced by signals.
     """
     pass
 
@@ -1052,6 +1060,7 @@ class Dataset(abc.ABC):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> None:
     """Export the dataset to a parquet file.
 
@@ -1062,6 +1071,7 @@ class Dataset(abc.ABC):
       include_labels: The labels to include in the export.
       exclude_labels: The labels to exclude in the export.
       include_deleted: Whether to include deleted rows in the export.
+      include_signals: Whether to include fields produced by signals.
     """
     pass
 
@@ -1074,6 +1084,7 @@ class Dataset(abc.ABC):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> None:
     """Export the dataset to a csv file.
 
@@ -1084,6 +1095,7 @@ class Dataset(abc.ABC):
       include_labels: The labels to include in the export.
       exclude_labels: The labels to exclude in the export.
       include_deleted: Whether to include deleted rows in the export.
+      include_signals: Whether to include fields produced by signals.
     """
     pass
 

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -1,4 +1,5 @@
 """The DuckDB implementation of the dataset database."""
+import copy
 import csv
 import functools
 import gc
@@ -2051,6 +2052,7 @@ class DatasetDuckDB(Dataset):
     resolve_span: bool = False,
     combine_columns: bool = False,
     include_deleted: bool = False,
+    exclude_signals: bool = False,
     user: Optional[UserInfo] = None,
   ) -> SelectRowsResult:
     manifest = self.manifest()
@@ -2071,6 +2073,14 @@ class DatasetDuckDB(Dataset):
         searches,
         combine_columns=True,
       ).data_schema
+
+    # Remove fields that are produced by signals.
+    if exclude_signals:
+      signal_paths: list[PathTuple] = []
+      for signal_manifest in self._signal_manifests:
+        signal_paths.extend(list(signal_manifest.data_schema.leafs.keys()))
+
+      cols = [col for col in cols if col.path not in signal_paths]
 
     self._validate_columns(cols, manifest.data_schema, schema)
 
@@ -2188,7 +2198,7 @@ class DatasetDuckDB(Dataset):
       if final_col_name not in columns_to_merge:
         columns_to_merge[final_col_name] = {}
 
-      duckdb_paths = self._column_to_duckdb_paths(column, schema, combine_columns)
+      duckdb_paths = self._column_to_duckdb_paths(column, schema, combine_columns, exclude_signals)
       span_from = self._resolve_span(path, manifest) if resolve_span or column.signal_udf else None
 
       for parquet_id, duckdb_path in duckdb_paths:
@@ -2415,6 +2425,7 @@ class DatasetDuckDB(Dataset):
     sort_order: Optional[SortOrder] = None,
     searches: Optional[Sequence[Search]] = None,
     combine_columns: bool = False,
+    exclude_signals: bool = False,
   ) -> SelectRowsSchemaResult:
     """Returns the schema of the result of `select_rows` above with the same arguments."""
     if not combine_columns:
@@ -2428,11 +2439,19 @@ class DatasetDuckDB(Dataset):
     search_udfs = self._search_udfs(searches, manifest)
     cols.extend([search_udf.udf for search_udf in search_udfs])
 
+    # Remove fields that are produced by signals.
+    if exclude_signals:
+      signal_paths: list[PathTuple] = []
+      for signal_manifest in self._signal_manifests:
+        signal_paths.extend(list(signal_manifest.data_schema.leafs.keys()))
+
+      cols = [col for col in cols if col.path not in signal_paths]
+
     udfs: list[SelectRowsSchemaUDF] = []
     col_schemas: list[Schema] = []
     for col in cols:
       dest_path = _col_destination_path(col)
-      if col.signal_udf:
+      if col.signal_udf and not exclude_signals:
         udfs.append(SelectRowsSchemaUDF(path=dest_path, alias=col.alias))
         field = col.signal_udf.fields()
         assert field, f'Signal {col.signal_udf.name} needs `Signal.fields` defined when run as UDF.'
@@ -2442,6 +2461,13 @@ class DatasetDuckDB(Dataset):
       else:
         # This column might refer to an output of a udf. We postpone validation to later.
         continue
+
+      # Delete any signals from the schema if we are excluding signals.
+      if exclude_signals:
+        field = copy.deepcopy(field)
+        field = _remove_signals_from_field(field)
+        assert field is not None
+
       col_schemas.append(_make_schema_from_path(dest_path, field))
 
     sort_results = self._merge_sorts(search_udfs, sort_by, sort_order)
@@ -2630,7 +2656,7 @@ class DatasetDuckDB(Dataset):
     return duckdb_path
 
   def _column_to_duckdb_paths(
-    self, column: Column, schema: Schema, combine_columns: bool
+    self, column: Column, schema: Schema, combine_columns: bool, exclude_signals: bool = False
   ) -> list[tuple[str, PathTuple]]:
     path = column.path
     if path[0] in self._label_schemas:
@@ -2640,7 +2666,7 @@ class DatasetDuckDB(Dataset):
     is_petal = schema.get_field(path).dtype is not None
 
     # NOTE: The order of this array matters as we check the source and map manifests for fields
-    # before reading signal manifests, via source_or_map_has_path.
+    # before reading signal manifests, via source_or_map_has_path.s
     parquet_manifests: list[Union[SourceManifest, SignalManifest, MapManifest]] = [
       self._source_manifest,
       *self._map_manifests,
@@ -2653,6 +2679,8 @@ class DatasetDuckDB(Dataset):
 
     for m in parquet_manifests:
       if not m.files:
+        continue
+      if exclude_signals and isinstance(m, SignalManifest):
         continue
       # Skip this parquet file if it doesn't contain the path.
       # if not schema_contains_path(m.data_schema, path):
@@ -3206,13 +3234,18 @@ class DatasetDuckDB(Dataset):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> HuggingFaceDataset:
     filters, _ = self._normalize_filters(
       filter_likes=filters, col_aliases={}, udf_aliases={}, manifest=self.manifest()
     )
     filters.extend(self._compile_include_exclude_filters(include_labels, exclude_labels))
     rows = self.select_rows(
-      columns, filters=filters, combine_columns=True, include_deleted=include_deleted
+      columns,
+      filters=filters,
+      combine_columns=True,
+      include_deleted=include_deleted,
+      exclude_signals=not include_signals,
     )
 
     def _gen() -> Iterator[Item]:
@@ -3231,13 +3264,18 @@ class DatasetDuckDB(Dataset):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> None:
     filters, _ = self._normalize_filters(
       filter_likes=filters, col_aliases={}, udf_aliases={}, manifest=self.manifest()
     )
     filters.extend(self._compile_include_exclude_filters(include_labels, exclude_labels))
     rows = self.select_rows(
-      columns, filters=filters, combine_columns=True, include_deleted=include_deleted
+      columns,
+      filters=filters,
+      combine_columns=True,
+      include_deleted=include_deleted,
+      exclude_signals=not include_signals,
     )
     filepath = os.path.expanduser(filepath)
     with open_file(filepath, 'wb') as file:
@@ -3257,13 +3295,18 @@ class DatasetDuckDB(Dataset):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> pd.DataFrame:
     filters, _ = self._normalize_filters(
       filter_likes=filters, col_aliases={}, udf_aliases={}, manifest=self.manifest()
     )
     filters.extend(self._compile_include_exclude_filters(include_labels, exclude_labels))
     rows = self.select_rows(
-      columns, filters=filters, combine_columns=True, include_deleted=include_deleted
+      columns,
+      filters=filters,
+      combine_columns=True,
+      include_deleted=include_deleted,
+      exclude_signals=not include_signals,
     )
     return pd.DataFrame.from_records(list(rows))
 
@@ -3276,6 +3319,7 @@ class DatasetDuckDB(Dataset):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> None:
     manifest = self.manifest()
     filters, _ = self._normalize_filters(
@@ -3284,7 +3328,11 @@ class DatasetDuckDB(Dataset):
     filters.extend(self._compile_include_exclude_filters(include_labels, exclude_labels))
     select_schema = self.select_rows_schema(columns, combine_columns=True)
     rows = self.select_rows(
-      columns, filters=filters, combine_columns=True, include_deleted=include_deleted
+      columns,
+      filters=filters,
+      combine_columns=True,
+      include_deleted=include_deleted,
+      exclude_signals=not include_signals,
     )
     fieldnames = list(select_schema.data_schema.fields.keys())
     filepath = os.path.expanduser(filepath)
@@ -3303,14 +3351,21 @@ class DatasetDuckDB(Dataset):
     include_labels: Optional[Sequence[str]] = None,
     exclude_labels: Optional[Sequence[str]] = None,
     include_deleted: bool = False,
+    include_signals: bool = False,
   ) -> None:
     filters, _ = self._normalize_filters(
       filter_likes=filters, col_aliases={}, udf_aliases={}, manifest=self.manifest()
     )
     filters.extend(self._compile_include_exclude_filters(include_labels, exclude_labels))
-    select_schema = self.select_rows_schema(columns, combine_columns=True)
+    select_schema = self.select_rows_schema(
+      columns, combine_columns=True, exclude_signals=not include_signals
+    )
     rows = self.select_rows(
-      columns, filters=filters, combine_columns=True, include_deleted=include_deleted
+      columns,
+      filters=filters,
+      combine_columns=True,
+      include_deleted=include_deleted,
+      exclude_signals=not include_signals,
     )
     filepath = os.path.expanduser(filepath)
     with open_file(filepath, 'wb') as f:
@@ -3702,6 +3757,33 @@ def _schema_has_spans(field: Field) -> bool:
   if field.repeated_field:
     return _schema_has_spans(field.repeated_field)
   return False
+
+
+def _remove_signals_from_field(field: Field) -> Optional[Field]:
+  """Remove signals from a field."""
+  if field.signal is not None:
+    return None
+
+  if field.fields:
+    fields: dict[str, Field] = {}
+    for key, sub_field in field.fields.items():
+      if not sub_field.signal:
+        sub_field = _remove_signals_from_field(sub_field)
+        if sub_field:
+          fields[key] = sub_field
+    return Field(fields=fields, dtype=field.dtype)
+
+  if field.repeated_field:
+    if not field.signal:
+      sub_field = _remove_signals_from_field(field.repeated_field)
+      if sub_field:
+        return Field(repeated_field=sub_field, dtype=field.dtype)
+      else:
+        return None
+    else:
+      return None
+
+  return field
 
 
 def _normalize_bins(bins: Optional[Union[Sequence[Bin], Sequence[float]]]) -> Optional[list[Bin]]:

--- a/lilac/data/dataset_test.py
+++ b/lilac/data/dataset_test.py
@@ -283,6 +283,27 @@ def test_select_rows_next(make_test_data: TestDataMaker) -> None:
   assert _get_rows() == SIMPLE_ITEMS
 
 
+def test_select_rows_exclude_signals(make_test_data: TestDataMaker) -> None:
+  dataset = make_test_data([{'text': 'hello'}, {'text': 'everybody'}])
+
+  # Compute a map and make sure it shows up.
+  dataset.map(lambda row: row['text'] + '_mapped', output_path='text_map')
+
+  test_signal = TestSignal()
+  dataset.compute_signal(test_signal, 'text')
+  length_signal = LengthSignal()
+  dataset.compute_signal(length_signal, 'text')
+
+  result = dataset.select_rows(combine_columns=True, exclude_signals=True)
+  assert list(result) == [
+    {
+      'text': 'hello',
+      'text_map': 'hello_mapped',
+    },
+    {'text': 'everybody', 'text_map': 'everybody_mapped'},
+  ]
+
+
 def test_merge_values(make_test_data: TestDataMaker) -> None:
   dataset = make_test_data([{'text': 'hello'}, {'text': 'everybody'}])
   test_signal = TestSignal()

--- a/notebooks/ClusterSampling.ipynb
+++ b/notebooks/ClusterSampling.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using clusters to sample a dataset\n",
+    "\n",
+    "This notebook will show you how to use computed clusters to sub-sample a dataset. We're going to create a distilled version of SlimOrca that only has translation-related conversations, and publish it to HuggingFace.\n",
+    "\n",
+    "For more details on clustering, see our [Clustering](https://docs.lilacml.com/datasets/dataset_cluster.html) guide.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nikhil/Code/lilac/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import lilac as ll\n",
+    "\n",
+    "ll.set_project_dir('./data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download the lilac-processed OpenOrca dataset.\n",
+    "if not ll.has_dataset('lilac', 'SlimOrca'):\n",
+    "  ll.download('lilacai/lilac-SlimOrca', dataset_namespace='lilac', dataset_name='SlimOrca')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Print the first row\n",
+    "\n",
+    "Let's print the first row to see how the data is shaped.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "signal paths: [('conversations', '*', 'value', 'lang_detection'), ('conversations', '*', 'value', 'gte-small', '*'), ('conversations', '*', 'value', 'gte-small', '*', 'embedding'), ('conversations', '*', 'value', 'text_statistics', 'num_characters'), ('conversations', '*', 'value', 'text_statistics', 'readability'), ('conversations', '*', 'value', 'text_statistics', 'log(type_token_ratio)'), ('conversations', '*', 'value', 'text_statistics', 'frac_non_ascii')]\n",
+      "{'__hfsplit__': 'train',\n",
+      " 'conversation__clusters': {'category_id': 135,\n",
+      "                            'category_membership_prob': 0.8721028566360474,\n",
+      "                            'category_title': 'Data Extraction',\n",
+      "                            'cluster_id': 6345,\n",
+      "                            'cluster_membership_prob': 1.0,\n",
+      "                            'cluster_title': 'Structured Data Extraction and '\n",
+      "                                             'Description'},\n",
+      " 'conversations': [{'from': 'system',\n",
+      "                    'value': 'You are an AI assistant. User will you give you '\n",
+      "                             'a task. Your goal is to complete the task as '\n",
+      "                             'faithfully as you can. While performing the task '\n",
+      "                             'think step-by-step and justify your steps.',\n",
+      "                    'weight': None},\n",
+      "                   {'from': 'human',\n",
+      "                    'value': 'Data: Maryland (3) SUCCESSOR John Creswell (UU); '\n",
+      "                             'John Creswell (UU) '\n",
+      "                             'DATE_OF_SUCCESSORS_FORMAL_INSTALLATION March 9, '\n",
+      "                             '1865; Vacant REASON_FOR_CHANGE Sen. Thomas H. '\n",
+      "                             'Hicks died during previous congress; Maryland '\n",
+      "                             '(3) VACATOR Vacant\\n'\n",
+      "                             '\\n'\n",
+      "                             'What would a sentence about this data be like?',\n",
+      "                    'weight': 0.0},\n",
+      "                   {'from': 'gpt',\n",
+      "                    'value': 'On March 9, 1865, John Creswell (UU) was '\n",
+      "                             'formally installed as the successor for the '\n",
+      "                             'Maryland (3) congressional seat, following the '\n",
+      "                             'death of Sen. Thomas H. Hicks during the '\n",
+      "                             'previous congress, which had left the seat '\n",
+      "                             'vacant.',\n",
+      "                    'weight': 1.0}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "\n",
+    "ds = ll.get_dataset('lilac', 'SlimOrca')\n",
+    "\n",
+    "# Print the first row.\n",
+    "pprint(next(ds.select_rows(limit=1, combine_columns=True, exclude_signals=True)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Print the top cluster categories\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('Translation', 42628),\n",
+      " ('Entailment and Hypothesis', 36039),\n",
+      " ('Mathematics', 22703),\n",
+      " ('Sentiment Analysis', 20037),\n",
+      " ('Fact-Checking', 12285),\n",
+      " ('Text Classification', 11307),\n",
+      " ('Sentence Analysis', 11100),\n",
+      " ('Inference Questions', 10345),\n",
+      " ('News Summarization', 9998),\n",
+      " ('Reading Comprehension', 9896)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "groups = ds.select_groups('conversation__clusters.category_title')\n",
+    "\n",
+    "# Print the top-10 cluster categories.\n",
+    "pprint(groups.counts[0:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a HuggingFace dataset with just the translation cluster\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "signal paths: [('conversations', '*', 'value', 'lang_detection'), ('conversations', '*', 'value', 'gte-small', '*'), ('conversations', '*', 'value', 'gte-small', '*', 'embedding'), ('conversations', '*', 'value', 'text_statistics', 'num_characters'), ('conversations', '*', 'value', 'text_statistics', 'readability'), ('conversations', '*', 'value', 'text_statistics', 'log(type_token_ratio)'), ('conversations', '*', 'value', 'text_statistics', 'frac_non_ascii')]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Generating train split: 42628 examples [00:01, 40086.06 examples/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset({\n",
+      "    features: ['conversations', '__hfsplit__', 'conversation__clusters'],\n",
+      "    num_rows: 42628\n",
+      "})\n",
+      "{'__hfsplit__': 'train',\n",
+      " 'conversation__clusters': {'category_id': 163,\n",
+      "                            'category_membership_prob': 0.5394969582557678,\n",
+      "                            'category_title': 'Translation',\n",
+      "                            'cluster_id': 1848,\n",
+      "                            'cluster_membership_prob': 0.6829708218574524,\n",
+      "                            'cluster_title': 'Translation Verification in '\n",
+      "                                             'Japanese and Filipino'},\n",
+      " 'conversations': [{'from': 'human',\n",
+      "                    'value': 'Q: Given a sentence in the Japanese and Filipino '\n",
+      "                             'language. Your task is check if the Filipino '\n",
+      "                             'sentence is translation of Japanese. if the '\n",
+      "                             'translation is correct than generate label '\n",
+      "                             '\"Yes\", otherwise generate label \"No\".\\n'\n",
+      "                             'Japanese: '\n",
+      "                             'ベルへはBBCに、グループがお金を得るためには「芝居」を打つことだってすると言った。 \\n'\n",
+      "                             ' Filipino: \"Ang praktikal na katotohanan ay ang '\n",
+      "                             'dalawang pinakamalaking partido ay hindi '\n",
+      "                             'ipinapakita na handa silang magpatuloy.\"\\n'\n",
+      "                             'A:',\n",
+      "                    'weight': 0.0},\n",
+      "                   {'from': 'gpt', 'value': 'No', 'weight': 1.0}]}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "hf_ds = ds.to_huggingface(\n",
+    "  filters=[('conversation__clusters.category_title', 'equals', 'Translation')],\n",
+    ")\n",
+    "\n",
+    "print(hf_ds)\n",
+    "pprint(hf_ds[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The motivation here is for export methods to quickly allow disabling signals for exporting.

- `select_rows` now has `exclude_signals`, which automatically disables signals.
- `to_*` now have `include_signals`, which by default removes signals. If you set this to true, you will get signals on the other side.

Also add a cluster sampling notebook that shows this workflow.