### PR TITLE
Add `skip_noisy_assignment` to `dataset.cluster`

### DIFF
--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -525,7 +525,9 @@ class Dataset(abc.ABC):
         of the task.
       category_fn: A function that returns a category for a set of related titles. It takes a list
         of (doc, membership_score) tuples and returns a single category name.
-      skip_noisy_assignment: Whether to skip noisy assignment of documents to clusters.
+      skip_noisy_assignment: If true, noisy points will not be assigned to the nearest cluster.
+        This only has an effect when the clustering is done locally (use_garden=False) and will
+        speedup clustering.
 
     """
     pass

--- a/lilac/data/dataset.py
+++ b/lilac/data/dataset.py
@@ -506,6 +506,7 @@ class Dataset(abc.ABC):
     task_id: Optional[TaskId] = None,
     # TODO(0.4.0): colocate with topic_fn.
     category_fn: Optional[TopicFn] = None,
+    skip_noisy_assignment: bool = False,
   ) -> None:
     """Compute clusters for a field of the dataset.
 
@@ -524,6 +525,7 @@ class Dataset(abc.ABC):
         of the task.
       category_fn: A function that returns a category for a set of related titles. It takes a list
         of (doc, membership_score) tuples and returns a single category name.
+      skip_noisy_assignment: Whether to skip noisy assignment of documents to clusters.
 
     """
     pass

--- a/lilac/data/dataset_duckdb.py
+++ b/lilac/data/dataset_duckdb.py
@@ -3334,6 +3334,7 @@ class DatasetDuckDB(Dataset):
     use_garden: bool = False,
     task_id: Optional[TaskId] = None,
     category_fn: Optional[TopicFn] = cluster_titling.generate_category_openai,
+    skip_noisy_assignment: bool = False,
   ) -> None:
     topic_fn = topic_fn or cluster_titling.generate_title_openai
     category_fn = category_fn or cluster_titling.generate_category_openai
@@ -3347,6 +3348,7 @@ class DatasetDuckDB(Dataset):
       overwrite=overwrite,
       use_garden=use_garden,
       task_id=task_id,
+      skip_noisy_assignment=skip_noisy_assignment,
     )
 
   @override
@@ -3950,6 +3952,7 @@ def _auto_bins(stats: StatsResult) -> list[Bin]:
     return [('0', const_val, None)]
 
   is_integer = stats.value_samples and all(isinstance(val, int) for val in stats.value_samples)
+
   def _round(value: float) -> float:
     # Select a round ndigits as a function of the value range. We offset it by 2 to allow for some
     # decimal places as a function of the range.


### PR DESCRIPTION
This reduces an expensive step for assigning noisy clusters. It's only effectively when running locally.