### PR TITLE
Variables for OpenAI API and Model

### DIFF
--- a/.env
+++ b/.env
@@ -13,9 +13,16 @@
 # Get key from https://dashboard.cohere.ai/api-keys
 # COHERE_API_KEY=
 
+OPENAI_API_BASE=https://api.openai.com/v1/
+API_MODEL='gpt-3.5-turbo-1106'
 
 # Get key from https://platform.openai.com/account/api-keys
 # OPENAI_API_KEY=
+
+# If you are using a different intrerence engine that adheres to the OpenAI, set it here
+# OPENAI_API_BASE='http://127.0.0.1:8080/v1'
+# OPENAI_VERSION='2023-05-15'
+
 # Get key from https://makersuite.google.com/app/apikey
 
 # HuggingFace demos: machine that uploads to HuggingFace.

--- a/lilac/embeddings/openai.py
+++ b/lilac/embeddings/openai.py
@@ -39,6 +39,7 @@ class OpenAIEmbedding(TextEmbeddingSignal):
   @override
   def setup(self) -> None:
     api_key = env('OPENAI_API_KEY')
+    api_base = env('OPENAI_API_BASE')
     azure_api_key = env('AZURE_OPENAI_KEY')
     azure_api_version = env('AZURE_OPENAI_VERSION')
     azure_api_endpoint = env('AZURE_OPENAI_ENDPOINT')
@@ -64,7 +65,7 @@ class OpenAIEmbedding(TextEmbeddingSignal):
 
     else:
       if api_key:
-        self._client = openai.OpenAI(api_key=api_key)
+        self._client = openai.OpenAI(api_key=api_key, base_url=api_base)
         self._azure = False
 
       elif azure_api_key:

--- a/lilac/gen/generator_openai.py
+++ b/lilac/gen/generator_openai.py
@@ -15,8 +15,7 @@ from ..text_gen import TextGenerator
 
 class OpenAIChatCompletionGenerator(TextGenerator):
   """An interface for OpenAI chat completion."""
-
-  model: str = 'gpt-3.5-turbo-0613'
+  model: str = env('API_MODEL')
   response_description: str = ''
 
   @override
@@ -25,11 +24,14 @@ class OpenAIChatCompletionGenerator(TextGenerator):
     api_key = env('OPENAI_API_KEY')
     api_type = env('OPENAI_API_TYPE')
     api_version = env('OPENAI_API_VERSION')
+    api_base = env('OPENAI_API_BASE')
+    api_model = env('API_MODEL')
     if not api_key:
       raise ValueError('`OPENAI_API_KEY` environment variable not set.')
 
     try:
       import openai
+
     except ImportError:
       raise ImportError(
         'Could not import the "openai" python package. '
@@ -41,7 +43,7 @@ class OpenAIChatCompletionGenerator(TextGenerator):
       openai.api_version = api_version
 
     # Enables response_model in the openai client.
-    client = instructor.patch(openai.OpenAI())
+    client = instructor.patch(openai.OpenAI(base_url=api_base))
 
     class Completion(OpenAISchema):
       """Generated completion of a prompt."""
@@ -49,7 +51,7 @@ class OpenAIChatCompletionGenerator(TextGenerator):
       completion: str = Field(..., description=self.response_description)
 
     return client.chat.completions.create(
-      model='gpt-3.5-turbo',
+      model=api_model,
       response_model=Completion,
       messages=[
         {

--- a/lilac/router_concept.py
+++ b/lilac/router_concept.py
@@ -248,6 +248,8 @@ def generate_examples(description: str) -> list[str]:
   api_type = env('OPENAI_API_TYPE')
   api_version = env('OPENAI_API_VERSION')
   api_engine = env('OPENAI_API_ENGINE_CHAT')
+  api_base = env('OPENAI_API_BASE')
+  api_model = env('API_MODEL')
   if not api_key:
     raise ValueError('`OPENAI_API_KEY` environment variable not set.')
   try:
@@ -262,16 +264,17 @@ def generate_examples(description: str) -> list[str]:
     openai.api_key = api_key
     api_engine = api_engine
 
+
     if api_type:
       openai.api_type = api_type
       openai.api_version = api_version
 
   try:
     # Enables response_model in the openai client.
-    client = instructor.patch(openai.OpenAI())
+    client = instructor.patch(openai.OpenAI(base_url=api_base))
 
     completion = client.chat.completions.create(
-      model='gpt-3.5-turbo-1106',
+      model=api_model,
       response_model=Examples,
       temperature=0.0,
       messages=[


### PR DESCRIPTION
Created a variable for the OpenAI Base URL and model that will be used. This allows for utilizing other services that adhere to the OpenAI API spec, as well as testing out additional models that work best with the function calling and requests.

I noticed that different model versions were used throughout the code (e.g. `gpt-3.5-turbo-1106` vs `gpt-3.5-turbo-0613`. This patch only included a single model for all locations. If different models were used due to performance reasons, this can be separated out.