### PR TITLE
Handle sqlite files separately during table/index creation 

### DIFF
--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -439,9 +439,14 @@ class DatasetDuckDB(Dataset):
       JOIN labels USING (rowid)
       JOIN maps USING (rowid))
 
-    Signals and maps are asynchronous, slow requests that act on the entire table.
-    Labels are synchronous fast requests that insert single rows into a sqlite table.
-    In the scenario where we are using cached Tables/indices, we separate out sqlite tables.
+    If LILAC_USE_TABLE_INDEX is set, then we apply a further optimization where we create a DuckDB
+    table as a cache and index over Sources, Signals, and Maps (excluding labels). We invalidate
+    this cache if the underlying data is updated. Labels are excluded from the cache because users
+    expect labeling to be a milliseconds-long operations, but recomputing the entire DuckDB table
+    can take a second for a 100k row table. Luckily, labels are stored as a indexed sqlite table, so
+    we can join them in at query time. The only time this logic is invalid is if an entire label
+    type is deleted or created. Therefore the sqlite files are added to the function signature for
+    cache busting reasons.
 
     CREATE TABLE cached_t AS (
       SELECT sources.*, signals.*, maps.*
@@ -455,8 +460,12 @@ class DatasetDuckDB(Dataset):
       FROM cached_t
       JOIN labels USING (rowid))
     )
+
+    One final complication is that the duckdb table is now on-disk state that can become invalid
+    for a variety of reasons (bugs, lilac version migrations, DuckDB version bumps.)
+    The solution is to nuke and recompute the entire cache if anything fails.
     """
-    del sqlite_files  # Unused. It's in the function signature for cache key busting reasons.
+    del sqlite_files  # Unused.
     merged_schema = self._source_manifest.data_schema.model_copy(deep=True)
     self._signal_manifests = []
     self._label_schemas = {}
@@ -572,14 +581,6 @@ class DatasetDuckDB(Dataset):
             f'LEFT JOIN {escape_col_name(parquet_id)} USING ({ROWID})' for parquet_id in parquet_ids
           ]
         )
-        view_select_sql = ', '.join(['cache_t.*'] + label_column_selects)
-        view_join_sql = ' '.join(
-          ['cache_t']
-          + [
-            f'LEFT JOIN {escape_col_name(label_name)} USING ({ROWID})'
-            for label_name in self._label_schemas.keys()
-          ]
-        )
         with DebugTimer(f'Recomputing table+index for {self.dataset_name}...'):
           # Need to check a variety of transitions that could throw errors...
           # What if cache_t exists but t does not?
@@ -589,12 +590,21 @@ class DatasetDuckDB(Dataset):
           self.con.execute(
             f'CREATE OR REPLACE TABLE cache_t AS (SELECT {table_select_sql} FROM {table_join_sql})'
           )
-          self.con.execute('CREATE INDEX row_idx ON cache_t ("__rowid__")')
-          self.con.execute(
-            f'CREATE OR REPLACE VIEW t AS (SELECT {view_select_sql} FROM {view_join_sql})'
-          )
+          self.con.execute(f'CREATE INDEX row_idx ON cache_t ({ROWID})')
           # If not checkpointed, the index will sometimes not be flushed to disk and be recomputed.
           self.con.execute('CHECKPOINT')
+      view_select_sql = ', '.join(['cache_t.*'] + label_column_selects)
+      view_join_sql = ' '.join(
+        ['cache_t']
+        + [
+          f'LEFT JOIN {escape_col_name(label_name)} USING ({ROWID})'
+          for label_name in self._label_schemas.keys()
+        ]
+      )
+      self.con.execute(
+        f'CREATE OR REPLACE VIEW t AS (SELECT {view_select_sql} FROM {view_join_sql})'
+      )
+
     else:
       select_sql = ', '.join(
         [f'{SOURCE_VIEW_NAME}.*']
@@ -648,7 +658,12 @@ class DatasetDuckDB(Dataset):
     self._recompute_joint_table.cache_clear()
     self._pivot_cache.clear()
     if env('LILAC_USE_TABLE_INDEX', default=False):
-      self.con.execute('DROP TABLE IF EXISTS mtime_cache')
+      self.con.close()
+      pathlib.Path(os.path.join(self.dataset_path, DUCKDB_CACHE_FILE)).unlink(missing_ok=True)
+      pathlib.Path(os.path.join(self.dataset_path, DUCKDB_CACHE_FILE + '.wal')).unlink(
+        missing_ok=True
+      )
+      self.con = duckdb.connect(database=os.path.join(self.dataset_path, DUCKDB_CACHE_FILE))
 
   def _add_map_keys_to_schema(self, path: PathTuple, field: Field, merged_schema: Schema) -> None:
     """Adds the keys of a map to the schema."""
@@ -681,7 +696,16 @@ class DatasetDuckDB(Dataset):
       slow_change = (f for f in slow_change if not f.endswith(LABELS_SQLITE_SUFFIX))
       latest_mtime = max(map(os.path.getmtime, slow_change))
       latest_mtime_micro_sec = int(latest_mtime * 1e6)
-      return self._recompute_joint_table(latest_mtime_micro_sec, tuple(rapid_change))
+      try:
+        return self._recompute_joint_table(latest_mtime_micro_sec, tuple(sorted(rapid_change)))
+      except Exception as e:
+        log(
+          'Encountered error while attempting to recompute joint table'
+          '; deleting cache and retrying. Exception:',
+          e,
+        )
+        self._clear_joint_table_cache()
+        return self._recompute_joint_table(latest_mtime_micro_sec, tuple(sorted(rapid_change)))
 
   def count(self, query_options: Optional[DuckDBQueryParams] = None) -> int:
     """Count the number of rows."""

--- a/lilac/env.py
+++ b/lilac/env.py
@@ -150,8 +150,8 @@ def _init_env() -> None:
 def env(key: str, default: Optional[Any] = None) -> Any:
   """Return the value of an environment variable."""
   # For backwards compatibility, shim USE_TABLE_INDEX to LILAC_USE_TABLE_INDEX.
-  if key == 'USE_TABLE_INDEX':
-    key = 'LILAC_USE_TABLE_INDEX'
+  if key == 'LILAC_USE_TABLE_INDEX':
+    default = os.environ.get('USE_TABLE_INDEX', default)
   return os.environ.get(key, default)
 
 


### PR DESCRIPTION
Sqlite files are now not included in the cached table; this means that label updates are instantaneous as they would be with LILAC_USE_TABLE_INDEX=false.

Some resulting changes:
- sqlite files are considered separately in cachebusting logic
- type of `t` switches from TABLE to VIEW, causing various duckdb errors. As a result...
- new generic try-catch to handle all sorts of migration/transition errors.

Users may see errors in their logs like

```
Exception: Catalog Error: Table with name cache_t does not exist!
Did you mean "t"?
Exception encountered while updating joint table cache; recomputing from scratch.
Recomputing table+index for $DATASET... took 0.154s.
```

or 
```
Catalog Error: t is not an table
```